### PR TITLE
Update "Bump CUDA-Q commit" workflow to accept any branch name.

### DIFF
--- a/.github/workflows/update-cudaq-dep.yml
+++ b/.github/workflows/update-cudaq-dep.yml
@@ -4,7 +4,7 @@ on:
       cudaq_branch_name:
         type: string
         required: true
-        description: 'Branch name for upstream CUDA-Q repo'
+        description: 'Branch name for upstream CUDA-Q repo (e.g. main or pull-request/2407)'
         default: main
 
   schedule:
@@ -71,8 +71,13 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
           BRANCH_NAME: ${{ steps.commit_and_push.outputs.BRANCH_NAME }}
         run: |
+          if [[ "${{ inputs.cudaq_branch_name }}" == "main"]]; then
+            TITLE_STR="Bump CUDA-Q commit (${{ inputs.cudaq_branch_name }} DO NOT MERGE)"
+          else
+            TITLE_STR="Bump CUDA-Q commit"
+          fi
           gh pr create \
-            --title "Bump CUDA-Q commit" \
-            --body "Auto update to the latest CUDA-Q commit" \
+            --title "${TITLE_STR}" \
+            --body "Auto update to the latest CUDA-Q commit on ${{ inputs.cudaq_branch_name }} branch" \
             --head "${BRANCH_NAME}" \
             --base "main"

--- a/.github/workflows/update-cudaq-dep.yml
+++ b/.github/workflows/update-cudaq-dep.yml
@@ -1,5 +1,12 @@
 on:
   workflow_dispatch:
+    inputs:
+      cudaq_branch_name:
+        type: string
+        required: true
+        description: 'Branch name for upstream CUDA-Q repo'
+        default: main
+
   schedule:
     - cron: 0 1 * * 6
 
@@ -22,7 +29,7 @@ jobs:
 
       - name: Fetch the latest commit
         run: |
-          SHA=$(curl -s "https://api.github.com/repos/NVIDIA/cuda-quantum/commits/main" | jq -r '.sha')
+          SHA=$(curl -s "https://api.github.com/repos/NVIDIA/cuda-quantum/commits/${{ inputs.cudaq_branch_name }}" | jq -r '.sha')
           echo "Latest SHA: $SHA"
           echo "sha=$SHA" >> $GITHUB_ENV
 

--- a/.github/workflows/update-cudaq-dep.yml
+++ b/.github/workflows/update-cudaq-dep.yml
@@ -72,9 +72,9 @@ jobs:
           BRANCH_NAME: ${{ steps.commit_and_push.outputs.BRANCH_NAME }}
         run: |
           if [[ "${{ inputs.cudaq_branch_name }}" == "main" ]]; then
-            TITLE_STR="Bump CUDA-Q commit (${{ inputs.cudaq_branch_name }} DO NOT MERGE)"
-          else
             TITLE_STR="Bump CUDA-Q commit"
+          else
+            TITLE_STR="Bump CUDA-Q commit (${{ inputs.cudaq_branch_name }} DO NOT MERGE)"
           fi
           gh pr create \
             --title "${TITLE_STR}" \

--- a/.github/workflows/update-cudaq-dep.yml
+++ b/.github/workflows/update-cudaq-dep.yml
@@ -71,7 +71,7 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
           BRANCH_NAME: ${{ steps.commit_and_push.outputs.BRANCH_NAME }}
         run: |
-          if [[ "${{ inputs.cudaq_branch_name }}" == "main"]]; then
+          if [[ "${{ inputs.cudaq_branch_name }}" == "main" ]]; then
             TITLE_STR="Bump CUDA-Q commit (${{ inputs.cudaq_branch_name }} DO NOT MERGE)"
           else
             TITLE_STR="Bump CUDA-Q commit"


### PR DESCRIPTION
This will be useful for targeted testing of specific feature branches or large PRs.