### PR TITLE
Correcting syndromes per shot in circuit-level example

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -70,6 +70,7 @@ jobs:
       - name: Build docs
         run: |
           cmake -S . -B "build" \
+            -DCMAKE_POLICY_VERSION_MINIMUM=3.5 \
             -DCMAKE_BUILD_TYPE=Release \
             -DCMAKE_C_COMPILER=gcc-11 \
             -DCMAKE_CXX_COMPILER=g++-11 \

--- a/docs/sphinx/examples/qec/python/circuit_level_noise.py
+++ b/docs/sphinx/examples/qec/python/circuit_level_noise.py
@@ -56,12 +56,15 @@ logical_measurements = (Lz @ data.transpose()) % 2
 logical_measurements = logical_measurements.flatten()
 print("LMz:\n", logical_measurements)
 
+# organize data by shot and round if desired
+syndromes = syndromes.reshape((nShots, nRounds, syndromes.shape[1]))
+
 # initialize a Pauli frame to track logical flips
 # through the stabilizer rounds
 pauli_frame = np.array([0, 0], dtype=np.uint8)
 for shot in range(0, nShots):
     print("shot:", shot)
-    for syndrome in syndromes:
+    for syndrome in syndromes[shot]:
         print("syndrome:", syndrome)
         # decode the syndrome
         convergence, result = decoder.decode(syndrome)


### PR DESCRIPTION
In the current python circuit-level noise example, all syndromes are mistakenly processed each shot, rather than only the syndromes contained within a shot.

This PR reshapes the syndromes into a new array, and corrects this behavior.