### PR TITLE
Add `__version__` info to packages

### DIFF
--- a/.github/workflows/scripts/build_wheels.sh
+++ b/.github/workflows/scripts/build_wheels.sh
@@ -115,6 +115,8 @@ fi
 export CC=gcc
 export CXX=g++
 export SETUPTOOLS_SCM_PRETEND_VERSION=$wheels_version
+export CUDAQX_QEC_VERSION=$wheels_version
+export CUDAQX_SOLVERS_VERSION=$wheels_version
 
 # ==============================================================================
 # QEC library

--- a/libs/qec/CMakeLists.txt
+++ b/libs/qec/CMakeLists.txt
@@ -122,6 +122,26 @@ if (SKBUILD)
   set(CMAKE_INSTALL_LIBDIR cudaq_qec/lib)
 endif()
 
+# Version
+# ==============================================================================
+if (DEFINED ENV{CUDAQX_QEC_VERSION})
+  # The version was defined by the user (likely a bot performing the build), so
+  # use the value provided as is.
+  set(CUDAQX_QEC_VERSION "$ENV{CUDAQX_QEC_VERSION}")
+  message(STATUS "CUDAQX_QEC_VERSION is set to ${CUDAQX_QEC_VERSION}")
+else()
+  # Otherwise, create a version based on the nearest tag in the git repo.
+  set(CUDAQX_QEC_VERSION "0.0.0")
+endif()
+
+# Retrieve the commit SHA for full revision description
+execute_process(COMMAND git rev-parse --verify HEAD
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+    OUTPUT_VARIABLE CUDAQX_QEC_COMMIT_SHA OUTPUT_STRIP_TRAILING_WHITESPACE)
+
+configure_file("${CMAKE_CURRENT_SOURCE_DIR}/lib/version.cpp.in"
+               "${CMAKE_CURRENT_BINARY_DIR}/lib/version.cpp" @ONLY)
+
 # Directory setup
 # ==============================================================================
 

--- a/libs/qec/CMakeLists.txt
+++ b/libs/qec/CMakeLists.txt
@@ -130,7 +130,7 @@ if (DEFINED ENV{CUDAQX_QEC_VERSION})
   set(CUDAQX_QEC_VERSION "$ENV{CUDAQX_QEC_VERSION}")
   message(STATUS "CUDAQX_QEC_VERSION is set to ${CUDAQX_QEC_VERSION}")
 else()
-  # Otherwise, create a version based on the nearest tag in the git repo.
+  # Otherwise, create a 0.0.0 version string.
   set(CUDAQX_QEC_VERSION "0.0.0")
 endif()
 

--- a/libs/qec/include/cudaq/qec/decoder.h
+++ b/libs/qec/include/cudaq/qec/decoder.h
@@ -137,6 +137,12 @@ public:
   /// @brief Destructor
   virtual ~decoder() {}
 
+  /// @brief Get the version of the decoder. Subclasses that are not part of the
+  /// standard GitHub repo should override this to provide a more tailored
+  /// version string.
+  /// @return A string containing the version of the decoder
+  virtual std::string get_version() const;
+
 protected:
   /// @brief For a classical `[n,k]` code, this is `n`.
   std::size_t block_size = 0;

