### PR TITLE
Add error checking before constructing internal structures from Python data

### DIFF
--- a/.github/workflows/pr_sanity_checks.yaml
+++ b/.github/workflows/pr_sanity_checks.yaml
@@ -102,6 +102,8 @@ jobs:
           echo "clang-format-${LLVM_VERSION} --version"
           clang-format-${LLVM_VERSION} --version || true
           which clang-format-${LLVM_VERSION} || true
+          rm /usr/bin/clang-format
+          ln -s /usr/bin/clang-format-${LLVM_VERSION} /usr/bin/clang-format
           git fetch --recurse-submodules=no origin ${{ github.base_ref }}
           DIFF_COMMIT_SHA=$(git rev-parse origin/${{ github.base_ref }})
 

--- a/.github/workflows/pr_sanity_checks.yaml
+++ b/.github/workflows/pr_sanity_checks.yaml
@@ -102,8 +102,8 @@ jobs:
           echo "clang-format-${LLVM_VERSION} --version"
           clang-format-${LLVM_VERSION} --version || true
           which clang-format-${LLVM_VERSION} || true
-          rm /usr/bin/clang-format
-          ln -s /usr/bin/clang-format-${LLVM_VERSION} /usr/bin/clang-format
+          sudo rm /usr/bin/clang-format
+          sudo ln -s /usr/bin/clang-format-${LLVM_VERSION} /usr/bin/clang-format
           git fetch --recurse-submodules=no origin ${{ github.base_ref }}
           DIFF_COMMIT_SHA=$(git rev-parse origin/${{ github.base_ref }})
 

--- a/.github/workflows/pr_sanity_checks.yaml
+++ b/.github/workflows/pr_sanity_checks.yaml
@@ -75,6 +75,11 @@ jobs:
           sudo add-apt-repository "deb http://apt.llvm.org/${UBUNTU_CODENAME}/  llvm-toolchain-${UBUNTU_CODENAME}-${LLVM_VERSION} main"
           sudo apt-get update && sudo apt-get install -y --no-install-recommends clang-format-${LLVM_VERSION}
 
+          # The Ubuntu base image provided by GitHub Actions has the wrong
+          # clang-format. We install the right one here.
+          sudo rm /usr/bin/clang-format
+          sudo ln -s /usr/bin/clang-format-${LLVM_VERSION} /usr/bin/clang-format
+
       # If the `clang-format` file changes, we require the reformatting of all
       # files. See https://github.com/NVIDIA/cudaqx/pull/15#discussion_r1868174072
       - name: clang-format all things
@@ -95,11 +100,6 @@ jobs:
         run: |
           # We did a shallow clone, and thus we need to make sure to fetch the base
           # commit.
-          # Dont exit if clang-format is not installed.
-          # The Ubuntu base image provided by GitHub Actions has the wrong
-          # clang-format. We install the right one here.
-          sudo rm /usr/bin/clang-format
-          sudo ln -s /usr/bin/clang-format-${LLVM_VERSION} /usr/bin/clang-format
           git fetch --recurse-submodules=no origin ${{ github.base_ref }}
           DIFF_COMMIT_SHA=$(git rev-parse origin/${{ github.base_ref }})
 

--- a/.github/workflows/pr_sanity_checks.yaml
+++ b/.github/workflows/pr_sanity_checks.yaml
@@ -34,6 +34,7 @@ jobs:
         with:
           filters: |
             check-all-cpp:
+              - '.github/workflows/pr_sanity_checks.yaml'
               - '.clang-format'
             check-cpp:
               - '**/*.c'
@@ -76,7 +77,9 @@ jobs:
           sudo apt-get update && sudo apt-get install -y --no-install-recommends clang-format-${LLVM_VERSION}
 
           # The Ubuntu base image provided by GitHub Actions has the wrong
-          # clang-format. We install the right one here.
+          # clang-format. We install the right one here.  This is important
+          # because the "git clang-format-16" command will use still attempt to
+          # use clang-format.
           sudo rm /usr/bin/clang-format
           sudo ln -s /usr/bin/clang-format-${LLVM_VERSION} /usr/bin/clang-format
 

--- a/.github/workflows/pr_sanity_checks.yaml
+++ b/.github/workflows/pr_sanity_checks.yaml
@@ -34,7 +34,6 @@ jobs:
         with:
           filters: |
             check-all-cpp:
-              - '.github/workflows/pr_sanity_checks.yaml'
               - '.clang-format'
             check-cpp:
               - '**/*.c'

--- a/.github/workflows/pr_sanity_checks.yaml
+++ b/.github/workflows/pr_sanity_checks.yaml
@@ -96,14 +96,10 @@ jobs:
           # We did a shallow clone, and thus we need to make sure to fetch the base
           # commit.
           # Dont exit if clang-format is not installed.
-          echo "clang-format --version"
-          clang-format --version || true
-          which clang-format || true
-          echo "clang-format-${LLVM_VERSION} --version"
-          clang-format-${LLVM_VERSION} --version || true
-          which clang-format-${LLVM_VERSION} || true
+          # The Ubuntu base image provided by GitHub Actions has the wrong
+          # clang-format. We install the right one here.
           sudo rm /usr/bin/clang-format
