### PR TITLE
Change default installation path in Docker images

### DIFF
--- a/.github/workflows/build_wheels.yaml
+++ b/.github/workflows/build_wheels.yaml
@@ -77,7 +77,7 @@ jobs:
       - name: Build CUDA-QX wheels
         run: |
           .github/workflows/scripts/build_wheels.sh \
-              --cudaq-prefix $HOME/.cudaq \
+              --cudaq-prefix /usr/local/cudaq \
               --build-type ${{ inputs.build_type }} \
               --python-version ${{ matrix.python }}
 

--- a/docker/build_env/cudaqx.dev.Dockerfile
+++ b/docker/build_env/cudaqx.dev.Dockerfile
@@ -19,6 +19,8 @@ RUN apt-get update && apt-get install -y gfortran libblas-dev jq cuda-nvtx-12-0 
 
 COPY .cudaq_version /cudaq_version
 
+ENV CUDAQ_INSTALL_PREFIX=/usr/local/cudaq
+
 RUN mkdir -p /workspaces/cudaq && cd /workspaces/cudaq \
   && git init \
   && CUDAQ_REPO=$(jq -r '.cudaq.repository' /cudaq_version) \
@@ -30,5 +32,5 @@ RUN mkdir -p /workspaces/cudaq && cd /workspaces/cudaq \
   && rm -rf build
 
 #RUN mkdir -p /workspaces/cudaqx && cd /workspaces/cudaqx \
-#  && ~/.local/bin/cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -DCUDAQ_DIR=~/.cudaq/lib/cmake/cudaq .. \
+#  && ~/.local/bin/cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -DCUDAQ_DIR=/usr/local/cudaq/lib/cmake/cudaq .. \
 #  && ninja install

--- a/docker/build_env/cudaqx.wheel.Dockerfile
+++ b/docker/build_env/cudaqx.wheel.Dockerfile
@@ -16,6 +16,8 @@ LABEL org.opencontainers.image.source="https://github.com/NVIDIA/cudaqx"
 LABEL org.opencontainers.image.title="cudaqx-dev"
 LABEL org.opencontainers.image.url="https://github.com/NVIDIA/cudaqx"
 
+ENV CUDAQ_INSTALL_PREFIX=/usr/local/cudaq
+
 RUN dnf install -y jq cuda-nvtx-12-0
 RUN mkdir -p /workspaces/cudaqx
 COPY .cudaq_version /workspaces/cudaqx


### PR DESCRIPTION
This is desirable because some of our test environments overwrite the $HOME directory with the the $HOME directory from outside the container, and we lose access to the pre-built CUDA-Q when that happens. Furthermore, this aligns us with CUDA-Q defaults in many other ways.