### PR TITLE
Workflow updates (incl creating all_libs_release.yaml)

### DIFF
--- a/.github/actions/build-lib/action.yaml
+++ b/.github/actions/build-lib/action.yaml
@@ -16,6 +16,10 @@ inputs:
     description: 'Platform (amd64 or arm64)'
     default: ''
     required: true
+  install-prefix:
+    description: 'Install prefix'
+    default: '~/.cudaqx'
+    required: false
 outputs:
   build-dir:
     description: 'Build dir.'
@@ -56,7 +60,7 @@ runs:
         CCACHE_DIR: /ccache-${{ inputs.lib }}
       run: |
         build_dir=build_${{ inputs.lib }}
-        .github/actions/build-lib/build_${{ inputs.lib }}.sh $build_dir
+        .github/actions/build-lib/build_${{ inputs.lib }}.sh $build_dir ${{ inputs.install-prefix }}
         echo "build_dir=$build_dir" >> $GITHUB_OUTPUT
       shell: bash
 

--- a/.github/actions/build-lib/build_all.sh
+++ b/.github/actions/build-lib/build_all.sh
@@ -10,7 +10,7 @@ cmake -S . -B "$1" \
   -DCUDAQX_ENABLE_LIBS="all" \
   -DCUDAQX_INCLUDE_TESTS=ON \
   -DCUDAQX_BINDINGS_PYTHON=ON \
-  -DCMAKE_INSTALL_PREFIX=$HOME/.cudaqx
+  -DCMAKE_INSTALL_PREFIX="$2"
 
 cmake --build "$1" --target install
 

--- a/.github/actions/build-lib/build_qec.sh
+++ b/.github/actions/build-lib/build_qec.sh
@@ -9,7 +9,7 @@ cmake -S libs/qec -B "$1" \
   -DCUDAQ_DIR=/cudaq-install/lib/cmake/cudaq/ \
   -DCUDAQX_INCLUDE_TESTS=ON \
   -DCUDAQX_BINDINGS_PYTHON=ON \
-  -DCMAKE_INSTALL_PREFIX=$HOME/.cudaqx
+  -DCMAKE_INSTALL_PREFIX="$2"
 
 cmake --build "$1" --target install
 

--- a/.github/actions/build-lib/build_solvers.sh
+++ b/.github/actions/build-lib/build_solvers.sh
@@ -9,7 +9,7 @@ cmake -S libs/solvers -B "$1" \
   -DCUDAQ_DIR=/cudaq-install/lib/cmake/cudaq/ \
   -DCUDAQX_INCLUDE_TESTS=ON \
   -DCUDAQX_BINDINGS_PYTHON=ON \
-  -DCMAKE_INSTALL_PREFIX=$HOME/.cudaqx
+  -DCMAKE_INSTALL_PREFIX="$2"
 
 cmake --build "$1" --target install
 

--- a/.github/workflows/all_libs_release.yaml
+++ b/.github/workflows/all_libs_release.yaml
@@ -85,7 +85,8 @@ jobs:
         with:
           lib: "all"
           platform: ${{ matrix.runner.arch }}
-      
+          install-prefix: /usr/local/cudaq
+
       - name: Save build artifacts
         run: |
           cmake --build ${{ steps.build.outputs.build-dir }} --target zip_installed_files

