### PR TITLE
Bump cudaq ref.

### DIFF
--- a/.cudaq_version
+++ b/.cudaq_version
@@ -1,11 +1,7 @@
 {
   "cudaq": {
     "repository": "NVIDIA/cuda-quantum",
-    "ref": "d63dc8d93b4f9c95677aad2ddad2f9020cde45d0"
-  },
-  "cuquantum": {
-    "url": "https://developer.download.nvidia.com/compute/cuquantum/redist/cuquantum/linux-x86_64/",
-    "pattern": "cuquantum-linux-x86_64-24.11.0.21_cuda12-archive.tar.xz"
+    "ref": "c9d0e4c020ca83b119a0df8a5fdf41911078e12a"
   }
 }
 

--- a/.github/actions/get-cudaq-build/action.yaml
+++ b/.github/actions/get-cudaq-build/action.yaml
@@ -91,8 +91,6 @@ runs:
         bash .github/workflows/scripts/install_git_cli.sh
         mkdir -p ${CUQUANTUM_INSTALL_PREFIX}
         python3 .github/actions/get-cudaq-build/get_assets.py
-        cuquantum_archive=$(jq -r '.cuquantum.pattern' .cudaq_version)
-        tar xf "${cuquantum_archive}" --strip-components 1 -C "${CUQUANTUM_INSTALL_PREFIX}"
       shell: bash --noprofile --norc -euo pipefail {0}
 
     # ==========================================================================

--- a/.github/actions/get-cudaq-build/build_cudaq.sh
+++ b/.github/actions/get-cudaq-build/build_cudaq.sh
@@ -14,7 +14,8 @@ CC=${3:-"gcc"}
 CXX=${4:-"g++"}
 
 LLVM_INSTALL_PREFIX=/usr/local/llvm
-CUTENSOR_INSTALL_PREFIX=/opt/nvidia/cutensor
+CUQUANTUM_INSTALL_PREFIX="$(pip show cuquantum-python-cu12 | grep "Location:" | cut -d " " -f 2)/cuquantum"
+CUTENSOR_INSTALL_PREFIX="$(pip show cutensor-cu12 | grep "Location:" | cut -d " " -f 2)/cutensor"
 
 cd cudaq
 


### PR DESCRIPTION
With 0.9.0 finally merged to main, we can now follow CUDAQ's main branch.