### PR TITLE
Include custom prebuilt CUDA-Q wheels in cudaqx-dev Python images

### DIFF
--- a/.github/workflows/build_dev.yaml
+++ b/.github/workflows/build_dev.yaml
@@ -128,6 +128,8 @@ jobs:
       run: |
         echo "ulimit -a"
         ulimit -a
+        cat ~/.dockerignore
+        echo '.git' >> ~/.dockerignore
         TAGS="-t ghcr.io/nvidia/cudaqx-dev:${{ steps.get-cudaq-version-short.outputs.commit_date }}-${{ steps.get-cudaq-version-short.outputs.shortref }}-py${{ matrix.python }}-${{ matrix.platform }}"
         TAGS+=" -t ghcr.io/nvidia/cudaqx-dev:${{ steps.get-cudaq-version-short.outputs.shortref }}-py${{ matrix.python }}-${{ matrix.platform }}"
         TAGS+=" -t ghcr.io/nvidia/cudaqx-dev:latest-py${{ matrix.python }}-${{ matrix.platform }}"

--- a/.github/workflows/build_dev.yaml
+++ b/.github/workflows/build_dev.yaml
@@ -65,8 +65,6 @@ jobs:
     - name: Build and push
       if: ${{ inputs.force_rebuild || steps.check-image.outputs.IMAGE_EXISTS == 'false' }}
       run: |
-        echo "ulimit -a"
-        ulimit -a
         TAGS="-t ghcr.io/nvidia/cudaqx-dev:${{ steps.get-cudaq-version-short.outputs.commit_date }}-${{ steps.get-cudaq-version-short.outputs.shortref }}-${{ matrix.platform }}"
         TAGS+=" -t ghcr.io/nvidia/cudaqx-dev:${{ steps.get-cudaq-version-short.outputs.shortref }}-${{ matrix.platform }}"
         TAGS+=" -t ghcr.io/nvidia/cudaqx-dev:latest-${{ matrix.platform }}"
@@ -82,7 +80,7 @@ jobs:
         python: ['3.10', '3.11', '3.12']
         platform: ['amd64', 'arm64']
       fail-fast: false
-    runs-on: linux-${{ matrix.platform }}-cpu16
+    runs-on: linux-${{ matrix.platform }}-cpu8
     steps:
     - name: Login to GitHub CR
       uses: docker/login-action@v3
@@ -126,14 +124,13 @@ jobs:
     - name: Build and push
       if: ${{ inputs.force_rebuild || steps.check-image.outputs.IMAGE_EXISTS == 'false' }}
       run: |
-        echo "ulimit -a"
-        ulimit -a
-        echo '.git' >> ~/.dockerignore
         TAGS="-t ghcr.io/nvidia/cudaqx-dev:${{ steps.get-cudaq-version-short.outputs.commit_date }}-${{ steps.get-cudaq-version-short.outputs.shortref }}-py${{ matrix.python }}-${{ matrix.platform }}"
         TAGS+=" -t ghcr.io/nvidia/cudaqx-dev:${{ steps.get-cudaq-version-short.outputs.shortref }}-py${{ matrix.python }}-${{ matrix.platform }}"
         TAGS+=" -t ghcr.io/nvidia/cudaqx-dev:latest-py${{ matrix.python }}-${{ matrix.platform }}"
         BUILDARGS="--build-arg base_image=ghcr.io/nvidia/cuda-quantum-devdeps:manylinux-${{ matrix.platform }}-cu12.0-gcc11-main"
         BUILDARGS+=" --build-arg python_version=${{ matrix.python }}"
+        # For some reason, this fails on amd64 unless DOCKER_BUILDKIT=0 is set.
+        # The exact error is: too many open files.
         DOCKER_BUILDKIT=0 docker build $TAGS $BUILDARGS -f docker/build_env/cudaqx.wheel.Dockerfile .
         docker push -a ghcr.io/nvidia/cudaqx-dev
       shell: bash --noprofile --norc -euo pipefail {0}

