### PR TITLE
Follow-up to #61 - apply first-round data to all shots

### DIFF
--- a/libs/qec/lib/experiments.cpp
+++ b/libs/qec/lib/experiments.cpp
@@ -155,11 +155,12 @@ sample_memory_circuit(const code &code, operation statePrep,
   measuresTensor.borrow(measurements.data());
 
   // First round, store bare syndrome measurement
-  for (std::size_t col = 0; col < numCols; ++col) {
-    std::size_t shot = 0;
-    std::size_t round = 0;
-    std::size_t measIdx = shot * numRounds + round;
-    syndromeTensor.at({measIdx, col}) = measuresTensor.at({measIdx, col});
+  for (std::size_t shot = 0; shot < numShots; ++shot) {
+    for (std::size_t col = 0; col < numCols; ++col) {
+      std::size_t round = 0;
+      std::size_t measIdx = shot * numRounds + round;
+      syndromeTensor.at({measIdx, col}) = measuresTensor.at({measIdx, col});
+    }
   }
 
   // After first round, store syndrome flips

--- a/libs/qec/unittests/backend-specific/stim/test_qec_stim.cpp
+++ b/libs/qec/unittests/backend-specific/stim/test_qec_stim.cpp
@@ -156,7 +156,7 @@ TEST(QECCodeTester, checkSteaneNoiseStim) {
         z_sum += syndromes.at({i, j_z});
       }
     }
-    EXPECT_TRUE(x_sum == 0);
+    EXPECT_TRUE(x_sum > 0);
     EXPECT_TRUE(z_sum > 0);
   }
   {


### PR DESCRIPTION
This fixes what I think is a bug with #61. @justinlietz - please verify.

The problem was that the first round data in `syndromeTensor` was only being copied for `shot == 0` and was left uninitialized/uncopied for all other shots.