### PR TITLE
Use explicit measurements for memory circuit experiments

### DIFF
--- a/.cudaq_version
+++ b/.cudaq_version
@@ -1,6 +1,6 @@
 {
   "cudaq": {
     "repository": "NVIDIA/cuda-quantum",
-    "ref": "76ffe23f402c230dc4b25de198142098124392c5"
+    "ref": "1e8c97d71baee9fcff57813063492e7ae1f6b559"
   }
 }

--- a/libs/core/include/cuda-qx/core/tensor.h
+++ b/libs/core/include/cuda-qx/core/tensor.h
@@ -1,5 +1,5 @@
 /****************************************************************-*- C++ -*-****
- * Copyright (c) 2024 NVIDIA Corporation & Affiliates.                         *
+ * Copyright (c) 2024 - 2025 NVIDIA Corporation & Affiliates.                  *
  * All rights reserved.                                                        *
  *                                                                             *
  * This source code and the accompanying materials are made available under    *
@@ -43,8 +43,9 @@ public:
   /// @brief Construct an empty tensor
   tensor()
       : pimpl(std::shared_ptr<details::tensor_impl<Scalar>>(
-            details::tensor_impl<Scalar>::get(
-                std::string("xtensor") + std::string(ScalarAsString), {})
+            details::tensor_impl<Scalar>::get(std::string("xtensor") +
+                                                  std::string(ScalarAsString),
+                                              std::vector<std::size_t>())
                 .release())) {}
 
   /// @brief Construct a tensor with the given shape
@@ -63,6 +64,16 @@ public:
             details::tensor_impl<Scalar>::get(std::string("xtensor") +
                                                   std::string(ScalarAsString),
                                               data, shape)
+                .release())) {}
+
+  /// @brief Construct a tensor with the given bitstrings
+  /// @param data Bitstrings from which to construct tensor
+  template <typename T, typename = std::enable_if_t<
+                            std::is_convertible<T, std::string>::value>>
+  tensor(const std::vector<T> &data)
+      : pimpl(std::shared_ptr<details::tensor_impl<Scalar>>(
+            details::tensor_impl<Scalar>::get(
+                std::string("xtensor") + std::string(ScalarAsString), data)
                 .release())) {}
 
   /// @brief Get the rank of the tensor
@@ -228,6 +239,10 @@ public:
   const scalar_type *data() const { return pimpl->data(); }
 
   void dump() const { pimpl->dump(); }
+
+  /// @brief Dump tensor as bits, where non-zero elements are shown as '1' and
+  /// zero-elements are shown as '.'.
+  void dump_bits() const { pimpl->dump_bits(); }
 };
 
 } // namespace cudaqx

--- a/libs/core/unittests/test_core.cpp
+++ b/libs/core/unittests/test_core.cpp
@@ -1,5 +1,5 @@
-/****************************************************************-*- C++ -*-****
- * Copyright (c) 2024 NVIDIA Corporation & Affiliates.                         *
+/*******************************************************************************
+ * Copyright (c) 2024 - 2025 NVIDIA Corporation & Affiliates.                  *
  * All rights reserved.                                                        *
  *                                                                             *
  * This source code and the accompanying materials are made available under    *
@@ -271,6 +271,20 @@ TEST(CoreTester, checkTensorSimple) {
 
     EXPECT_ANY_THROW({ t.at({2, 2, 2}); });
   }
+}
+
+TEST(TensorTest, checkBitStringConstruction) {
+  std::vector<std::string> bitstrings;
+  bitstrings.push_back("000"); // Shot 0
+  bitstrings.push_back("001"); // Shot 1
+
+  cudaqx::tensor<uint8_t> t(bitstrings);
+  EXPECT_EQ(t.at({0, 0}), 0);
+  EXPECT_EQ(t.at({0, 1}), 0);
+  EXPECT_EQ(t.at({0, 2}), 0);
+  EXPECT_EQ(t.at({1, 0}), 0);
+  EXPECT_EQ(t.at({1, 1}), 0);
+  EXPECT_EQ(t.at({1, 2}), 1);
 }
 
 // Test elementwise operations

--- a/libs/qec/lib/codes/surface_code_device.cpp
+++ b/libs/qec/lib/codes/surface_code_device.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024 NVIDIA Corporation & Affiliates.                         *
+ * Copyright (c) 2024 - 2025 NVIDIA Corporation & Affiliates.                  *
  * All rights reserved.                                                        *
  *                                                                             *
  * This source code and the accompanying materials are made available under    *
@@ -64,7 +64,7 @@ stabilizer(patch logicalQubit, const std::vector<std::size_t> &x_stabilizers,
       if (z_stabilizers[zi * logicalQubit.data.size() + di] == 1)
         cudaq::x<cudaq::ctrl>(logicalQubit.data[di], logicalQubit.ancz[zi]);
 
-  // S = (S_X, S_Z), (x flip syndromes, z flip syndrones).
+  // S = (S_X, S_Z), (x flip syndromes, z flip syndromes).
   // x flips are triggered by z-stabilizers (ancz)
   // z flips are triggered by x-stabilizers (ancx)
   auto results = mz(logicalQubit.ancz, logicalQubit.ancx);

--- a/libs/qec/lib/device/memory_circuit.cpp
+++ b/libs/qec/lib/device/memory_circuit.cpp
@@ -9,38 +9,6 @@
 
 namespace cudaq::qec {
 
-static std::unique_ptr<std::vector<uint8_t>> rawAncillaMeasurements;
-static std::unique_ptr<std::vector<uint8_t>> rawDataMeasurements;
-
-void persistDataMeasures(uint8_t *measures, std::size_t size) {
-  if (!rawDataMeasurements)
-    rawDataMeasurements = std::make_unique<std::vector<uint8_t>>();
-
-  auto &store = *rawDataMeasurements;
-  store.insert(store.end(), measures, measures + size);
-}
-
-void persistAncillaMeasures(uint8_t *measures, std::size_t size) {
-  if (!rawAncillaMeasurements)
-    rawAncillaMeasurements = std::make_unique<std::vector<uint8_t>>();
-
-  auto &store = *rawAncillaMeasurements;
-  store.insert(store.end(), measures, measures + size);
-}
-
-std::vector<uint8_t> &getMemoryCircuitAncillaMeasurements() {
-  return *rawAncillaMeasurements.get();
-}
-
-std::vector<uint8_t> &getMemoryCircuitDataMeasurements() {
-  return *rawDataMeasurements.get();
-}
-
-void clearRawMeasurements() {
-  (*rawDataMeasurements).clear();
-  (*rawAncillaMeasurements).clear();
-}
-
 __qpu__ void __memory_circuit_stabs(
     cudaq::qview<> data, cudaq::qview<> xstab_anc, cudaq::qview<> zstab_anc,
     const code::stabilizer_round &stabilizer_round,
@@ -54,22 +22,10 @@ __qpu__ void __memory_circuit_stabs(
   statePrep({data, xstab_anc, zstab_anc});
 
   // Generate syndrome data
-  size_t counter = 0;
-  std::vector<uint8_t> measureInts((xstab_anc.size() + zstab_anc.size()) *
-                                   numRounds);
   for (std::size_t round = 0; round < numRounds; round++) {
     // Run the stabilizer round, generate the syndrome measurements
     auto syndrome = stabilizer_round(logical, x_stabilizers, z_stabilizers);
-
-    // Convert to integers for easy passing
-    for (size_t i = 0; i < syndrome.size(); i++) {
-      measureInts[counter] = syndrome[i];
-      counter++;
-    }
   }
-
-  // Store the ancillas for analysis / decoding
-  persistAncillaMeasures(measureInts.data(), measureInts.size());
 }
 
 __qpu__ void memory_circuit_mz(const code::stabilizer_round &stabilizer_round,
@@ -87,11 +43,6 @@ __qpu__ void memory_circuit_mz(const code::stabilizer_round &stabilizer_round,
                          statePrep, numRounds, x_stabilizers, z_stabilizers);
 
   auto dataResults = mz(data);
-  std::vector<uint8_t> dataInts(numData);
-  for (size_t i = 0; i < numData; i++)
-    dataInts[i] = dataResults[i];
-
-  persistDataMeasures(dataInts.data(), numData);
 }
 
 __qpu__ void memory_circuit_mx(const code::stabilizer_round &stabilizer_round,
@@ -110,11 +61,6 @@ __qpu__ void memory_circuit_mx(const code::stabilizer_round &stabilizer_round,
 
   h(data);
   auto dataResults = mz(data);
-  std::vector<uint8_t> dataInts(numData);
-  for (size_t i = 0; i < numData; i++)
-    dataInts[i] = dataResults[i];
-
-  persistDataMeasures(dataInts.data(), numData);
 }
 
 } // namespace cudaq::qec

--- a/libs/qec/lib/device/memory_circuit.h
+++ b/libs/qec/lib/device/memory_circuit.h
@@ -1,5 +1,5 @@
 /****************************************************************-*- C++ -*-****
- * Copyright (c) 2024 NVIDIA Corporation & Affiliates.                         *
+ * Copyright (c) 2024 - 2025 NVIDIA Corporation & Affiliates.                  *
  * All rights reserved.                                                        *
  *                                                                             *
  * This source code and the accompanying materials are made available under    *
@@ -12,17 +12,6 @@
 #include "cudaq/qec/code.h"
 
 namespace cudaq::qec {
-
-/// @brief Get a reference to the raw measurements from the memory circuit
-/// execution
-/// @return Reference to the vector of integers storing syndrome information
-std::vector<uint8_t> &getMemoryCircuitMeasurements();
-
-std::vector<uint8_t> &getMemoryCircuitAncillaMeasurements();
-
-std::vector<uint8_t> &getMemoryCircuitDataMeasurements();
-
-void clearRawMeasurements();
 
 /// \entry_point_kernel
 ///

--- a/libs/qec/lib/experiments.cpp
+++ b/libs/qec/lib/experiments.cpp
@@ -1,12 +1,12 @@
-/****************************************************************-*- C++ -*-****
- * Copyright (c) 2024 NVIDIA Corporation & Affiliates.                         *
+/*******************************************************************************
+ * Copyright (c) 2024 - 2025 NVIDIA Corporation & Affiliates.                  *
  * All rights reserved.                                                        *
  *                                                                             *
  * This source code and the accompanying materials are made available under    *
  * the terms of the Apache License 2.0 which accompanies this distribution.    *
  ******************************************************************************/
