### PR TITLE
[ci] Fix docs workflow (missing cuquantum-python)

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -61,7 +61,7 @@ jobs:
 
           python3 -m pip install IPython breathe enum_tools myst_parser nbsphinx \
             sphinx_copybutton sphinx_inline_tabs sphinx_gallery sphinx_rtd_theme \
-            sphinx_reredirects sphinx_toolbox cupy-cuda12x
+            sphinx_reredirects sphinx_toolbox cupy-cuda12x cuquantum-python-cu12
 
           python3 -m pip install cmake --user
           echo "$HOME/.local/bin:$PATH" >> $GITHUB_PATH


### PR DESCRIPTION
This PR fixes the documentation part of #5. The docs workflow was missing the `cuquantum-python` installation. 