--- a/.github/workflows/build_dev.yaml
+++ b/.github/workflows/build_dev.yaml
@@ -129,6 +129,8 @@ jobs:
         TAGS+=" -t ghcr.io/nvidia/cudaqx-dev:latest-py${{ matrix.python }}-${{ matrix.platform }}"
         BUILDARGS="--build-arg base_image=ghcr.io/nvidia/cuda-quantum-devdeps:manylinux-${{ matrix.platform }}-cu12.0-gcc11-main"
         BUILDARGS+=" --build-arg python_version=${{ matrix.python }}"
+        # Failure to link if there are too many jobs
+        BUILDARGS+=" --build-arg cudaq_ninja_jobs_arg="-j 8"
         docker build $TAGS $BUILDARGS -f docker/build_env/cudaqx.wheel.Dockerfile .
         docker push -a ghcr.io/nvidia/cudaqx-dev
       shell: bash --noprofile --norc -euo pipefail {0}

--- a/.github/workflows/build_dev.yaml
+++ b/.github/workflows/build_dev.yaml
@@ -80,7 +80,7 @@ jobs:
         python: ['3.10', '3.11', '3.12']
         platform: ['amd64', 'arm64']
       fail-fast: false
-    runs-on: linux-${{ matrix.platform }}-cpu16
+    runs-on: linux-${{ matrix.platform }}-cpu4
     steps:
     - name: Login to GitHub CR
       uses: docker/login-action@v3

--- a/.github/workflows/build_dev.yaml
+++ b/.github/workflows/build_dev.yaml
@@ -65,6 +65,8 @@ jobs:
     - name: Build and push
       if: ${{ inputs.force_rebuild || steps.check-image.outputs.IMAGE_EXISTS == 'false' }}
       run: |
+        echo "ulimit -a"
+        ulimit -a
         TAGS="-t ghcr.io/nvidia/cudaqx-dev:${{ steps.get-cudaq-version-short.outputs.commit_date }}-${{ steps.get-cudaq-version-short.outputs.shortref }}-${{ matrix.platform }}"
         TAGS+=" -t ghcr.io/nvidia/cudaqx-dev:${{ steps.get-cudaq-version-short.outputs.shortref }}-${{ matrix.platform }}"
         TAGS+=" -t ghcr.io/nvidia/cudaqx-dev:latest-${{ matrix.platform }}"
@@ -80,7 +82,7 @@ jobs:
         python: ['3.10', '3.11', '3.12']
         platform: ['amd64', 'arm64']
       fail-fast: false
-    runs-on: linux-${{ matrix.platform }}-cpu4
+    runs-on: linux-${{ matrix.platform }}-cpu16
     steps:
     - name: Login to GitHub CR
       uses: docker/login-action@v3
@@ -124,6 +126,8 @@ jobs:
     - name: Build and push
       if: ${{ inputs.force_rebuild || steps.check-image.outputs.IMAGE_EXISTS == 'false' }}
       run: |
+        echo "ulimit -a"
+        ulimit -a
         TAGS="-t ghcr.io/nvidia/cudaqx-dev:${{ steps.get-cudaq-version-short.outputs.commit_date }}-${{ steps.get-cudaq-version-short.outputs.shortref }}-py${{ matrix.python }}-${{ matrix.platform }}"
         TAGS+=" -t ghcr.io/nvidia/cudaqx-dev:${{ steps.get-cudaq-version-short.outputs.shortref }}-py${{ matrix.python }}-${{ matrix.platform }}"
         TAGS+=" -t ghcr.io/nvidia/cudaqx-dev:latest-py${{ matrix.python }}-${{ matrix.platform }}"

--- a/.github/workflows/build_dev.yaml
+++ b/.github/workflows/build_dev.yaml
@@ -121,9 +121,33 @@ jobs:
           echo "IMAGE_EXISTS=false" >> $GITHUB_OUTPUT
         fi
 
