### PR TITLE
Follow-up to #154 - fix build error in wheel

### DIFF
--- a/.github/workflows/build_wheels.yaml
+++ b/.github/workflows/build_wheels.yaml
@@ -108,6 +108,9 @@ jobs:
             unzip -d tmp cudaq_qec-*-cp${PYVER}-cp${PYVER}-manylinux*${SUFFIX}*.whl
             export QEC_EXTERNAL_DECODERS=$(pwd)/tmp/cudaq_qec/lib/decoder-plugins/libcudaq-qec-nv-qldpc-decoder.so
           fi
+          # This is needed to allow the "git rev-parse" commands in the build
+          # scripts to work.
+          git config --global --add safe.directory $GITHUB_WORKSPACE
           .github/workflows/scripts/build_wheels.sh \
               --cudaq-prefix /usr/local/cudaq \
               --build-type ${{ inputs.build_type }} \


### PR DESCRIPTION
Bad (on main)
https://github.com/NVIDIA/cudaqx/actions/runs/14888803804/job/41815449341#step:9:202

```
-- CUDAQX_QEC_VERSION is set to 0.3.0
fatal: detected dubious ownership in repository at '/__w/cudaqx/cudaqx'
To add an exception for this directory, call:

	git config --global --add safe.directory /__w/cudaqx/cudaqx
-- pybind11 v2.13.6 
```

Good (with this PR, no error)
https://github.com/NVIDIA/cudaqx/actions/runs/14888838927/job/41815573954#step:9:204