-          #sudo ln -s /usr/bin/clang-format-${LLVM_VERSION} /usr/bin/clang-format
+          sudo ln -s /usr/bin/clang-format-${LLVM_VERSION} /usr/bin/clang-format
           git fetch --recurse-submodules=no origin ${{ github.base_ref }}
           DIFF_COMMIT_SHA=$(git rev-parse origin/${{ github.base_ref }})
 

--- a/.github/workflows/pr_sanity_checks.yaml
+++ b/.github/workflows/pr_sanity_checks.yaml
@@ -103,7 +103,7 @@ jobs:
           clang-format-${LLVM_VERSION} --version || true
           which clang-format-${LLVM_VERSION} || true
           sudo rm /usr/bin/clang-format
-          sudo ln -s /usr/bin/clang-format-${LLVM_VERSION} /usr/bin/clang-format
+          #sudo ln -s /usr/bin/clang-format-${LLVM_VERSION} /usr/bin/clang-format
           git fetch --recurse-submodules=no origin ${{ github.base_ref }}
           DIFF_COMMIT_SHA=$(git rev-parse origin/${{ github.base_ref }})
 

--- a/.github/workflows/pr_sanity_checks.yaml
+++ b/.github/workflows/pr_sanity_checks.yaml
@@ -96,6 +96,13 @@ jobs:
         run: |
           # We did a shallow clone, and thus we need to make sure to fetch the base
           # commit.
+          # Dont exit if clang-format is not installed.
+          echo "clang-format --version"
+          clang-format --version || true
+          which clang-format || true
+          echo "clang-format-${LLVM_VERSION} --version"
+          clang-format-${LLVM_VERSION} --version || true
+          which clang-format-${LLVM_VERSION} || true
           git fetch --recurse-submodules=no origin ${{ github.base_ref }}
           DIFF_COMMIT_SHA=$(git rev-parse origin/${{ github.base_ref }})
 

--- a/docs/sphinx/api/qec/nv_qldpc_decoder_api.rst
+++ b/docs/sphinx/api/qec/nv_qldpc_decoder_api.rst
@@ -33,6 +33,10 @@
                           [0, 1, 0, 1, 1, 0, 1],
                           [0, 0, 1, 0, 1, 1, 1]], dtype=np.uint8) # sample 3x7 PCM
             opts = dict() # see below for options
+            # Note: H must be in row-major order. If you use
+            # `scipy.sparse.csr_matrix.todense()` to get the parity check
+            # matrix, you must specify todense(order='C') to get a row-major
+            # matrix.
             nvdec = qec.get_decoder('nv-qldpc-decoder', H, **opts)
 
       .. tab:: C++

--- a/libs/core/include/cuda-qx/core/kwargs_utils.h
+++ b/libs/core/include/cuda-qx/core/kwargs_utils.h
@@ -77,6 +77,11 @@ template <typename T>
 tensor<T> toTensor(const py::array_t<T> &H) {
   py::buffer_info buf = H.request();
 
+  if (buf.ndim >= 1 && buf.strides[0] == buf.itemsize) {
+    throw std::runtime_error("toTensor: data must be in row-major order, but "
+                             "column-major order was detected.");
+  }
+
   // Create a vector of the array dimensions
   std::vector<std::size_t> shape;
   for (py::ssize_t d : buf.shape) {

--- a/libs/qec/python/bindings/py_decoder.cpp
+++ b/libs/qec/python/bindings/py_decoder.cpp
@@ -209,6 +209,22 @@ void bindDecoder(py::module &mod) {
 
         py::buffer_info buf = H.request();
 
+        if (buf.ndim != 2) {
+          throw std::runtime_error(
+              "Parity check matrix must be 2-dimensional.");
+        }
+
+        if (buf.itemsize != sizeof(uint8_t)) {
+          throw std::runtime_error(
+              "Parity check matrix must be an array of uint8_t.");
+        }
+
+        if (buf.strides[0] == buf.itemsize) {
+          throw std::runtime_error(
+              "Parity check matrix must be in row-major order, but "
+              "column-major order was detected.");
+        }
+
         // Create a vector of the array dimensions
         std::vector<std::size_t> shape;
         for (py::ssize_t d : buf.shape) {

--- a/libs/qec/python/bindings/py_decoder.cpp
+++ b/libs/qec/python/bindings/py_decoder.cpp
@@ -238,7 +238,8 @@ void bindDecoder(py::module &mod) {
         return get_decoder(name, tensor_H, hetMapFromKwargs(options));
       },
       "Get a decoder by name with a given parity check matrix"
-      "and optional decoder-specific parameters");
+      "and optional decoder-specific parameters. Note: the parity check matrix "
+      "must be in row-major order.");
 }
 
 } // namespace cudaq::qec

--- a/libs/qec/python/tests/test_decoder.py
+++ b/libs/qec/python/tests/test_decoder.py
@@ -29,6 +29,13 @@ def test_decoder_initialization():
     assert hasattr(decoder, 'decode')
 
 
+def test_decoder_initialization_with_error():
+    # We do not support column-major order (Fortran order)
+    H_bad = np.zeros((10, 20), dtype=np.uint8, order='F')
+    with pytest.raises(RuntimeError) as e:
+        decoder = qec.get_decoder('single_error_lut_example', H_bad)
+
+
 def test_decoder_api():
     # Test decode_batch
     decoder = qec.get_decoder('example_byod', H)


### PR DESCRIPTION
Our Python bindings require that matrices be supplied in row-major ordering. This PR adds error checks to verify that and adds documentation to clarify that.