--- a/.github/workflows/all_libs_release.yaml
+++ b/.github/workflows/all_libs_release.yaml
@@ -1,0 +1,133 @@
+name: All libs (Release)
+
+on:
+  workflow_dispatch:
+    inputs:
+      release-number:
+        description: 'Release Number (e.g. 0.3.0)'
+        required: true
+        default: '0.0.0'
+      assets_repo:
+        type: string
+        description: Retrieve assets from a draft release from this repo (e.g. NVIDIA/cudaqx)
+        required: false
+      assets_tag:
+        type: string
+        description: Retrieve assets from a draft release with this tag (e.g. installed_files-1)
+        required: false
+
+jobs:
+  pr-build:
+    name: Build and test
+    strategy:
+      fail-fast: false
+      matrix:
+        runner: [
+          { arch: arm64, gpu: a100 },
+          { arch: amd64, gpu: v100 },
+        ]
+    runs-on: linux-${{ matrix.runner.arch }}-gpu-${{ matrix.runner.gpu }}-latest-1
+    container: 
+      image: ${{ format('ghcr.io/nvidia/cudaqx-dev:{0}-{1}', inputs.release-number, matrix.runner.arch) }}
+      env:
+        NVIDIA_VISIBLE_DEVICES: ${{ env.NVIDIA_VISIBLE_DEVICES }}
+    permissions: write-all
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          ref: releases/v${{ inputs.release-number }}
+          set-safe-directory: true
+
+      - name: Set git safe directory
+        run: git config --global --add safe.directory $GITHUB_WORKSPACE
+
+      - name: Set release number
+        id: set-release-number
+        run: |
+          echo "CUDAQX_QEC_VERSION=${{ inputs.release-number }}" >> $GITHUB_ENV
+          echo "CUDAQX_SOLVERS_VERSION=${{ inputs.release-number }}" >> $GITHUB_ENV
+          # And output to the GitHub Actions summary.
+          echo "Setting CUDAQX_QEC_VERSION=${{ inputs.release-number }}" >> $GITHUB_STEP_SUMMARY
+          echo "Setting CUDAQX_SOLVERS_VERSION=${{ inputs.release-number }}" >> $GITHUB_STEP_SUMMARY
+
+      - name: Install dependencies
+        run: |
+          apt update && apt install -y --no-install-recommends zip unzip patchelf
+
+      - name: Fetch assets and set QEC_EXTERNAL_DECODERS
+        env:
+          GH_TOKEN: ${{ github.token }}
+        id: fetch-assets
+        run: |
+          if [[ -n "${{ inputs.assets_repo }}" ]] && [[ -n "${{ inputs.assets_tag }}" ]]; then
+            bash .github/workflows/scripts/install_git_cli.sh
+            # Fetch the assets into this directory
+            gh release download -R ${{ inputs.assets_repo }} ${{ inputs.assets_tag }}
+            # Show what was downloaded
+            ls
+            # Show release info (and save to summary)
+            gh release view -R ${{ inputs.assets_repo }} ${{ inputs.assets_tag }} >> $GITHUB_STEP_SUMMARY
+            # Extract the decoder that needs to be embedded in the release
+            mkdir -p tmp
+            unzip -d tmp installed_files-${{ matrix.runner.arch }}.zip
+            echo "QEC_EXTERNAL_DECODERS=$(pwd)/tmp/lib/decoder-plugins/libcudaq-qec-nv-qldpc-decoder.so" >> $GITHUB_ENV
+          fi
+        shell: bash
+          
+      # ========================================================================
+      # Build
+      # ========================================================================
+
+      - name: Build
+        id: build
+        uses: ./.github/actions/build-lib
+        with:
+          lib: "all"
+          platform: ${{ matrix.runner.arch }}
+      
+      - name: Save build artifacts
+        run: |
+          cmake --build ${{ steps.build.outputs.build-dir }} --target zip_installed_files
+          cd ${{ steps.build.outputs.build-dir }}
+          mv installed_files.zip installed_files-${{ matrix.runner.arch }}.zip
+      
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: installed_files-${{ matrix.runner.arch }}
+          path: ${{ steps.build.outputs.build-dir }}/installed_files-${{ matrix.runner.arch }}.zip
+
+      # ========================================================================
+      # Run tests
+      # ========================================================================
+      #
+      - name: Run tests
+        run: cmake --build ${{ steps.build.outputs.build-dir }} --target run_tests
+
+      # ========================================================================
+      # Run python tests
+      # ========================================================================
+ 
+      - name: Install python requirements
+        run: pip install numpy pytest cupy-cuda12x cuquantum-python-cu12
+
+      - name: Run Python tests
+        run: |
+          if [[ -n "${{ env.QEC_EXTERNAL_DECODERS }}" ]]; then
+            # Verify that external decoder is available if applicable
+            export PYTHONPATH="/usr/local/cudaq:$HOME/.cudaqx"
+            python3 -c "import cudaq_qec as qec; print(qec.__version__); d = qec.get_decoder('nv-qldpc-decoder', qec.get_code('steane').get_parity()); print(d.get_version())"
+          fi
+          cmake --build ${{ steps.build.outputs.build-dir }} --target run_python_tests
+        shell: bash
+
+      # ========================================================================
+      # Run example tests
+      # ========================================================================
+ 
+      - name: Run example tests
+        run: |
+          ln -s /usr/local/cudaq /cudaq-install
+          bash scripts/ci/test_examples.sh all 
+

