### PR TITLE
Change default decoder float type to double

### DIFF
--- a/libs/qec/include/cudaq/qec/decoder.h
+++ b/libs/qec/include/cudaq/qec/decoder.h
@@ -1,5 +1,5 @@
 /****************************************************************-*- C++ -*-****
- * Copyright (c) 2022 - 2024 NVIDIA Corporation & Affiliates.                  *
+ * Copyright (c) 2024 NVIDIA Corporation & Affiliates.                         *
  * All rights reserved.                                                        *
  *                                                                             *
  * This source code and the accompanying materials are made available under    *
@@ -19,7 +19,7 @@ namespace cudaq::qec {
 #if defined(CUDAQX_QEC_FLOAT_TYPE)
 using float_t = CUDAQX_QEC_FLOAT_TYPE;
 #else
-using float_t = float;
+using float_t = double;
 #endif
 
 /// @brief Decoder results
@@ -30,6 +30,17 @@ struct decoder_result {
   /// @brief Vector of length `block_size` with soft probabilities of errors in
   /// each index.
   std::vector<float_t> result;
+
+  // Manually define the equality operator
+  bool operator==(const decoder_result &other) const {
+    return std::tie(converged, result) ==
+           std::tie(other.converged, other.result);
+  }
+
+  // Manually define the inequality operator
+  bool operator!=(const decoder_result &other) const {
+    return !(*this == other);
+  }
 };
 
 /// @brief The `decoder` base class should be subclassed by specific decoder

--- a/libs/qec/lib/CMakeLists.txt
+++ b/libs/qec/lib/CMakeLists.txt
@@ -6,10 +6,12 @@
 # the terms of the Apache License 2.0 which accompanies this distribution.     #
 # ============================================================================ #
 
+set(LIBRARY_NAME cudaq-qec)
+
 add_compile_options(-Wno-attributes) 
 
 # FIXME?: This must be a shared library. Trying to build a static one will fail.
-add_library(cudaq-qec SHARED
+add_library(${LIBRARY_NAME} SHARED
   code.cpp
   stabilizer_utils.cpp 
   decoder.cpp
@@ -20,22 +22,22 @@ add_library(cudaq-qec SHARED
 add_subdirectory(codes)
 add_subdirectory(device) 
 
-if (CUDAQX_QEC_USE_DOUBLE)
-   target_compile_definitions(cudaq-qec PUBLIC -DCUDAQX_QEC_FLOAT_TYPE=double)
+if (CUDAQX_QEC_USE_FLOAT)
+   target_compile_definitions(${LIBRARY_NAME} PUBLIC -DCUDAQX_QEC_FLOAT_TYPE=float)
 endif()
 
-target_include_directories(cudaq-qec
+target_include_directories(${LIBRARY_NAME}
   PUBLIC 
     $<BUILD_INTERFACE:${CUDAQX_QEC_INCLUDE_DIR}>
     $<INSTALL_INTERFACE:${CUDAQ_INCLUDE_DIR}>
     $<INSTALL_INTERFACE:include>
 )
 
-target_link_options(cudaq-qec PUBLIC
+target_link_options(${LIBRARY_NAME} PUBLIC
   $<$<CXX_COMPILER_ID:GNU>:-Wl,--no-as-needed>
 )
 
-target_link_libraries(cudaq-qec
+target_link_libraries(${LIBRARY_NAME}
   PUBLIC 
     cudaqx-core
     cudaq::cudaq 
@@ -44,25 +46,25 @@ target_link_libraries(cudaq-qec
     cudaq::cudaq-common
 )
 
-set_target_properties(cudaq-qec PROPERTIES
+set_target_properties(${LIBRARY_NAME} PROPERTIES
   LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 
 # RPATH configuration 
 # ==============================================================================
 
 if (NOT SKBUILD)
-  set_target_properties(cudaq-qec PROPERTIES
+  set_target_properties(${LIBRARY_NAME} PROPERTIES
     BUILD_RPATH "$ORIGIN"
     INSTALL_RPATH "$ORIGIN:$ORIGIN/../lib"
   )
 
   # Let CMake automatically add paths of linked libraries to the RPATH:
-  set_target_properties(cudaq-qec PROPERTIES
+  set_target_properties(${LIBRARY_NAME} PROPERTIES
     INSTALL_RPATH_USE_LINK_PATH TRUE)
 else()
   # CUDA-Q install its libraries in site-packages/lib (or dist-packages/lib)
   # Thus, we need the $ORIGIN/../lib
-  set_target_properties(cudaq-qec PROPERTIES
+  set_target_properties(${LIBRARY_NAME} PROPERTIES
     INSTALL_RPATH "$ORIGIN/../../lib"
   )
 endif()
@@ -70,7 +72,7 @@ endif()
 # Install 
 # ==============================================================================
 
-install(TARGETS cudaq-qec
+install(TARGETS ${LIBRARY_NAME}
   COMPONENT qec-lib
   LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
 )


### PR DESCRIPTION
1. Change default decoder float type to double.
2. Define equality and inequality operators for `decoder_result`.
3. Cleanup CMakeLists.txt to use var instead of repeated name.