### PR TITLE
Bump CUDA-Q commit and pin CMake

### DIFF
--- a/.cudaq_version
+++ b/.cudaq_version
@@ -1,6 +1,6 @@
 {
   "cudaq": {
     "repository": "NVIDIA/cuda-quantum",
-    "ref": "c53f77436f306f19e412015049dfafb7ae80a690"
+    "ref": "313ffefaecf656581366ab34e6cab3612c45ae17"
   }
 }

--- a/.github/actions/build-lib/action.yaml
+++ b/.github/actions/build-lib/action.yaml
@@ -29,7 +29,7 @@ runs:
       run: |
         apt update
         apt install -y --no-install-recommends ccache
-        python3 -m pip install cmake --user
+        python3 -m pip install "cmake<4" --user
         echo "$HOME/.local/bin:$PATH" >> $GITHUB_PATH
       shell: bash
 

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -70,7 +70,6 @@ jobs:
       - name: Build docs
         run: |
           cmake -S . -B "build" \
-            -DCMAKE_POLICY_VERSION_MINIMUM=3.5 \
             -DCMAKE_BUILD_TYPE=Release \
             -DCMAKE_C_COMPILER=gcc-11 \
             -DCMAKE_CXX_COMPILER=g++-11 \

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -64,7 +64,7 @@ jobs:
             sphinx_copybutton sphinx_inline_tabs sphinx_gallery sphinx_rtd_theme \
             sphinx_reredirects sphinx_toolbox cupy-cuda12x cuquantum-python-cu12
 
-          python3 -m pip install cmake --user
+          python3 -m pip install "cmake<4" --user
           echo "$HOME/.local/bin:$PATH" >> $GITHUB_PATH
 
       - name: Build docs

--- a/docker/build_env/cudaqx.dev.Dockerfile
+++ b/docker/build_env/cudaqx.dev.Dockerfile
@@ -14,7 +14,7 @@ LABEL org.opencontainers.image.title="cudaqx-dev"
 LABEL org.opencontainers.image.url="https://github.com/NVIDIA/cudaqx"
 
 RUN apt-get update && apt-get install -y gfortran libblas-dev jq cuda-nvtx-12-0 \
-  && python3 -m pip install cmake --user \
+  && python3 -m pip install "cmake<4" --user \
   && apt-get autoremove -y --purge && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 COPY .cudaq_version /cudaq_version

--- a/docs/sphinx/quickstart/installation.rst
+++ b/docs/sphinx/quickstart/installation.rst
@@ -62,7 +62,7 @@ Prerequisites
 Before building CUDA-QX from source, ensure your system meets the following requirements:
 
 * **CUDA-Q**: The NVIDIA quantum-classical programming model
-* **CMake**: Version 3.28 or higher (``pip install cmake>=3.28``)
+* **CMake**: Version 3.28 or higher (``pip install "cmake<4"``), less than 4.0
 * **GCC**: Version 11 or higher
 * **Python**: Version 3.10, 3.11, or 3.12
 * **NVIDIA GPU**: CUDA-capable GPU with compute capability 12.0 or higher

--- a/libs/solvers/lib/operators/molecule/molecule.cpp
+++ b/libs/solvers/lib/operators/molecule/molecule.cpp
@@ -6,6 +6,7 @@
  * the terms of the Apache License 2.0 which accompanies this distribution.    *
  ******************************************************************************/
 #include "cudaq/solvers/operators/molecule/molecule_package_driver.h"
+#include "cudaq/utils/cudaq_utils.h"
 
 #include <fstream>
 #include <iostream>

--- a/libs/solvers/lib/operators/operator_pools/spin_complement_gsd.cpp
+++ b/libs/solvers/lib/operators/operator_pools/spin_complement_gsd.cpp
@@ -7,6 +7,7 @@
  ******************************************************************************/
 
 #include "cudaq/solvers/operators/operator_pools/spin_complement_gsd.h"
+#include "cudaq/utils/cudaq_utils.h"
 
 using namespace cudaqx;
 


### PR DESCRIPTION
Contains minor changes as a result of https://github.com/NVIDIA/cuda-quantum/pull/2765 and also updates our build scripts to keep CMake < 4.0 for now because some of our dependencies do not support 4.0 at the moment.