### PR TITLE
Ensure items are mentioned in the same order in docs

### DIFF
--- a/docs/sphinx/index.rst
+++ b/docs/sphinx/index.rst
@@ -25,8 +25,8 @@ solvers.
    :maxdepth: 2
    :caption: Examples
 
-   examples_rst/solvers/examples
    examples_rst/qec/examples
+   examples_rst/solvers/examples
 
 .. toctree::
    :maxdepth: 1


### PR DESCRIPTION
Minor update. Make sure that the libraries are mentioned in the same order in docs. E.g, follow the order of "QEC" and then "Solvers" in all sections. 