### PR TITLE
Use known Python path if we are running in a Python context

### DIFF
--- a/libs/solvers/include/cudaq/solvers/operators/molecule.h
+++ b/libs/solvers/include/cudaq/solvers/operators/molecule.h
@@ -1,5 +1,5 @@
 /****************************************************************-*- C++ -*-****
- * Copyright (c) 2024 NVIDIA Corporation & Affiliates.                         *
+ * Copyright (c) 2024 - 2025 NVIDIA Corporation & Affiliates.                  *
  * All rights reserved.                                                        *
  *                                                                             *
  * This source code and the accompanying materials are made available under    *
@@ -102,6 +102,12 @@ struct molecule_options {
   /// @brief Driver for the quantum chemistry calculations
   /// default "RESTPySCFDriver"
   std::string driver = "RESTPySCFDriver";
+
+  /// @brief Fully qualified path to Python executable to use (if applicable).
+  /// The CUDA-Q Solvers Python wheel will automatically populate this with the
+  /// current Python executable path.
+  /// default ""
+  std::string python_path = "";
 
   /// @brief Method for mapping fermionic operators to qubit operators
   /// default "jordan_wigner"

--- a/libs/solvers/include/cudaq/solvers/operators/molecule/molecule_package_driver.h
+++ b/libs/solvers/include/cudaq/solvers/operators/molecule/molecule_package_driver.h
@@ -1,5 +1,5 @@
 /****************************************************************-*- C++ -*-****
- * Copyright (c) 2024 NVIDIA Corporation & Affiliates.                         *
+ * Copyright (c) 2024 - 2025 NVIDIA Corporation & Affiliates.                  *
  * All rights reserved.                                                        *
  *                                                                             *
  * This source code and the accompanying materials are made available under    *
@@ -33,7 +33,10 @@ public:
   /// @brief In the case that this service is not available,
   /// make it available and return any required application shutdown
   /// routines as a new tear_down instance.
-  virtual std::unique_ptr<tear_down> make_available() const = 0;
+  /// @param python_path If a fully-qualified Python executable path name is
+  /// known, use it here.
+  virtual std::unique_ptr<tear_down>
+  make_available(const std::string &python_path = "") const = 0;
 
   /// Virtual destructor needed when deleting an instance of a derived class
   /// via a pointer to the base class.

--- a/libs/solvers/lib/operators/molecule/drivers/pyscf_driver.cpp
+++ b/libs/solvers/lib/operators/molecule/drivers/pyscf_driver.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022 - 2023 NVIDIA Corporation & Affiliates.                  *
+ * Copyright (c) 2022 - 2025 NVIDIA Corporation & Affiliates.                  *
  * All rights reserved.                                                        *
  *                                                                             *
  * This source code and the accompanying materials are made available under    *
@@ -59,7 +59,8 @@ public:
     return true;
   }
 
-  std::unique_ptr<tear_down> make_available() const override {
+  std::unique_ptr<tear_down>
+  make_available(const std::string &python_path) const override {
 
     // Start up the web service, if failed, return nullptr
     std::filesystem::path libPath{cudaqx::__internal__::getCUDAQXLibraryPath(
@@ -67,6 +68,8 @@ public:
     auto cudaqLibPath = libPath.parent_path();
     auto cudaqPySCFTool = cudaqLibPath.parent_path() / "bin" / "cudaq-pyscf";
     auto argString = cudaqPySCFTool.string() + " --server-mode";
+    if (!python_path.empty())
+      argString = python_path + " " + argString;
     int a0, a1;
     auto [ret, msg] = cudaqx::launchProcess(argString.c_str());
     if (ret == -1)

--- a/libs/solvers/lib/operators/molecule/molecule.cpp
+++ b/libs/solvers/lib/operators/molecule/molecule.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024 NVIDIA Corporation & Affiliates.                         *
+ * Copyright (c) 2024 - 2025 NVIDIA Corporation & Affiliates.                  *
  * All rights reserved.                                                        *
  *                                                                             *
  * This source code and the accompanying materials are made available under    *
@@ -76,7 +76,7 @@ molecular_hamiltonian create_molecule(const molecular_geometry &geometry,
                              options.driver + ")");
   auto driver = MoleculePackageDriver::get(options.driver);
   if (!driver->is_available()) {
-    auto tearDownRoutine = driver->make_available();
+    auto tearDownRoutine = driver->make_available(options.python_path);
     if (!tearDownRoutine)
       throw std::runtime_error("invalid molecule generator.");
 
@@ -88,6 +88,7 @@ molecular_hamiltonian create_molecule(const molecular_geometry &geometry,
 
 void molecule_options::dump() {
   std::cout << "\tmolecule_options dump() [\n";
+  std::cout << "\tpython_path: " << python_path << "\n";
   std::cout << "\tfermion_to_spin: " << fermion_to_spin << "\n";
   std::cout << "\ttype: " << type << "\n";
   std::cout << "\tsymmetry: " << symmetry << "\n";

--- a/libs/solvers/python/bindings/solvers/py_solvers.cpp
+++ b/libs/solvers/python/bindings/solvers/py_solvers.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022 - 2023 NVIDIA Corporation & Affiliates.                  *
+ * Copyright (c) 2024 - 2025 NVIDIA Corporation & Affiliates.                  *
  * All rights reserved.                                                        *
  *                                                                             *
  * This source code and the accompanying materials are made available under    *
@@ -589,6 +589,15 @@ Notes:
     inOptions.integrals_casscf =
         getValueOr<bool>(options, "integrals_casscf", false);
     inOptions.verbose = getValueOr<bool>(options, "verbose", false);
+
+    // We are already running in a specific Python environment. Get the fully
+    // qualified path to the executable and populate it here so that we don't
+    // accidentally use the wrong Python environment for any child processes
+    // that may be spawned.
+    inOptions.python_path = []() {
+      auto sys = py::module::import("sys");
+      return sys.attr("executable").cast<std::string>();
+    }();
 
     if (inOptions.verbose)
       inOptions.dump();


### PR DESCRIPTION
This will help when using environments that have multiple versions of Python installed (like we do in some of our cudaqx-dev images).