-#include "cudaq/qec/experiments.h"
 
+#include "cudaq/qec/experiments.h"
 #include "device/memory_circuit.h"
 
 using namespace cudaqx;
@@ -100,10 +100,6 @@ sample_memory_circuit(const code &code, operation statePrep,
   auto &stabRound =
       code.get_operation<code::stabilizer_round>(operation::stabilizer_round);
 
-  cudaq::ExecutionContext ctx("");
-  ctx.noiseModel = &noise;
-  auto &platform = cudaq::get_platform();
-
   auto parity_x = code.get_parity_x();
   auto parity_z = code.get_parity_z();
   auto numData = code.get_num_data_qubits();
@@ -122,60 +118,64 @@ sample_memory_circuit(const code &code, operation statePrep,
   cudaqx::tensor<uint8_t> syndromeTensor({numShots * numRounds, numCols});
   cudaqx::tensor<uint8_t> dataResults({numShots, numData});
 
+  cudaq::sample_options opts;
+  opts.shots = numShots;
+  opts.noise = noise;
+  opts.explicit_measurements = true;
+
+  cudaq::sample_result result;
+
   // Run the memory circuit experiment
   if (statePrep == operation::prep0 || statePrep == operation::prep1) {
     // run z basis
-    for (std::size_t shot = 0; shot < numShots; shot++) {
-      platform.set_exec_ctx(&ctx);
-      memory_circuit_mz(stabRound, prep, numData, numAncx, numAncz, numRounds,
-                        xVec, zVec);
-      platform.reset_exec_ctx();
-    }
+    result = cudaq::sample(opts, memory_circuit_mz, stabRound, prep, numData,
+                           numAncx, numAncz, numRounds, xVec, zVec);
   } else if (statePrep == operation::prepp || statePrep == operation::prepm) {
-    // run z basis
-    for (std::size_t shot = 0; shot < numShots; shot++) {
-      platform.set_exec_ctx(&ctx);
-      memory_circuit_mx(stabRound, prep, numData, numAncx, numAncz, numRounds,
-                        xVec, zVec);
-      platform.reset_exec_ctx();
-    }
+    // run x basis
+    result = cudaq::sample(opts, memory_circuit_mx, stabRound, prep, numData,
+                           numAncx, numAncz, numRounds, xVec, zVec);
   } else {
     throw std::runtime_error(
         "sample_memory_circuit_error - invalid requested state prep kernel.");
   }
 
-  auto &dataMeasures = getMemoryCircuitDataMeasurements();
-  dataResults.copy(dataMeasures.data());
+  cudaqx::tensor<uint8_t> mzTable(result.sequential_data());
+  const auto numColsBeforeData = numCols * numRounds;
 
-  // Get the raw ancilla measurments
-  auto &measurements = getMemoryCircuitAncillaMeasurements();
+  // Populate dataResults from mzTable
+  for (std::size_t shot = 0; shot < numShots; shot++) {
+    uint8_t __restrict__ *dataResultsRow = &dataResults.at({shot, 0});
+    uint8_t __restrict__ *mzTableRow = &mzTable.at({shot, 0});
+    for (std::size_t d = 0; d < numData; d++)
+      dataResultsRow[d] = mzTableRow[numColsBeforeData + d];
+  }
 
-  std::size_t numMeasRows = numShots * numRounds;
-  cudaqx::tensor<uint8_t> measuresTensor({numMeasRows, numCols});
-  measuresTensor.borrow(measurements.data());
+  // Now populate syndromeTensor.
 
   // First round, store bare syndrome measurement
   for (std::size_t shot = 0; shot < numShots; ++shot) {
-    for (std::size_t col = 0; col < numCols; ++col) {
-      std::size_t round = 0;
-      std::size_t measIdx = shot * numRounds + round;
-      syndromeTensor.at({measIdx, col}) = measuresTensor.at({measIdx, col});
-    }
+    std::size_t round = 0;
+    std::size_t measIdx = shot * numRounds + round;
+    std::uint8_t __restrict__ *syndromeTensorRow =
+        &syndromeTensor.at({measIdx, 0});
+    std::uint8_t __restrict__ *mzTableRow = &mzTable.at({shot, 0});
+    for (std::size_t col = 0; col < numCols; ++col)
+      syndromeTensorRow[col] = mzTableRow[col];
   }
 
   // After first round, store syndrome flips
-  // #pragma omp parallel for collapse(2)
-  for (std::size_t shot = 0; shot < numShots; ++shot)
-    for (std::size_t round = 1; round < numRounds; ++round)
+  for (std::size_t shot = 0; shot < numShots; ++shot) {
+    std::uint8_t __restrict__ *mzTableRow = &mzTable.at({shot, 0});
+    for (std::size_t round = 1; round < numRounds; ++round) {
+      std::size_t measIdx = shot * numRounds + round;
+      std::uint8_t __restrict__ *syndromeTensorRow =
+          &syndromeTensor.at({measIdx, 0});
       for (std::size_t col = 0; col < numCols; ++col) {
-        std::size_t measIdx = shot * numRounds + round;
-        std::size_t prevMeasIdx = shot * numRounds + (round - 1);
-        syndromeTensor.at({measIdx, col}) =
-            measuresTensor.at({measIdx, col}) ^
-            measuresTensor.at({prevMeasIdx, col});
+        syndromeTensorRow[col] = mzTableRow[round * numCols + col] ^
+                                 mzTableRow[(round - 1) * numCols + col];
       }
-
-  clearRawMeasurements();
+    }
+  }
 
   // Return the data.
   return std::make_tuple(syndromeTensor, dataResults);

--- a/libs/qec/lib/experiments.cpp
+++ b/libs/qec/lib/experiments.cpp
@@ -118,10 +118,8 @@ sample_memory_circuit(const code &code, operation statePrep,
   cudaqx::tensor<uint8_t> syndromeTensor({numShots * numRounds, numCols});
   cudaqx::tensor<uint8_t> dataResults({numShots, numData});
 
-  cudaq::sample_options opts;
-  opts.shots = numShots;
-  opts.noise = noise;
-  opts.explicit_measurements = true;
+  cudaq::sample_options opts{
+      .shots = numShots, .noise = noise, .explicit_measurements = true};
 
   cudaq::sample_result result;
 

--- a/libs/qec/unittests/backend-specific/stim/test_qec_stim.cpp
+++ b/libs/qec/unittests/backend-specific/stim/test_qec_stim.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024 NVIDIA Corporation & Affiliates.                         *
+ * Copyright (c) 2024 - 2025 NVIDIA Corporation & Affiliates.                  *
  * All rights reserved.                                                        *
  *                                                                             *
  * This source code and the accompanying materials are made available under    *
@@ -186,7 +186,7 @@ TEST(QECCodeTester, checkSteaneNoiseStim) {
       }
     }
     // Even though phase flip is a z error,
-    // additional hadamards in prepp can convert to x error.
+    // additional hadamards in prepp can convert to x error (first round only)
     EXPECT_TRUE(x_sum > 0);
     EXPECT_TRUE(z_sum > 0);
   }
@@ -221,7 +221,7 @@ TEST(QECCodeTester, checkSteaneNoiseStim) {
   }
 }
 