--- a/libs/qec/include/cudaq/qec/version.h
+++ b/libs/qec/include/cudaq/qec/version.h
@@ -1,0 +1,13 @@
+/****************************************************************-*- C++ -*-****
+ * Copyright (c) 2025 NVIDIA Corporation & Affiliates.                         *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+#pragma once
+
+namespace cudaq::qec {
+const char *getVersion();
+const char *getFullRepositoryVersion();
+} // namespace cudaq::qec

--- a/libs/qec/lib/CMakeLists.txt
+++ b/libs/qec/lib/CMakeLists.txt
@@ -1,5 +1,5 @@
 # ============================================================================ #
-# Copyright (c) 2024 NVIDIA Corporation & Affiliates.                          #
+# Copyright (c) 2024 - 2025 NVIDIA Corporation & Affiliates.                   #
 # All rights reserved.                                                         #
 #                                                                              #
 # This source code and the accompanying materials are made available under     #
@@ -18,6 +18,7 @@ add_library(${LIBRARY_NAME} SHARED
   experiments.cpp
   decoders/single_error_lut.cpp
   plugin_loader.cpp
+  version.cpp
 )
 
 add_subdirectory(decoders/plugins/example)

--- a/libs/qec/lib/decoder.cpp
+++ b/libs/qec/lib/decoder.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022 - 2024 NVIDIA Corporation & Affiliates.                  *
+ * Copyright (c) 2022 - 2025 NVIDIA Corporation & Affiliates.                  *
  * All rights reserved.                                                        *
  *                                                                             *
  * This source code and the accompanying materials are made available under    *
@@ -9,6 +9,7 @@
 #include "cudaq/qec/decoder.h"
 #include "cuda-qx/core/library_utils.h"
 #include "cudaq/qec/plugin_loader.h"
+#include "cudaq/qec/version.h"
 #include <cassert>
 #include <dlfcn.h>
 #include <filesystem>
@@ -52,6 +53,13 @@ decoder::decode_batch(const std::vector<std::vector<float_t>> &syndrome) {
   for (auto &s : syndrome)
     result.push_back(decode(s));
   return result;
+}
+
+std::string decoder::get_version() const {
+  std::stringstream ss;
+  ss << "CUDA-Q QEC Base Decoder Interface " << cudaq::qec::getVersion() << " ("
+     << cudaq::qec::getFullRepositoryVersion() << ")";
+  return ss.str();
 }
 
 std::future<decoder_result>

--- a/libs/qec/lib/version.cpp.in
+++ b/libs/qec/lib/version.cpp.in
@@ -1,0 +1,18 @@
+/*******************************************************************************
+ * Copyright (c) 2025 NVIDIA Corporation & Affiliates.                         *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+#include "cudaq/qec/version.h"
+
+namespace cudaq::qec {
+
+const char *getVersion() { return "@CUDAQX_QEC_VERSION@"; }
+
+const char *getFullRepositoryVersion() {
+  return "https://github.com/NVIDIA/cudaqx @CUDAQX_QEC_COMMIT_SHA@";
+}
+} // namespace cudaq::qec

--- a/libs/qec/python/bindings/py_code.cpp
+++ b/libs/qec/python/bindings/py_code.cpp
@@ -12,10 +12,11 @@
 #include <pybind11/stl.h>
 
 #include "common/Logger.h"
-#include "cudaq/python/PythonCppInterop.h"
-#include "cudaq/utils/registry.h"
 
+#include "cudaq/python/PythonCppInterop.h"
 #include "cudaq/qec/experiments.h"
+#include "cudaq/qec/version.h"
+#include "cudaq/utils/registry.h"
 
 #include "cuda-qx/core/kwargs_utils.h"
 #include "type_casters.h"
@@ -453,5 +454,10 @@ void bindCode(py::module &mod) {
       },
       "Sample syndrome measurements with code capacity noise.", py::arg("H"),
       py::arg("numShots"), py::arg("errorProb"), py::arg("seed") = py::none());
+
+  std::stringstream ss;
+  ss << "CUDA-Q QEC " << cudaq::qec::getVersion() << " ("
+     << cudaq::qec::getFullRepositoryVersion() << ")";
+  qecmod.attr("__version__") = ss.str();
 }
 } // namespace cudaq::qec

--- a/libs/qec/python/bindings/py_decoder.cpp
+++ b/libs/qec/python/bindings/py_decoder.cpp
@@ -167,7 +167,9 @@ void bindDecoder(py::module &mod) {
       .def("get_block_size", &decoder::get_block_size,
            "Get the size of the code block")
       .def("get_syndrome_size", &decoder::get_syndrome_size,
-           "Get the size of the syndrome");
+           "Get the size of the syndrome")
+      .def("get_version", &decoder::get_version,
+           "Get the version of the decoder");
 
   // Expose decorator function that handles inheritance
   qecmod.def("decoder", [&](const std::string &name) {

--- a/libs/qec/python/cudaq_qec/__init__.py
+++ b/libs/qec/python/cudaq_qec/__init__.py
@@ -1,5 +1,5 @@
 # ============================================================================ #
-# Copyright (c) 2024 NVIDIA Corporation & Affiliates.                          #
+# Copyright (c) 2024 - 2025 NVIDIA Corporation & Affiliates.                   #
 # All rights reserved.                                                         #
 #                                                                              #
 # This source code and the accompanying materials are made available under     #
@@ -9,6 +9,7 @@
 from .patch import patch
 from ._pycudaqx_qec_the_suffix_matters_cudaq_qec import *
 
+__version__ = qecrt.__version__
 code = qecrt.code
 Code = qecrt.Code
 decoder = qecrt.decoder

--- a/libs/qec/python/tests/test_code.py
+++ b/libs/qec/python/tests/test_code.py
@@ -229,5 +229,9 @@ def test_het_map_from_kwargs_bool():
     assert isinstance(steane, qec.Code)
 
 
+def test_version():
+    assert "CUDA-Q QEC" in qec.__version__
+
+
 if __name__ == "__main__":
     pytest.main()

--- a/libs/qec/python/tests/test_decoder.py
+++ b/libs/qec/python/tests/test_decoder.py
@@ -188,5 +188,10 @@ def test_pass_weights():
     # Test is that no error is thrown
 
 
+def test_version():
+    decoder = qec.get_decoder('example_byod', H)
+    assert "CUDA-Q QEC Base Decoder" in decoder.get_version()
+
+
 if __name__ == "__main__":
     pytest.main()

--- a/libs/qec/unittests/test_qec.cpp
+++ b/libs/qec/unittests/test_qec.cpp
@@ -13,6 +13,7 @@
 
 #include "cudaq/qec/codes/surface_code.h"
 #include "cudaq/qec/experiments.h"
+#include "cudaq/qec/version.h"
 
 TEST(StabilizerTester, checkConstructFromSpinOps) {
   {
@@ -770,4 +771,15 @@ TEST(QECCodeTester, checkStabilizerGrid) {
     EXPECT_EQ(144, grid.x_stabilizers.size());
     EXPECT_EQ(144, grid.z_stabilizers.size());
   }
+}
+
+TEST(QECCodeTester, checkVersion) {
+  std::string version = cudaq::qec::getVersion();
+  EXPECT_FALSE(version.empty());
+  EXPECT_TRUE(version.find("CUDAQX_QEC_VERSION") == std::string::npos);
+
+  std::string fullVersion = cudaq::qec::getFullRepositoryVersion();
+  EXPECT_TRUE(fullVersion.find("NVIDIA/cudaqx") != std::string::npos);
+  EXPECT_TRUE(fullVersion.find("CUDAQX_SOLVERS_COMMIT_SHA") ==
+              std::string::npos);
 }

--- a/libs/solvers/CMakeLists.txt
+++ b/libs/solvers/CMakeLists.txt
@@ -153,6 +153,26 @@ if (SKBUILD)
   set(CMAKE_INSTALL_LIBDIR cudaq_solvers/lib)
 endif()
 
+# Version
+# ==============================================================================
+if (DEFINED ENV{CUDAQX_SOLVERS_VERSION})
+  # The version was defined by the user (likely a bot performing the build), so
+  # use the value provided as is.
+  set(CUDAQX_SOLVERS_VERSION "$ENV{CUDAQX_SOLVERS_VERSION}")
+  message(STATUS "CUDAQX_SOLVERS_VERSION is set to ${CUDAQX_SOLVERS_VERSION}")
+else()
+  # Otherwise, create a version based on the nearest tag in the git repo.
+  set(CUDAQX_SOLVERS_VERSION "0.0.0")
+endif()
+
+# Retrieve the commit SHA for full revision description
+execute_process(COMMAND git rev-parse --verify HEAD
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+    OUTPUT_VARIABLE CUDAQX_SOLVERS_COMMIT_SHA OUTPUT_STRIP_TRAILING_WHITESPACE)
+
+configure_file("${CMAKE_CURRENT_SOURCE_DIR}/lib/version.cpp.in"
+               "${CMAKE_CURRENT_BINARY_DIR}/lib/version.cpp" @ONLY)
+
 # Directory setup
 # ==============================================================================
 

--- a/libs/solvers/CMakeLists.txt
+++ b/libs/solvers/CMakeLists.txt
@@ -161,7 +161,7 @@ if (DEFINED ENV{CUDAQX_SOLVERS_VERSION})
   set(CUDAQX_SOLVERS_VERSION "$ENV{CUDAQX_SOLVERS_VERSION}")
   message(STATUS "CUDAQX_SOLVERS_VERSION is set to ${CUDAQX_SOLVERS_VERSION}")
 else()
-  # Otherwise, create a version based on the nearest tag in the git repo.
+  # Otherwise, create a 0.0.0 version string.
   set(CUDAQX_SOLVERS_VERSION "0.0.0")
 endif()
 

--- a/libs/solvers/include/cudaq/solvers/version.h
+++ b/libs/solvers/include/cudaq/solvers/version.h
@@ -1,0 +1,13 @@
+/****************************************************************-*- C++ -*-****
+ * Copyright (c) 2025 NVIDIA Corporation & Affiliates.                         *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+#pragma once
+
+namespace cudaq::solvers {
+const char *getVersion();
+const char *getFullRepositoryVersion();
+} // namespace cudaq::solvers

--- a/libs/solvers/lib/CMakeLists.txt
+++ b/libs/solvers/lib/CMakeLists.txt
@@ -1,5 +1,5 @@
 # ============================================================================ #
-# Copyright (c) 2024 NVIDIA Corporation & Affiliates.                          #
+# Copyright (c) 2024 - 2025 NVIDIA Corporation & Affiliates.                   #
 # All rights reserved.                                                         #
 #                                                                              #
 # This source code and the accompanying materials are made available under     #
@@ -23,7 +23,7 @@ add_library(cudaq-solvers SHARED
   operators/operator_pools/spin_complement_gsd.cpp
   operators/operator_pools/uccsd_operator_pool.cpp
   operators/operator_pools/qaoa_operator_pool.cpp
-
+  version.cpp
 )
 
 add_subdirectory(adapt)

--- a/libs/solvers/lib/version.cpp.in
+++ b/libs/solvers/lib/version.cpp.in
@@ -1,0 +1,18 @@
+/*******************************************************************************
+ * Copyright (c) 2025 NVIDIA Corporation & Affiliates.                         *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+#include "cudaq/solvers/version.h"
+
+namespace cudaq::solvers {
+
+const char *getVersion() { return "@CUDAQX_SOLVERS_VERSION@"; }
+
+const char *getFullRepositoryVersion() {
+  return "https://github.com/NVIDIA/cudaqx @CUDAQX_SOLVERS_COMMIT_SHA@";
+}
+} // namespace cudaq::solvers

--- a/libs/solvers/python/bindings/solvers/py_solvers.cpp
+++ b/libs/solvers/python/bindings/solvers/py_solvers.cpp
@@ -16,6 +16,7 @@
 #include "cudaq/solvers/adapt.h"
 #include "cudaq/solvers/qaoa.h"
 #include "cudaq/solvers/stateprep/uccsd.h"
+#include "cudaq/solvers/version.h"
 #include "cudaq/solvers/vqe.h"
 
 #include "cudaq/solvers/operators/graph/clique.h"
@@ -1141,6 +1142,11 @@ Notes:
       },
       "Generate Clique Hamiltonian from a NetworkX graph", py::arg("graph"),
       py::arg("penalty") = 4.0);
+
+  std::stringstream ss;
+  ss << "CUDA-Q Solvers " << cudaq::solvers::getVersion() << " ("
+     << cudaq::solvers::getFullRepositoryVersion() << ")";
+  solvers.attr("__version__") = ss.str();
 }
 
 } // namespace cudaq::solvers

--- a/libs/solvers/python/cudaq_solvers/__init__.py
+++ b/libs/solvers/python/cudaq_solvers/__init__.py
@@ -1,5 +1,5 @@
 # ============================================================================ #
-# Copyright (c) 2024 NVIDIA Corporation & Affiliates.                          #
+# Copyright (c) 2024 - 2025 NVIDIA Corporation & Affiliates.                   #
 # All rights reserved.                                                         #
 #                                                                              #
 # This source code and the accompanying materials are made available under     #
@@ -7,3 +7,4 @@
 # ============================================================================ #
 
 from ._pycudaqx_solvers_the_suffix_matters_cudaq_solvers import *
+from ._pycudaqx_solvers_the_suffix_matters_cudaq_solvers import __version__

--- a/libs/solvers/python/tests/test_optim.py
+++ b/libs/solvers/python/tests/test_optim.py
@@ -1,5 +1,5 @@
 # ============================================================================ #
-# Copyright (c) 2024 NVIDIA Corporation & Affiliates.                          #
+# Copyright (c) 2024 - 2025 NVIDIA Corporation & Affiliates.                   #
 # All rights reserved.                                                         #
 #                                                                              #
 # This source code and the accompanying materials are made available under     #
@@ -32,3 +32,7 @@ def test_cobyla():
     assert np.isclose(0.0, opt, atol=1e-6)
     assert np.isclose(1.0, params[0], atol=1e-6)
     assert np.isclose(1.0, params[1], atol=1e-6)
+
+
+def test_version():
+    assert "CUDA-Q Solvers" in solvers.__version__

--- a/libs/solvers/unittests/test_optimizers.cpp
+++ b/libs/solvers/unittests/test_optimizers.cpp
@@ -5,7 +5,9 @@
  * This source code and the accompanying materials are made available under    *
  * the terms of the Apache License 2.0 which accompanies this distribution.    *
  ******************************************************************************/
