### PR TITLE
Update QEC interfaces to use spin_op_term

### DIFF
--- a/libs/qec/include/cudaq/qec/code.h
+++ b/libs/qec/include/cudaq/qec/code.h
@@ -1,5 +1,5 @@
 /****************************************************************-*- C++ -*-****
- * Copyright (c) 2024 NVIDIA Corporation & Affiliates.                         *
+ * Copyright (c) 2024 - 2025 NVIDIA Corporation & Affiliates.                  *
  * All rights reserved.                                                        *
  *                                                                             *
  * This source code and the accompanying materials are made available under    *
@@ -117,14 +117,14 @@ protected:
   std::unordered_map<operation, encoding> operation_encodings;
 
   /// @brief Stabilizer generators for the code
-  std::vector<cudaq::spin_op> m_stabilizers;
+  std::vector<cudaq::spin_op_term> m_stabilizers;
 
   /// @brief Pauli Logical operators
-  std::vector<cudaq::spin_op> m_pauli_observables;
+  std::vector<cudaq::spin_op_term> m_pauli_observables;
 
-  std::vector<cudaq::spin_op>
+  std::vector<cudaq::spin_op_term>
   fromPauliWords(const std::vector<std::string> &words) {
-    std::vector<cudaq::spin_op> ops;
+    std::vector<cudaq::spin_op_term> ops;
     for (auto &os : words)
       ops.emplace_back(cudaq::spin_op::from_word(os));
     sortStabilizerOps(ops);
@@ -158,7 +158,8 @@ public:
   /// @param options Optional code-specific configuration options
   /// @return Unique pointer to created code instance
   static std::unique_ptr<code>
-  get(const std::string &name, const std::vector<cudaq::spin_op> &stabilizers,
+  get(const std::string &name,
+      const std::vector<cudaq::spin_op_term> &stabilizers,
       const heterogeneous_map options = {});
 
   /// @brief Factory method to create a code instance
@@ -194,7 +195,7 @@ public:
 
   /// @brief Get the stabilizer generators
   /// @return Reference to stabilizers
-  const std::vector<cudaq::spin_op> &get_stabilizers() const {
+  const std::vector<cudaq::spin_op_term> &get_stabilizers() const {
     return m_stabilizers;
   }
 
@@ -229,7 +230,7 @@ std::unique_ptr<code> get_code(const std::string &name,
 /// @param stab stabilizers
 /// @return Unique pointer to the created code instance
 std::unique_ptr<code> get_code(const std::string &name,
-                               const std::vector<cudaq::spin_op> &stab,
+                               const std::vector<cudaq::spin_op_term> &stab,
                                const heterogeneous_map options = {});
 
 /// Get a list of available quantum error correcting codes

--- a/libs/qec/include/cudaq/qec/codes/surface_code.h
+++ b/libs/qec/include/cudaq/qec/codes/surface_code.h
@@ -1,5 +1,5 @@
 /****************************************************************-*- C++ -*-****
- * Copyright (c) 2024 NVIDIA Corporation & Affiliates.                         *
+ * Copyright (c) 2024 - 2025 NVIDIA Corporation & Affiliates.                  *
  * All rights reserved.                                                        *
  *                                                                             *
  * This source code and the accompanying materials are made available under    *
@@ -160,11 +160,11 @@ public:
   /// @brief Print the stabilizers in sparse pauli format
   void print_stabilizers() const;
 
-  /// @brief Get the stabilizers as a vector of cudaq::spin_ops
-  std::vector<cudaq::spin_op> get_spin_op_stabilizers() const;
+  /// @brief Get the stabilizers as a vector of cudaq::spin_op_terms
+  std::vector<cudaq::spin_op_term> get_spin_op_stabilizers() const;
 
-  /// @brief Get the observables as a vector of cudaq::spin_ops
-  std::vector<cudaq::spin_op> get_spin_op_observables() const;
+  /// @brief Get the observables as a vector of cudaq::spin_op_terms
+  std::vector<cudaq::spin_op_term> get_spin_op_observables() const;
 };
 
 /// \pure_device_kernel

--- a/libs/qec/include/cudaq/qec/stabilizer_utils.h
+++ b/libs/qec/include/cudaq/qec/stabilizer_utils.h
@@ -1,5 +1,5 @@
 /****************************************************************-*- C++ -*-****
- * Copyright (c) 2024 NVIDIA Corporation & Affiliates.                         *
+ * Copyright (c) 2024 - 2025 NVIDIA Corporation & Affiliates.                  *
  * All rights reserved.                                                        *
  *                                                                             *
  * This source code and the accompanying materials are made available under    *
@@ -16,12 +16,12 @@
 
 namespace cudaq::qec {
 enum class stabilizer_type { XZ, X, Z };
-void sortStabilizerOps(std::vector<cudaq::spin_op> &ops);
+void sortStabilizerOps(std::vector<cudaq::spin_op_term> &ops);
 
 /// Convert stabilizers to a parity check matrix
 /// @return Tensor representing the parity check matrix
 cudaqx::tensor<uint8_t>
-to_parity_matrix(const std::vector<cudaq::spin_op> &stabilizers,
+to_parity_matrix(const std::vector<cudaq::spin_op_term> &stabilizers,
                  stabilizer_type type = stabilizer_type::XZ);
 cudaqx::tensor<uint8_t>
 to_parity_matrix(const std::vector<std::string> &words,

--- a/libs/qec/lib/code.cpp
+++ b/libs/qec/lib/code.cpp
@@ -13,9 +13,10 @@ INSTANTIATE_REGISTRY(cudaq::qec::code, const cudaqx::heterogeneous_map &)
 
 namespace cudaq::qec {
 
-std::unique_ptr<code> code::get(const std::string &name,
-                                const std::vector<cudaq::spin_op> &_stabilizers,
-                                const heterogeneous_map options) {
+std::unique_ptr<code>
+code::get(const std::string &name,
+          const std::vector<cudaq::spin_op_term> &_stabilizers,
+          const heterogeneous_map options) {
   auto &registry = get_registry();
   auto iter = registry.find(name);
   if (iter == registry.end())
@@ -59,7 +60,7 @@ cudaqx::tensor<uint8_t> code::get_observables_z() const {
 }
 
 std::unique_ptr<code> get_code(const std::string &name,
-                               const std::vector<cudaq::spin_op> &stab,
+                               const std::vector<cudaq::spin_op_term> &stab,
                                const heterogeneous_map options) {
   return code::get(name, stab, options);
 }

--- a/libs/qec/lib/codes/repetition.cpp
+++ b/libs/qec/lib/codes/repetition.cpp
@@ -43,7 +43,7 @@ repetition::repetition(const heterogeneous_map &options) : code() {
   // Default Logical Observable is ZI...I
   // This class is only for Z basis experiments
   // so there is no X observable included.
-  cudaq::spin_op Lz = cudaq::spin::z(0) * identity;
+  cudaq::spin_op_term Lz = cudaq::spin::z(0) * identity;
 
   m_pauli_observables.push_back(Lz);
 

--- a/libs/qec/lib/codes/surface_code.cpp
+++ b/libs/qec/lib/codes/surface_code.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024 NVIDIA Corporation & Affiliates.                         *
+ * Copyright (c) 2024 - 2025 NVIDIA Corporation & Affiliates.                  *
  * All rights reserved.                                                        *
  *                                                                             *
  * This source code and the accompanying materials are made available under    *
@@ -309,8 +309,9 @@ void stabilizer_grid::print_stabilizers() const {
   std::cout << "\n";
 }
 
-std::vector<cudaq::spin_op> stabilizer_grid::get_spin_op_stabilizers() const {
-  std::vector<cudaq::spin_op> spin_op_stabs;
+std::vector<cudaq::spin_op_term>
+stabilizer_grid::get_spin_op_stabilizers() const {
+  std::vector<cudaq::spin_op_term> spin_op_stabs;
   for (size_t s_i = 0; s_i < x_stabilizers.size(); ++s_i) {
     std::string stab(data_coords.size(), 'I');
     for (auto elem : x_stabilizers[s_i]) {
@@ -328,8 +329,9 @@ std::vector<cudaq::spin_op> stabilizer_grid::get_spin_op_stabilizers() const {
   return spin_op_stabs;
 }
 
-std::vector<cudaq::spin_op> stabilizer_grid::get_spin_op_observables() const {
-  std::vector<cudaq::spin_op> spin_op_obs;
+std::vector<cudaq::spin_op_term>
+stabilizer_grid::get_spin_op_observables() const {
+  std::vector<cudaq::spin_op_term> spin_op_obs;
   // X obs runs along top row of data qubits
   std::string xobs(data_coords.size(), 'I');
   for (size_t i = 0; i < distance; ++i) {

--- a/libs/qec/lib/stabilizer_utils.cpp
+++ b/libs/qec/lib/stabilizer_utils.cpp
@@ -31,17 +31,18 @@ static bool spinOpComparatorStr(const std::string &astr,
   return zIdxA < zIdxB;
 }
 
-static bool spinOpComparator(const cudaq::spin_op &a, const cudaq::spin_op &b) {
-  auto astr = a.begin()->get_pauli_word();
-  auto bstr = b.begin()->get_pauli_word();
+static bool spinOpComparator(const cudaq::spin_op_term &a,
+                             const cudaq::spin_op_term &b) {
+  auto astr = a.get_pauli_word();
+  auto bstr = b.get_pauli_word();
   return spinOpComparatorStr(astr, bstr);
 }
 
-static bool isStabilizerSorted(const std::vector<cudaq::spin_op> &ops) {
+static bool isStabilizerSorted(const std::vector<cudaq::spin_op_term> &ops) {
   return std::is_sorted(ops.begin(), ops.end(), spinOpComparator);
 }
 
-void sortStabilizerOps(std::vector<cudaq::spin_op> &ops) {
+void sortStabilizerOps(std::vector<cudaq::spin_op_term> &ops) {
   std::sort(ops.begin(), ops.end(), spinOpComparator);
 }
 
@@ -49,14 +50,14 @@ void sortStabilizerOps(std::vector<cudaq::spin_op> &ops) {
 // H = [ H_Z | 0   ]
 //     [ 0   | H_X ]
 cudaqx::tensor<uint8_t>
-to_parity_matrix(const std::vector<cudaq::spin_op> &stabilizers,
+to_parity_matrix(const std::vector<cudaq::spin_op_term> &stabilizers,
                  stabilizer_type type) {
   if (stabilizers.empty())
     return cudaqx::tensor<uint8_t>();
 
   std::vector<std::string> stab_strings;
   for (auto &s : stabilizers)
-    stab_strings.emplace_back(s.begin()->get_pauli_word());
+    stab_strings.emplace_back(s.get_pauli_word());
   std::sort(stab_strings.begin(), stab_strings.end(), spinOpComparatorStr);
 
   auto numQubits = stab_strings[0].size();
@@ -141,7 +142,7 @@ to_parity_matrix(const std::vector<cudaq::spin_op> &stabilizers,
 cudaqx::tensor<uint8_t> to_parity_matrix(const std::vector<std::string> &words,
                                          stabilizer_type type) {
 
-  std::vector<cudaq::spin_op> ops;
+  std::vector<cudaq::spin_op_term> ops;
   for (auto &os : words)
     ops.emplace_back(cudaq::spin_op::from_word(os));
   sortStabilizerOps(ops);

--- a/libs/qec/python/bindings/py_code.cpp
+++ b/libs/qec/python/bindings/py_code.cpp
@@ -269,16 +269,16 @@ void bindCode(py::module &mod) {
           if (py::isinstance<py::str>(obj.cast<py::list>()[0])) {
             options.attr("pop")("stabilizers");
             auto words = obj.cast<std::vector<std::string>>();
-            std::vector<cudaq::spin_op> ops;
+            std::vector<cudaq::spin_op_term> ops;
             for (auto &os : words)
               ops.emplace_back(cudaq::spin_op::from_word(os));
             sortStabilizerOps(ops);
             return get_code(name, ops, hetMapFromKwargs(options));
           }
 
-          if (py::isinstance<cudaq::spin_op>(obj[0])) {
+          if (py::isinstance<cudaq::spin_op_term>(obj[0])) {
             options.attr("pop")("stabilizers");
-            return get_code(name, obj.cast<std::vector<cudaq::spin_op>>(),
+            return get_code(name, obj.cast<std::vector<cudaq::spin_op_term>>(),
                             hetMapFromKwargs(options));
           }
 

--- a/libs/qec/python/tests/test_code.py
+++ b/libs/qec/python/tests/test_code.py
@@ -44,7 +44,7 @@ def test_code_stabilizers():
     assert isinstance(stabilizers, list)
     assert len(stabilizers) == 6
     assert all(isinstance(stab, cudaq.Operator) for stab in stabilizers)
-    stabStrings = [term.get_pauli_word() for s in stabilizers for term in s]
+    stabStrings = [term.get_pauli_word() for term in stabilizers]
     expected = [
         "ZZZZIII", "XXXXIII", "IXXIXXI", "IIXXIXX", "IZZIZZI", "IIZZIZZ"
     ]

--- a/libs/qec/unittests/test_qec.cpp
+++ b/libs/qec/unittests/test_qec.cpp
@@ -18,12 +18,12 @@
 TEST(StabilizerTester, checkConstructFromSpinOps) {
   {
     // Constructor will always auto sort
-    std::vector<cudaq::spin_op> stab{cudaq::spin_op::from_word("ZZZZIII"),
-                                     cudaq::spin_op::from_word("XXXXIII"),
-                                     cudaq::spin_op::from_word("IXXIXXI"),
-                                     cudaq::spin_op::from_word("IIXXIXX"),
-                                     cudaq::spin_op::from_word("IZZIZZI"),
-                                     cudaq::spin_op::from_word("IIZZIZZ")};
+    std::vector<cudaq::spin_op_term> stab{cudaq::spin_op::from_word("ZZZZIII"),
+                                          cudaq::spin_op::from_word("XXXXIII"),
+                                          cudaq::spin_op::from_word("IXXIXXI"),
+                                          cudaq::spin_op::from_word("IIXXIXX"),
+                                          cudaq::spin_op::from_word("IZZIZZI"),
+                                          cudaq::spin_op::from_word("IIZZIZZ")};
     EXPECT_EQ(stab.size(), 6);
     auto parity = cudaq::qec::to_parity_matrix(stab);
     parity.dump();
@@ -259,7 +259,7 @@ TEST(QECCodeTester, checkSteane) {
     // From Stabilizers
     std::vector<std::string> words{"ZZZZIII", "XXXXIII", "IXXIXXI",
                                    "IIXXIXX", "IZZIZZI", "IIZZIZZ"};
-    std::vector<cudaq::spin_op> ops;
+    std::vector<cudaq::spin_op_term> ops;
     for (auto &os : words)
       ops.emplace_back(cudaq::spin_op::from_word(os));
     cudaq::qec::sortStabilizerOps(ops);
@@ -429,7 +429,7 @@ TEST(QECCodeTester, checkRepetition) {
 
     std::vector<std::string> actual_stabs;
     for (auto &s : stabilizers)
-      actual_stabs.push_back(s.begin()->get_pauli_word());
+      actual_stabs.push_back(s.get_pauli_word());
 
     std::vector<std::string> expected_strings = {
         "ZZIIIIIII", "IZZIIIIII", "IIZZIIIII", "IIIZZIIII",


### PR DESCRIPTION
This is a follow-up to https://github.com/NVIDIA/cudaqx/pull/134, bringing our QEC interfaces in line with the new CUDA-Q interfaces for spin op terms (and no longer using spin ops).