-TEST(QECCodeTester, checkSampleMemoryCircuit) {
+TEST(QECCodeTester, checkSampleMemoryCircuitStim) {
   {
     // Steane tests
     auto steane = cudaq::qec::get_code("steane");
@@ -326,7 +326,7 @@ TEST(QECCodeTester, checkSampleMemoryCircuit) {
   }
 }
 
-TEST(QECCodeTester, checkTwoQubitBitflip) {
+TEST(QECCodeTester, checkTwoQubitBitflipStim) {
   // This circuit should read out |00> with and without bitflip noise
   struct null1 {
     void operator()() __qpu__ {
@@ -380,7 +380,7 @@ TEST(QECCodeTester, checkBitflip) {
   EXPECT_TRUE(counts2.probability("0") < 0.9);
 }
 
-TEST(QECCodeTester, checkNoisySampleMemoryCircuitAndDecode) {
+TEST(QECCodeTester, checkNoisySampleMemoryCircuitAndDecodeStim) {
   {
     // Steane tests
     auto steane = cudaq::qec::get_code("steane");


### PR DESCRIPTION
This PR makes use of a new CUDA-Q feature that speeds up our QEC workloads when using Stim as the target simulator. These changes allow all the shots to be generated in a single execution of the quantum kernel.

Ref: https://github.com/NVIDIA/cuda-quantum/pull/2567