-    - name: Build and push
+    - name: Fetch CUDA-Q
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ steps.get-cudaq-version.outputs.repo }}
+        ref: ${{ steps.get-cudaq-version.outputs.ref }}
+        path: cudaq
+        set-safe-directory: true
+
+    - name: Build CUDA-Q wheels
+      id: wheel_build
+      uses: docker/build-push-action@v5
+      with:
+        context: cudaq
+        file: cudaq/docker/release/cudaq.wheel.Dockerfile
+        build-args: |
+          base_image=ghcr.io/nvidia/cuda-quantum-devdeps:manylinux-${{ matrix.platform }}-cu12.0-gcc11-main
+          python_version=${{ matrix.python }}
+        outputs: type=local,dest=/tmp/wheels
+
+    - name: Build and push dev image with prebuilt CUDA-Q wheels
       if: ${{ inputs.force_rebuild || steps.check-image.outputs.IMAGE_EXISTS == 'false' }}
       run: |
+        # Bring wheels into upcoming Docker context
+        mkdir cudaq-wheels
+        cp /tmp/wheels/*.whl cudaq-wheels/
+
+        # Perform build
         TAGS="-t ghcr.io/nvidia/cudaqx-dev:${{ steps.get-cudaq-version-short.outputs.commit_date }}-${{ steps.get-cudaq-version-short.outputs.shortref }}-py${{ matrix.python }}-${{ matrix.platform }}"
         TAGS+=" -t ghcr.io/nvidia/cudaqx-dev:${{ steps.get-cudaq-version-short.outputs.shortref }}-py${{ matrix.python }}-${{ matrix.platform }}"
         TAGS+=" -t ghcr.io/nvidia/cudaqx-dev:latest-py${{ matrix.python }}-${{ matrix.platform }}"

--- a/.github/workflows/build_dev.yaml
+++ b/.github/workflows/build_dev.yaml
@@ -127,7 +127,9 @@ jobs:
         TAGS="-t ghcr.io/nvidia/cudaqx-dev:${{ steps.get-cudaq-version-short.outputs.commit_date }}-${{ steps.get-cudaq-version-short.outputs.shortref }}-py${{ matrix.python }}-${{ matrix.platform }}"
         TAGS+=" -t ghcr.io/nvidia/cudaqx-dev:${{ steps.get-cudaq-version-short.outputs.shortref }}-py${{ matrix.python }}-${{ matrix.platform }}"
         TAGS+=" -t ghcr.io/nvidia/cudaqx-dev:latest-py${{ matrix.python }}-${{ matrix.platform }}"
-        docker build $TAGS -f docker/build_env/cudaqx.dev.Dockerfile .
+        BUILDARGS="--build-arg base_image=ghcr.io/nvidia/cuda-quantum-devdeps:manylinux-${{ matrix.platform }}-cu12.0-gcc11-main"
+        BUILDARGS+=" --build-arg python_version=${{ matrix.python }}"
+        docker build $TAGS $BUILDARGS -f docker/build_env/cudaqx.dev.Dockerfile .
         docker push -a ghcr.io/nvidia/cudaqx-dev
       shell: bash --noprofile --norc -euo pipefail {0}
 

--- a/.github/workflows/build_dev.yaml
+++ b/.github/workflows/build_dev.yaml
@@ -80,7 +80,7 @@ jobs:
         python: ['3.10', '3.11', '3.12']
         platform: ['amd64', 'arm64']
       fail-fast: false
-    runs-on: linux-${{ matrix.platform }}-cpu8
+    runs-on: linux-${{ matrix.platform }}-cpu16
     steps:
     - name: Login to GitHub CR
       uses: docker/login-action@v3
@@ -129,8 +129,6 @@ jobs:
         TAGS+=" -t ghcr.io/nvidia/cudaqx-dev:latest-py${{ matrix.python }}-${{ matrix.platform }}"
         BUILDARGS="--build-arg base_image=ghcr.io/nvidia/cuda-quantum-devdeps:manylinux-${{ matrix.platform }}-cu12.0-gcc11-main"
         BUILDARGS+=" --build-arg python_version=${{ matrix.python }}"
-        # Failure to link if there are too many jobs
-        BUILDARGS+=" --build-arg cudaq_ninja_jobs_arg=\'-j 8\'"
         docker build $TAGS $BUILDARGS -f docker/build_env/cudaqx.wheel.Dockerfile .
         docker push -a ghcr.io/nvidia/cudaqx-dev
       shell: bash --noprofile --norc -euo pipefail {0}

--- a/.github/workflows/build_dev.yaml
+++ b/.github/workflows/build_dev.yaml
@@ -128,15 +128,13 @@ jobs:
       run: |
         echo "ulimit -a"
         ulimit -a
-        ulimit -n 2000000
-        ulimit -a
         echo '.git' >> ~/.dockerignore
         TAGS="-t ghcr.io/nvidia/cudaqx-dev:${{ steps.get-cudaq-version-short.outputs.commit_date }}-${{ steps.get-cudaq-version-short.outputs.shortref }}-py${{ matrix.python }}-${{ matrix.platform }}"
         TAGS+=" -t ghcr.io/nvidia/cudaqx-dev:${{ steps.get-cudaq-version-short.outputs.shortref }}-py${{ matrix.python }}-${{ matrix.platform }}"
         TAGS+=" -t ghcr.io/nvidia/cudaqx-dev:latest-py${{ matrix.python }}-${{ matrix.platform }}"
         BUILDARGS="--build-arg base_image=ghcr.io/nvidia/cuda-quantum-devdeps:manylinux-${{ matrix.platform }}-cu12.0-gcc11-main"
         BUILDARGS+=" --build-arg python_version=${{ matrix.python }}"
-        docker build $TAGS $BUILDARGS -f docker/build_env/cudaqx.wheel.Dockerfile .
+        DOCKER_BUILDKIT=0 docker build $TAGS $BUILDARGS -f docker/build_env/cudaqx.wheel.Dockerfile .
         docker push -a ghcr.io/nvidia/cudaqx-dev
       shell: bash --noprofile --norc -euo pipefail {0}
 

--- a/.github/workflows/build_dev.yaml
+++ b/.github/workflows/build_dev.yaml
@@ -129,7 +129,7 @@ jobs:
         TAGS+=" -t ghcr.io/nvidia/cudaqx-dev:latest-py${{ matrix.python }}-${{ matrix.platform }}"
         BUILDARGS="--build-arg base_image=ghcr.io/nvidia/cuda-quantum-devdeps:manylinux-${{ matrix.platform }}-cu12.0-gcc11-main"
         BUILDARGS+=" --build-arg python_version=${{ matrix.python }}"
-        docker build $TAGS $BUILDARGS -f docker/build_env/cudaqx.dev.Dockerfile .
+        docker build $TAGS $BUILDARGS -f docker/build_env/cudaqx.wheel.Dockerfile .
         docker push -a ghcr.io/nvidia/cudaqx-dev
       shell: bash --noprofile --norc -euo pipefail {0}
 

--- a/.github/workflows/build_dev.yaml
+++ b/.github/workflows/build_dev.yaml
@@ -128,7 +128,6 @@ jobs:
       run: |
         echo "ulimit -a"
         ulimit -a
-        cat ~/.dockerignore
         echo '.git' >> ~/.dockerignore
         TAGS="-t ghcr.io/nvidia/cudaqx-dev:${{ steps.get-cudaq-version-short.outputs.commit_date }}-${{ steps.get-cudaq-version-short.outputs.shortref }}-py${{ matrix.python }}-${{ matrix.platform }}"
         TAGS+=" -t ghcr.io/nvidia/cudaqx-dev:${{ steps.get-cudaq-version-short.outputs.shortref }}-py${{ matrix.python }}-${{ matrix.platform }}"

--- a/.github/workflows/build_dev.yaml
+++ b/.github/workflows/build_dev.yaml
@@ -130,7 +130,7 @@ jobs:
         BUILDARGS="--build-arg base_image=ghcr.io/nvidia/cuda-quantum-devdeps:manylinux-${{ matrix.platform }}-cu12.0-gcc11-main"
         BUILDARGS+=" --build-arg python_version=${{ matrix.python }}"
         # Failure to link if there are too many jobs
-        BUILDARGS+=" --build-arg cudaq_ninja_jobs_arg="-j 8"
+        BUILDARGS+=" --build-arg cudaq_ninja_jobs_arg='-j 8'"
         docker build $TAGS $BUILDARGS -f docker/build_env/cudaqx.wheel.Dockerfile .
         docker push -a ghcr.io/nvidia/cudaqx-dev
       shell: bash --noprofile --norc -euo pipefail {0}

--- a/.github/workflows/build_dev.yaml
+++ b/.github/workflows/build_dev.yaml
@@ -130,7 +130,7 @@ jobs:
         BUILDARGS="--build-arg base_image=ghcr.io/nvidia/cuda-quantum-devdeps:manylinux-${{ matrix.platform }}-cu12.0-gcc11-main"
         BUILDARGS+=" --build-arg python_version=${{ matrix.python }}"
         # Failure to link if there are too many jobs
-        BUILDARGS+=" --build-arg cudaq_ninja_jobs_arg='-j 8'"
+        BUILDARGS+=" --build-arg cudaq_ninja_jobs_arg=\'-j 8\'"
         docker build $TAGS $BUILDARGS -f docker/build_env/cudaqx.wheel.Dockerfile .
         docker push -a ghcr.io/nvidia/cudaqx-dev
       shell: bash --noprofile --norc -euo pipefail {0}

--- a/.github/workflows/build_dev.yaml
+++ b/.github/workflows/build_dev.yaml
@@ -128,6 +128,8 @@ jobs:
       run: |
         echo "ulimit -a"
         ulimit -a
+        ulimit -n 2000000
+        ulimit -a
         echo '.git' >> ~/.dockerignore
         TAGS="-t ghcr.io/nvidia/cudaqx-dev:${{ steps.get-cudaq-version-short.outputs.commit_date }}-${{ steps.get-cudaq-version-short.outputs.shortref }}-py${{ matrix.python }}-${{ matrix.platform }}"
         TAGS+=" -t ghcr.io/nvidia/cudaqx-dev:${{ steps.get-cudaq-version-short.outputs.shortref }}-py${{ matrix.python }}-${{ matrix.platform }}"

--- a/.github/workflows/update-cudaq-dep.yml
+++ b/.github/workflows/update-cudaq-dep.yml
@@ -29,7 +29,7 @@ jobs:
 
       - name: Fetch the latest commit
         run: |
-          SHA=$(curl -s "https://api.github.com/repos/NVIDIA/cuda-quantum/commits/${{ inputs.cudaq_branch_name }}" | jq -r '.sha')
+          SHA=$(curl -s "https://api.github.com/repos/NVIDIA/cuda-quantum/commits/${{ inputs.cudaq_branch_name || 'main' }}" | jq -r '.sha')
           echo "Latest SHA: $SHA"
           echo "sha=$SHA" >> $GITHUB_ENV
 

--- a/docker/build_env/cudaqx.wheel.Dockerfile
+++ b/docker/build_env/cudaqx.wheel.Dockerfile
@@ -10,7 +10,6 @@ ARG base_image=ghcr.io/nvidia/cuda-quantum-devdeps:manylinux-amd64-cu12.0-gcc11-
 FROM ${base_image}
 
 ARG python_version=3.10
-ARG cudaq_ninja_jobs_arg=""
 
 LABEL org.opencontainers.image.description="Dev tools for building and testing CUDA-QX libraries"
 LABEL org.opencontainers.image.source="https://github.com/NVIDIA/cudaqx"
@@ -29,5 +28,5 @@ RUN mkdir -p /workspaces/cudaqx/cudaq && cd /workspaces/cudaqx/cudaq \
   && git remote add origin https://github.com/${CUDAQ_REPO} \
   && git fetch -q --depth=1 origin ${CUDAQ_COMMIT} \
   && git reset --hard FETCH_HEAD \
-  && bash ../build_cudaq.sh --python-version ${python_version} ${cudaq_ninja_jobs_arg} \
+  && bash ../build_cudaq.sh --python-version ${python_version} \
   && rm -rf build

--- a/docker/build_env/cudaqx.wheel.Dockerfile
+++ b/docker/build_env/cudaqx.wheel.Dockerfile
@@ -30,4 +30,4 @@ RUN mkdir -p /workspaces/cudaqx/cudaq && cd /workspaces/cudaqx/cudaq \
   && git reset --hard FETCH_HEAD \
   && cd .. \
   && bash build_cudaq.sh --python-version ${python_version} \
-  && rm -rf build
+  && rm -rf cudaq

--- a/docker/build_env/cudaqx.wheel.Dockerfile
+++ b/docker/build_env/cudaqx.wheel.Dockerfile
@@ -29,5 +29,5 @@ RUN mkdir -p /workspaces/cudaqx/cudaq && cd /workspaces/cudaqx/cudaq \
   && git fetch -q --depth=1 origin ${CUDAQ_COMMIT} \
   && git reset --hard FETCH_HEAD \
   && cd .. \
-  && bash build_cudaq.sh --python-version ${python_version} -j 8 \
+  && bash build_cudaq.sh --python-version ${python_version} \
   && rm -rf build

--- a/docker/build_env/cudaqx.wheel.Dockerfile
+++ b/docker/build_env/cudaqx.wheel.Dockerfile
@@ -28,5 +28,6 @@ RUN mkdir -p /workspaces/cudaqx/cudaq && cd /workspaces/cudaqx/cudaq \
   && git remote add origin https://github.com/${CUDAQ_REPO} \
   && git fetch -q --depth=1 origin ${CUDAQ_COMMIT} \
   && git reset --hard FETCH_HEAD \
-  && bash ../build_cudaq.sh --python-version ${python_version} \
+  && cd .. \
+  && bash build_cudaq.sh --python-version ${python_version} -j 8 \
   && rm -rf build

--- a/docker/build_env/cudaqx.wheel.Dockerfile
+++ b/docker/build_env/cudaqx.wheel.Dockerfile
@@ -10,6 +10,7 @@ ARG base_image=ghcr.io/nvidia/cuda-quantum-devdeps:manylinux-amd64-cu12.0-gcc11-
 FROM ${base_image}
 
 ARG python_version=3.10
+ARG cudaq_ninja_jobs_arg=""
 
 LABEL org.opencontainers.image.description="Dev tools for building and testing CUDA-QX libraries"
 LABEL org.opencontainers.image.source="https://github.com/NVIDIA/cudaqx"
@@ -28,5 +29,5 @@ RUN mkdir -p /workspaces/cudaqx/cudaq && cd /workspaces/cudaqx/cudaq \
   && git remote add origin https://github.com/${CUDAQ_REPO} \
   && git fetch -q --depth=1 origin ${CUDAQ_COMMIT} \
   && git reset --hard FETCH_HEAD \
-  && bash ../build_cudaq.sh --python-version ${python_version} \
+  && bash ../build_cudaq.sh --python-version ${python_version} ${cudaq_ninja_jobs_arg} \
   && rm -rf build

--- a/docker/build_env/cudaqx.wheel.Dockerfile
+++ b/docker/build_env/cudaqx.wheel.Dockerfile
@@ -20,6 +20,8 @@ RUN dnf install -y jq
 RUN mkdir -p /workspaces/cudaqx
 COPY .cudaq_version /workspaces/cudaqx
 COPY .github/workflows/scripts/build_cudaq.sh /workspaces/cudaqx
+RUN mkdir /cudaq-wheels
+COPY cudaq-wheels/ /cudaq-wheels/
 
 RUN mkdir -p /workspaces/cudaqx/cudaq && cd /workspaces/cudaqx/cudaq \
   && git init \


### PR DESCRIPTION
Also includes misc other fixes:
* Use correct Dockerfile for py-* images
* Use DOCKER_BUILDKIT=0 to workaround "too many open files" issue with GitHub action.
* Fix bug w/ scheduled workflow introduced by #75