### PR TITLE
Bump GoogleTest to v1.17.0

### DIFF
--- a/libs/core/unittests/CMakeLists.txt
+++ b/libs/core/unittests/CMakeLists.txt
@@ -1,5 +1,5 @@
 # ============================================================================ #
-# Copyright (c) 2024 NVIDIA Corporation & Affiliates.                          #
+# Copyright (c) 2024 - 2025 NVIDIA Corporation & Affiliates.                   #
 # All rights reserved.                                                         #
 #                                                                              #
 # This source code and the accompanying materials are made available under     #
@@ -12,7 +12,7 @@
 FetchContent_Declare(
   googletest
   GIT_REPOSITORY https://github.com/google/googletest.git
-  GIT_TAG v1.15.2
+  GIT_TAG v1.17.0
   EXCLUDE_FROM_ALL
 )
 FetchContent_MakeAvailable(googletest)

--- a/libs/qec/unittests/CMakeLists.txt
+++ b/libs/qec/unittests/CMakeLists.txt
@@ -1,5 +1,5 @@
 # ============================================================================ #
-# Copyright (c) 2024 NVIDIA Corporation & Affiliates.                          #
+# Copyright (c) 2024 - 2025 NVIDIA Corporation & Affiliates.                   #
 # All rights reserved.                                                         #
 #                                                                              #
 # This source code and the accompanying materials are made available under     #
@@ -12,7 +12,7 @@
 FetchContent_Declare(
   googletest
   GIT_REPOSITORY https://github.com/google/googletest.git
-  GIT_TAG v1.15.2
+  GIT_TAG v1.17.0
   EXCLUDE_FROM_ALL
 )
 FetchContent_MakeAvailable(googletest)

--- a/libs/solvers/unittests/CMakeLists.txt
+++ b/libs/solvers/unittests/CMakeLists.txt
@@ -1,5 +1,5 @@
 # ============================================================================ #
-# Copyright (c) 2024 NVIDIA Corporation & Affiliates.                          #
+# Copyright (c) 2024 - 2025 NVIDIA Corporation & Affiliates.                   #
 # All rights reserved.                                                         #
 #                                                                              #
 # This source code and the accompanying materials are made available under     #
@@ -12,7 +12,7 @@
 FetchContent_Declare(
   googletest
   GIT_REPOSITORY https://github.com/google/googletest.git
-  GIT_TAG v1.15.2
+  GIT_TAG v1.17.0
   EXCLUDE_FROM_ALL
 )
 FetchContent_MakeAvailable(googletest)


### PR DESCRIPTION
The new version of GoogleTest has support for custom `ConvertGenerator` functions, which will enable better support for parameterized tests (coming in a later PR/MR).