+
 #include "cudaq/solvers/optimizer.h"
+#include "cudaq/solvers/version.h"
 
 #include <cmath>
 #include <iostream>
@@ -82,4 +84,15 @@ TEST(OptimTester, checkLBFGS) {
       EXPECT_NEAR(1.0, params[1], 1e-3);
     }
   }
+}
+
+TEST(OptimTester, checkVersion) {
+  std::string version = cudaq::solvers::getVersion();
+  EXPECT_FALSE(version.empty());
+  EXPECT_TRUE(version.find("CUDAQX_SOLVERS_VERSION") == std::string::npos);
+
+  std::string fullVersion = cudaq::solvers::getFullRepositoryVersion();
+  EXPECT_TRUE(fullVersion.find("NVIDIA/cudaqx") != std::string::npos);
+  EXPECT_TRUE(fullVersion.find("CUDAQX_SOLVERS_COMMIT_SHA") ==
+              std::string::npos);
 }


### PR DESCRIPTION
This PR makes it so that the following commands work.

```python
>>> print(solvers.__version__)
CUDA-Q Solvers 0.0.0 (https://github.com/NVIDIA/cudaqx a36bdffa2da8fb147c3b23d170ffcf8317600fcd)
>>> print(qec.__version__)
CUDA-Q QEC 0.0.0 (https://github.com/NVIDIA/cudaqx a36bdffa2da8fb147c3b23d170ffcf8317600fcd)
```

The actual version number (0.0.0) will be replaced if built with the `CUDAQX_QEC_VERSION` and/or `CUDAQX_SOLVERS_VERSION` environment variables set.

It also adds a `decoder.get_version()` function for our decoders.