--- a/.github/workflows/build_docker.yaml
+++ b/.github/workflows/build_docker.yaml
@@ -15,6 +15,10 @@ on:
         type: string
         description: Retrieve assets from a draft release with this tag (e.g. docker-files-89)
         required: false
+      artifacts_from_run:
+        type: string
+        description: As opposed to downloading assets from a release (`asset_tag`), download them from a run of the "All Libs (Release)" workflow.
+        required: false
       pub_tag:
         type: string
         description: Docker tag to use for published image (e.g. ghcr.io/nvidia/cudaqx:latest-pub, defaults to private repo if blank)
@@ -59,6 +63,12 @@ jobs:
           if [[ -n "${{ inputs.assets_repo }}" ]] && [[ -n "${{ inputs.assets_tag }}" ]]; then
             # Fetch the assets into this directory
             gh release download -R ${{ inputs.assets_repo }} ${{ inputs.assets_tag }}
+            ls
+          fi
+          if [[ -n "${{ inputs.artifacts_from_run }}" ]]; then
+            # Download the artifacts from the run
+            gh run download -R ${{ inputs.assets_repo }} ${{ inputs.artifacts_from_run }}
+            mv installed_files-*/installed_files-*.zip .
             ls
           fi
 

--- a/.github/workflows/build_docker.yaml
+++ b/.github/workflows/build_docker.yaml
@@ -9,11 +9,11 @@ on:
         required: false
       assets_repo:
         type: string
-        description: Retrieve assets from a draft release from this repo (e.g. NVIDIA/cudaqx)
+        description: Retrieve artifacts from a draft release from this repo (e.g. NVIDIA/cudaqx)
         required: false
       assets_tag:
         type: string
-        description: Retrieve assets from a draft release with this tag (e.g. docker-files-89)
+        description: (Deprecated) Retrieve assets from a draft release with this tag (e.g. docker-files-89)
         required: false
       artifacts_from_run:
         type: string

--- a/.github/workflows/build_qa_wheel_test.yaml
+++ b/.github/workflows/build_qa_wheel_test.yaml
@@ -6,10 +6,18 @@ on:
       wheels_repo:
         type: string
         description: Retrieve assets from a draft release from this repo (e.g. NVIDIA/cudaqx)
-        required: false
+        required: true
       wheels_run_id:
         type: string
         description: Retrieve wheels from this GitHub Actions run (e.g. 14368511401)
+        required: true
+      cudaq_repo:
+        type: string
+        description: Retrieve CUDA-Q from this repo (e.g. NVIDIA/cuda-quantum)
+        required: false
+      cudaq_assets_tag:
+        type: string
+        description: Retrieve CUDA-Q assets from this release (e.g. 0.11.0)
         required: false
 
 jobs:
@@ -54,10 +62,17 @@ jobs:
           # gh release download -R NVIDIA/cudaq-private cuquantum-25.03 -p '*cu12*.whl'
           # Fetch the CUDA-Q wheels
           # gh release download -R NVIDIA/cudaq-private staging-0.10.0 -p '*cu12*.whl'
+          if [[ -n "${{ inputs.cudaq_assets_tag }}" ]]; then
+            gh release download -R ${{ inputs.cudaq_repo }} ${{ inputs.cudaq_assets_tag }} -p 'wheelhouse-*.zip'
+            for f in wheelhouse-*.zip; do unzip $f; done
+            mv wheelhouse-*/*.whl .
+          fi
+
           # Fetch the CUDA-QX wheels
           gh run download -R ${{ inputs.wheels_repo }} ${{ inputs.wheels_run_id }} -p 'wheels-py*'
           mv */*.whl .
           ls
+        shell: bash
 
       - name: Build and push image
         id: docker_build


### PR DESCRIPTION
These workflow updates are needed to build the majority of the libraries on the public runners. This is needed to ensure that the `__version__` values return the right strings and right hashes.

The nv-qldpc-decoder version hash will still be from a private repo.

Note: this is a cherry-picked version of https://github.com/NVIDIA/cudaqx/commit/e179eef5169cfc66ca2c21f4625e6e5af232548e, which is on the releases/v0.3.0 branch now.