### PR TITLE
Add `opt_results` field to `decoder_result` 

### DIFF
--- a/docs/sphinx/examples/qec/cpp/circuit_level_noise.cpp
+++ b/docs/sphinx/examples/qec/cpp/circuit_level_noise.cpp
@@ -91,9 +91,9 @@ int main() {
       syndrome.dump();
 
       // Decode the syndrome
-      auto [converged, v_result] = decoder->decode(syndrome);
+      auto result = decoder->decode(syndrome);
       cudaqx::tensor<uint8_t> result_tensor;
-      cudaq::qec::convert_vec_soft_to_tensor_hard(v_result, result_tensor);
+      cudaq::qec::convert_vec_soft_to_tensor_hard(result.result, result_tensor);
       std::cout << "decode result:\n";
       result_tensor.dump();
 

--- a/docs/sphinx/examples/qec/cpp/code_capacity_noise.cpp
+++ b/docs/sphinx/examples/qec/cpp/code_capacity_noise.cpp
@@ -65,11 +65,11 @@ int main() {
     std::cout << "syndrome:\n";
     syndrome.dump();
 
-    auto [converged, v_result] = lut_decoder->decode(syndrome);
+    auto result = lut_decoder->decode(syndrome);
     cudaqx::tensor<uint8_t> result_tensor;
-    // v_result is a std::vector<float_t>, of soft information. We'll convert
-    // this to hard information and store as a tensor<uint8_t>.
-    cudaq::qec::convert_vec_soft_to_tensor_hard(v_result, result_tensor);
+    // result.result is a std::vector<float_t>, of soft information. We'll
+    // convert this to hard information and store as a tensor<uint8_t>.
+    cudaq::qec::convert_vec_soft_to_tensor_hard(result.result, result_tensor);
     std::cout << "decode result:\n";
     result_tensor.dump();
 

--- a/docs/sphinx/examples/qec/python/circuit_level_noise.py
+++ b/docs/sphinx/examples/qec/python/circuit_level_noise.py
@@ -66,8 +66,8 @@ for shot in range(0, nShots):
     print("shot:", shot)
     for syndrome in syndromes[shot]:
         print("syndrome:", syndrome)
-        # decode the syndrome
-        convergence, result = decoder.decode(syndrome)
+        # Decode the syndrome
+        convergence, result, opt = decoder.decode(syndrome)
         data_prediction = np.array(result, dtype=np.uint8)
 
         # see if the decoded result anti-commutes with the observables

--- a/docs/sphinx/examples/qec/python/code_capacity_noise.py
+++ b/docs/sphinx/examples/qec/python/code_capacity_noise.py
@@ -40,8 +40,8 @@ for i in range(nShots):
     syndrome = Hz @ data % 2
     print(f"syndrome: {syndrome}")
 
-    # Decode the syndrome to predict what happen to the data
-    convergence, result = decoder.decode(syndrome)
+    # Decode the syndrome to predict what happened to the data
+    convergence, result, opt = decoder.decode(syndrome)
     data_prediction = np.array(result, dtype=np.uint8)
     print(f"data_prediction: {data_prediction}")
 

--- a/docs/sphinx/examples/qec/python/pseudo_threshold.py
+++ b/docs/sphinx/examples/qec/python/pseudo_threshold.py
@@ -37,7 +37,8 @@ for p in PERates:
         # Calculate which syndromes are flagged.
         syndrome = Hz @ data % 2
 
-        convergence, result = decoder.decode(syndrome)
+        # Decode the syndrome
+        convergence, result, opt = decoder.decode(syndrome)
         data_prediction = np.array(result)
 
         predicted_observable = observable @ data_prediction % 2

--- a/docs/sphinx/examples/qec/python/repetition_code_fine_grain_noise.py
+++ b/docs/sphinx/examples/qec/python/repetition_code_fine_grain_noise.py
@@ -159,7 +159,7 @@ for shot, outcome in enumerate(result.get_sequential_data()):
     print("syndrome:", syndrome)
 
     # Decode the syndrome
-    convergence, result = decoder.decode(syndrome)
+    convergence, result, opt = decoder.decode(syndrome)
     data_prediction = np.array(result, dtype=np.uint8)
 
     # See if the decoded result anti-commutes with the observables

--- a/libs/core/include/cuda-qx/core/heterogeneous_map.h
+++ b/libs/core/include/cuda-qx/core/heterogeneous_map.h
@@ -39,6 +39,18 @@ private:
   }
 
 public:
+  // Type aliases for iterators
+  using iterator = std::unordered_map<std::string, std::any>::iterator;
+  using const_iterator = std::unordered_map<std::string, std::any>::const_iterator;
+
+  // Iterator methods
+  iterator begin() { return items.begin(); }
+  iterator end() { return items.end(); }
+  const_iterator begin() const { return items.begin(); }
+  const_iterator end() const { return items.end(); }
+  const_iterator cbegin() const { return items.cbegin(); }
+  const_iterator cend() const { return items.cend(); }
+
   /// @brief Default constructor
   heterogeneous_map() = default;
 

--- a/libs/core/include/cuda-qx/core/heterogeneous_map.h
+++ b/libs/core/include/cuda-qx/core/heterogeneous_map.h
@@ -41,7 +41,8 @@ private:
 public:
   // Type aliases for iterators
   using iterator = std::unordered_map<std::string, std::any>::iterator;
-  using const_iterator = std::unordered_map<std::string, std::any>::const_iterator;
+  using const_iterator =
+      std::unordered_map<std::string, std::any>::const_iterator;
 
   // Iterator methods
   iterator begin() { return items.begin(); }

--- a/libs/core/include/cuda-qx/core/kwargs_utils.h
+++ b/libs/core/include/cuda-qx/core/kwargs_utils.h
@@ -44,6 +44,9 @@ inline heterogeneous_map hetMapFromKwargs(const py::kwargs &kwargs) {
       result.insert(key, value.cast<double>());
     } else if (py::isinstance<py::str>(value)) {
       result.insert(key, value.cast<std::string>());
+    } else if (py::isinstance<py::dict>(value)) {
+      // Recursively convert nested dictionary
+      result.insert(key, hetMapFromKwargs(value.cast<py::dict>()));
     } else if (py::isinstance<py::array>(value)) {
       py::array np_array = value.cast<py::array>();
       py::buffer_info info = np_array.request();

--- a/libs/qec/include/cudaq/qec/decoder.h
+++ b/libs/qec/include/cudaq/qec/decoder.h
@@ -57,46 +57,6 @@ struct decoder_result {
   }
 };
 
-/// @brief Decoder results
-struct decoder_result_2 {
-  /// @brief Whether or not the decoder converged
-  bool converged = false;
-
-  /// @brief Vector of length `block_size` with soft probabilities of errors in
-  /// each index.
-  std::vector<float_t> result;
-
-  /// @brief Optional additional results from the decoder stored in a
-  /// heterogeneous map
-  std::optional<cudaqx::heterogeneous_map> optional_results;
-
-  /// @brief Check if optional results exist
-  bool has_optional_results() const { return optional_results.has_value(); }
-
-  /// @brief Get optional results if they exist, otherwise return empty map
-  cudaqx::heterogeneous_map get_optional_results() const {
-    return optional_results.value_or(cudaqx::heterogeneous_map());
-  }
-
-  // Manually define the equality operator
-  bool operator==(const decoder_result_2 &other) const {
-    // First compare the non-optional fields
-    if (std::tie(converged, result) !=
-        std::tie(other.converged, other.result)) {
-      return false;
-    }
-
-    // Handle optional_results comparison - just check if both have or don't
-    // have it
-    return optional_results.has_value() == other.optional_results.has_value();
-  }
-
-  // Manually define the inequality operator
-  bool operator!=(const decoder_result_2 &other) const {
-    return !(*this == other);
-  }
-};
-
 /// @brief Return type for asynchronous decoding results
 class async_decoder_result {
 public:

--- a/libs/qec/include/cudaq/qec/decoder.h
+++ b/libs/qec/include/cudaq/qec/decoder.h
@@ -23,9 +23,27 @@ using float_t = CUDAQX_QEC_FLOAT_TYPE;
 using float_t = double;
 #endif
 
+/// @brief Validates that all keys in a heterogeneous map are found in a list of
+/// acceptable types
+/// @param config The heterogeneous map to validate
+/// @param acceptable_types List of acceptable key types
+/// @return Vector of invalid keys (empty if all keys are valid)
+inline std::vector<std::string>
+validate_config_parameters(const cudaqx::heterogeneous_map &config,
+                           const std::vector<std::string> &acceptable_types) {
+  std::vector<std::string> invalid_types;
+  for (const auto &[key, _] : config) {
+    if (std::find(acceptable_types.begin(), acceptable_types.end(), key) ==
+        acceptable_types.end()) {
+      invalid_types.push_back(key);
+    }
+  }
+  return invalid_types;
+}
+
 /// @brief Decoder results
 struct decoder_result {
-  /// @brief Whether or not the decoder converged
+  /// @brief Whether or not the decoder converged.
   bool converged = false;
 
   /// @brief Vector of length `block_size` with soft probabilities of errors in
@@ -33,7 +51,10 @@ struct decoder_result {
   std::vector<float_t> result;
 
   /// @brief Optional additional results from the decoder stored in a
-  /// heterogeneous map
+  /// heterogeneous map. For equality comparison, this field is treated as a
+  /// boolean flag - two decoder_results are considered equal only if both have
+  /// empty opt_results (either std::nullopt or an empty map). If either result
+  /// has non-empty opt_results, they are considered not equal.
   std::optional<cudaqx::heterogeneous_map> opt_results;
 
   // Manually define the equality operator
@@ -43,8 +64,12 @@ struct decoder_result {
         std::tie(other.converged, other.result)) {
       return false;
     }
-    // If both do not have opt_results, then they are equal
-    if (!opt_results.has_value() && !other.opt_results.has_value()) {
+    // If both do not have opt_results or both have empty maps, then they are
+    // equal
+    bool this_empty = !opt_results.has_value() || opt_results->size() == 0;
+    bool other_empty =
+        !other.opt_results.has_value() || other.opt_results->size() == 0;
+    if (this_empty && other_empty) {
       return true;
     }
     // Otherwise, they are not equal

--- a/libs/qec/include/cudaq/qec/decoder.h
+++ b/libs/qec/include/cudaq/qec/decoder.h
@@ -12,8 +12,8 @@
 #include "cuda-qx/core/heterogeneous_map.h"
 #include "cuda-qx/core/tensor.h"
 #include <future>
-#include <vector>
 #include <optional>
+#include <vector>
 
 namespace cudaq::qec {
 
@@ -32,39 +32,23 @@ struct decoder_result {
   /// each index.
   std::vector<float_t> result;
 
-  /// @brief Optional additional results from the decoder stored in a heterogeneous map
-  std::optional<cudaqx::heterogeneous_map> optional_results;
-
-  /// @brief Check if optional results exist
-  bool has_optional_results() const { return optional_results.has_value(); }
-
-  /// @brief Get optional results if they exist, otherwise return empty map
-  cudaqx::heterogeneous_map get_optional_results() const {
-    return optional_results.value_or(cudaqx::heterogeneous_map());
-  }
-
-  // Tuple-like interface for structured binding
-  template<std::size_t I>
-  auto& get() {
-    if constexpr (I == 0) return converged;
-    if constexpr (I == 1) return result;
-  }
-
-  template<std::size_t I>
-  const auto& get() const {
-    if constexpr (I == 0) return converged;
-    if constexpr (I == 1) return result;
-  }
+  /// @brief Optional additional results from the decoder stored in a
+  /// heterogeneous map
+  std::optional<cudaqx::heterogeneous_map> opt_results;
 
   // Manually define the equality operator
   bool operator==(const decoder_result &other) const {
     // First compare the non-optional fields
-    if (std::tie(converged, result) != std::tie(other.converged, other.result)) {
+    if (std::tie(converged, result) !=
+        std::tie(other.converged, other.result)) {
       return false;
     }
-
-    // Handle optional_results comparison - just check if both have or don't have it
-    return optional_results.has_value() == other.optional_results.has_value();
+    // If both do not have opt_results, then they are equal
+    if (!opt_results.has_value() && !other.opt_results.has_value()) {
+      return true;
+    }
+    // Otherwise, they are not equal
+    return false;
   }
 
   // Manually define the inequality operator
@@ -72,7 +56,6 @@ struct decoder_result {
     return !(*this == other);
   }
 };
-
 
 /// @brief Decoder results
 struct decoder_result_2 {
@@ -83,7 +66,8 @@ struct decoder_result_2 {
   /// each index.
   std::vector<float_t> result;
 
-  /// @brief Optional additional results from the decoder stored in a heterogeneous map
+  /// @brief Optional additional results from the decoder stored in a
+  /// heterogeneous map
   std::optional<cudaqx::heterogeneous_map> optional_results;
 
   /// @brief Check if optional results exist
@@ -97,11 +81,13 @@ struct decoder_result_2 {
   // Manually define the equality operator
   bool operator==(const decoder_result_2 &other) const {
     // First compare the non-optional fields
-    if (std::tie(converged, result) != std::tie(other.converged, other.result)) {
+    if (std::tie(converged, result) !=
+        std::tie(other.converged, other.result)) {
       return false;
     }
 
-    // Handle optional_results comparison - just check if both have or don't have it
+    // Handle optional_results comparison - just check if both have or don't
+    // have it
     return optional_results.has_value() == other.optional_results.has_value();
   }
 
@@ -347,23 +333,3 @@ std::unique_ptr<decoder>
 get_decoder(const std::string &name, const cudaqx::tensor<uint8_t> &H,
             const cudaqx::heterogeneous_map options = {});
 } // namespace cudaq::qec
-
-// Add tuple_size specialization
-namespace std {
-  template<>
-  struct tuple_size<cudaq::qec::decoder_result> : std::integral_constant<std::size_t, 2> {};
-}
-
-// Add tuple_element specializations
-namespace std {
-  template<>
-  struct tuple_element<0, cudaq::qec::decoder_result> {
-    using type = bool;
-  };
-  template<>
-  struct tuple_element<1, cudaq::qec::decoder_result> {
-    using type = std::vector<cudaq::qec::float_t>;
-  };
-}
-
-

--- a/libs/qec/lib/decoders/single_error_lut.cpp
+++ b/libs/qec/lib/decoders/single_error_lut.cpp
@@ -20,11 +20,60 @@ class single_error_lut : public decoder {
 private:
   std::map<std::string, std::size_t> single_qubit_err_signatures;
 
+  // List of available result types for this decoder
+  const std::vector<std::string> available_result_types = {
+      "error_probability", // Probability of the detected error (bool)
+      "syndrome_weight",   // Number of non-zero syndrome measurements (bool)
+      "decoding_time",     // Time taken to perform the decoding (bool)
+      "num_repetitions"    // Number of repetitions to perform (int > 0)
+  };
+
+  bool has_opt_results;
+  bool error_probability;
+  bool syndrome_weight;
+  bool decoding_time;
+  int num_repetitions;
+
 public:
   single_error_lut(const cudaqx::tensor<uint8_t> &H,
                    const cudaqx::heterogeneous_map &params)
       : decoder(H) {
     // Decoder-specific constructor arguments can be placed in `params`.
+    // Check if opt_results was requested
+    if (params.contains("opt_results")) {
+      try {
+        auto requested_results =
+            params.get<cudaqx::heterogeneous_map>("opt_results");
+
+        // Validate requested result types
+        auto invalid_types = validate_config_parameters(requested_results,
+                                                        available_result_types);
+
+        if (!invalid_types.empty()) {
+          std::string error_msg = "Requested result types not available in "
+                                  "single_error_lut decoder: ";
+          for (size_t i = 0; i < invalid_types.size(); ++i) {
+            error_msg += invalid_types[i];
+            if (i < invalid_types.size() - 1) {
+              error_msg += ", ";
+            }
+          }
+          throw std::runtime_error(error_msg);
+        } else {
+          has_opt_results = true;
+          error_probability =
+              requested_results.get<bool>("error_probability", false);
+          syndrome_weight =
+              requested_results.get<bool>("syndrome_weight", false);
+          decoding_time = requested_results.get<bool>("decoding_time", false);
+          num_repetitions = requested_results.get<int>("num_repetitions", 0);
+        }
+      } catch (const std::runtime_error &e) {
+        throw; // Re-throw if it's our error
+      } catch (...) {
+        throw std::runtime_error("opt_results must be a heterogeneous_map");
+      }
+    }
 
     // Build a lookup table for an error on each possible qubit
 
@@ -45,7 +94,7 @@ public:
   }
 
   virtual decoder_result decode(const std::vector<float_t> &syndrome) {
-    // This is a simple decoder that simply results
+    // This is a simple decoder with trivial results
     decoder_result result{false, std::vector<float_t>(block_size, 0.0)};
 
     // Convert syndrome to a string
@@ -71,6 +120,34 @@ public:
       result.result[it->second] = 1.0;
     } else {
       // Leave result.converged set to false.
+    }
+
+    // Add opt_results if requested
+    /*
+     * Example opt_results map:
+     * {
+     *   "error_probability": true,    // Include error probability in results
+     *   "syndrome_weight": true,      // Include syndrome weight in results
+     *   "decoding_time": false,       // Don't include decoding time
+     *   "num_repetitions": 5          // Include num_repetitions=5 in results
+     * }
+     */
+    if (has_opt_results) {
+      result.opt_results =
+          cudaqx::heterogeneous_map(); // Initialize the optional map
+      // Values are for demonstration purposes only.
+      if (error_probability) {
+        result.opt_results->insert("error_probability", 1.0);
+      }
+      if (syndrome_weight) {
+        result.opt_results->insert("syndrome_weight", 1);
+      }
+      if (decoding_time) {
+        result.opt_results->insert("decoding_time", 0.0);
+      }
+      if (num_repetitions > 0) {
+        result.opt_results->insert("num_repetitions", num_repetitions);
+      }
     }
 
     return result;

--- a/libs/qec/lib/decoders/single_error_lut.cpp
+++ b/libs/qec/lib/decoders/single_error_lut.cpp
@@ -28,11 +28,11 @@ private:
       "num_repetitions"    // Number of repetitions to perform (int > 0)
   };
 
-  bool has_opt_results;
-  bool error_probability;
-  bool syndrome_weight;
-  bool decoding_time;
-  int num_repetitions;
+  bool has_opt_results = false;
+  bool error_probability = false;
+  bool syndrome_weight = false;
+  bool decoding_time = false;
+  int num_repetitions = 0;
 
 public:
   single_error_lut(const cudaqx::tensor<uint8_t> &H,

--- a/libs/qec/lib/decoders/single_error_lut.cpp
+++ b/libs/qec/lib/decoders/single_error_lut.cpp
@@ -62,11 +62,11 @@ public:
         } else {
           has_opt_results = true;
           error_probability =
-              requested_results.get<bool>("error_probability", false);
+              requested_results.get<bool>("error_probability", error_probability);
           syndrome_weight =
-              requested_results.get<bool>("syndrome_weight", false);
-          decoding_time = requested_results.get<bool>("decoding_time", false);
-          num_repetitions = requested_results.get<int>("num_repetitions", 0);
+              requested_results.get<bool>("syndrome_weight", syndrome_weight);
+          decoding_time = requested_results.get<bool>("decoding_time", decoding_time);
+          num_repetitions = requested_results.get<int>("num_repetitions", num_repetitions);
         }
       } catch (const std::runtime_error &e) {
         throw; // Re-throw if it's our error

--- a/libs/qec/lib/decoders/single_error_lut.cpp
+++ b/libs/qec/lib/decoders/single_error_lut.cpp
@@ -61,12 +61,14 @@ public:
           throw std::runtime_error(error_msg);
         } else {
           has_opt_results = true;
-          error_probability =
-              requested_results.get<bool>("error_probability", error_probability);
+          error_probability = requested_results.get<bool>("error_probability",
+                                                          error_probability);
           syndrome_weight =
               requested_results.get<bool>("syndrome_weight", syndrome_weight);
-          decoding_time = requested_results.get<bool>("decoding_time", decoding_time);
-          num_repetitions = requested_results.get<int>("num_repetitions", num_repetitions);
+          decoding_time =
+              requested_results.get<bool>("decoding_time", decoding_time);
+          num_repetitions =
+              requested_results.get<int>("num_repetitions", num_repetitions);
         }
       } catch (const std::runtime_error &e) {
         throw; // Re-throw if it's our error

--- a/libs/qec/python/bindings/py_code.cpp
+++ b/libs/qec/python/bindings/py_code.cpp
@@ -76,13 +76,10 @@ public:
           "{...}. Please provide the CUDA-Q kernels for the operation "
           "encodings.");
 
-    // Get the stabilizers. First convert to spin_op_term's and then convert to
-    // spin_op's.
-    auto stab_terms = registeredCode.attr("stabilizers")
-                          .cast<std::vector<cudaq::spin_op_term>>();
-    m_stabilizers.reserve(stab_terms.size());
-    for (auto &term : stab_terms)
-      m_stabilizers.emplace_back(std::move(term));
+    // Get the stabilizers. First convert to spin_op's.
+    auto stab_terms =
+        registeredCode.attr("stabilizers").cast<std::vector<cudaq::spin_op>>();
+    m_stabilizers = std::move(stab_terms);
 
     // Get the CUDA-Q kernels for the operation encodings
     auto opsDict = registeredCode.attr("operation_encodings").cast<py::dict>();

--- a/libs/qec/python/bindings/py_code.cpp
+++ b/libs/qec/python/bindings/py_code.cpp
@@ -76,10 +76,13 @@ public:
           "{...}. Please provide the CUDA-Q kernels for the operation "
           "encodings.");
 
-    // Get the stabilizers. First convert to spin_op's.
-    auto stab_terms =
-        registeredCode.attr("stabilizers").cast<std::vector<cudaq::spin_op>>();
-    m_stabilizers = std::move(stab_terms);
+    // Get the stabilizers. First convert to spin_op_term's and then convert to
+    // spin_op's.
+    auto stab_terms = registeredCode.attr("stabilizers")
+                          .cast<std::vector<cudaq::spin_op_term>>();
+    m_stabilizers.reserve(stab_terms.size());
+    for (auto &term : stab_terms)
+      m_stabilizers.emplace_back(std::move(term));
 
     // Get the CUDA-Q kernels for the operation encodings
     auto opsDict = registeredCode.attr("operation_encodings").cast<py::dict>();

--- a/libs/qec/python/bindings/py_decoder.cpp
+++ b/libs/qec/python/bindings/py_decoder.cpp
@@ -106,19 +106,12 @@ void bindDecoder(py::module &mod) {
         the original quantum state. The format depends on the specific decoder
         implementation.
     )pbdoc")
-      .def("has_optional_results", &decoder_result::has_optional_results, R"pbdoc(
-        Check if optional results exist.
+      .def_readwrite("opt_results", &decoder_result::opt_results, R"pbdoc(
+        Optional additional results from the decoder stored in a heterogeneous map.
         
-        Returns True if the decoder has additional optional results, False otherwise.
+        This field may be empty if no additional results are available.
     )pbdoc")
-      .def("get_optional_results", &decoder_result::get_optional_results, R"pbdoc(
-        Get the optional results if they exist.
-        
-        Returns a heterogeneous map containing the optional results, or an empty map
-        if no optional results exist.
-    )pbdoc")
-      // Add tuple interface
-      .def("__len__", [](const decoder_result &) { return 2; })  // Only expose converged and result
+      .def("__len__", [](const decoder_result &) { return 3; })
       .def("__getitem__",
            [](const decoder_result &r, size_t i) {
              switch (i) {
@@ -126,13 +119,15 @@ void bindDecoder(py::module &mod) {
                return py::cast(r.converged);
              case 1:
                return py::cast(r.result);
+             case 2:
+               return py::cast(r.opt_results);
              default:
                throw py::index_error();
              }
            })
       // Enable iteration protocol
       .def("__iter__", [](const decoder_result &r) -> py::object {
-        return py::iter(py::make_tuple(r.converged, r.result));
+        return py::iter(py::make_tuple(r.converged, r.result, r.opt_results));
       });
 
   py::class_<async_decoder_result>(qecmod, "AsyncDecoderResult",

--- a/libs/qec/python/bindings/py_decoder.cpp
+++ b/libs/qec/python/bindings/py_decoder.cpp
@@ -106,8 +106,19 @@ void bindDecoder(py::module &mod) {
         the original quantum state. The format depends on the specific decoder
         implementation.
     )pbdoc")
+      .def("has_optional_results", &decoder_result::has_optional_results, R"pbdoc(
+        Check if optional results exist.
+        
+        Returns True if the decoder has additional optional results, False otherwise.
+    )pbdoc")
+      .def("get_optional_results", &decoder_result::get_optional_results, R"pbdoc(
+        Get the optional results if they exist.
+        
+        Returns a heterogeneous map containing the optional results, or an empty map
+        if no optional results exist.
+    )pbdoc")
       // Add tuple interface
-      .def("__len__", [](const decoder_result &) { return 2; })
+      .def("__len__", [](const decoder_result &) { return 2; })  // Only expose converged and result
       .def("__getitem__",
            [](const decoder_result &r, size_t i) {
              switch (i) {

--- a/libs/qec/python/cudaq_qec/plugins/decoders/example.py
+++ b/libs/qec/python/cudaq_qec/plugins/decoders/example.py
@@ -22,4 +22,5 @@ class ExampleDecoder:
         res = qec.DecoderResult()
         res.converged = True
         res.result = np.random.random(len(syndrome)).tolist()
+        res.opt_results = None
         return res

--- a/libs/qec/python/tests/test_decoder.py
+++ b/libs/qec/python/tests/test_decoder.py
@@ -143,7 +143,7 @@ def test_decoder_different_matrix_sizes(matrix_shape, syndrome_size):
     syndrome = np.random.random(syndrome_size).tolist()
 
     decoder = qec.get_decoder('example_byod', H)
-    convergence, result = decoder.decode(syndrome)
+    convergence, result, opt = decoder.decode(syndrome)
 
     assert len(result) == syndrome_size
     assert convergence is True
@@ -171,10 +171,10 @@ def test_decoder_reproducibility():
     decoder = qec.get_decoder('example_byod', H)
 
     np.random.seed(42)
-    convergence1, result1 = decoder.decode(create_test_syndrome())
+    convergence1, result1, opt1 = decoder.decode(create_test_syndrome())
 
     np.random.seed(42)
-    convergence2, result2 = decoder.decode(create_test_syndrome())
+    convergence2, result2, opt2 = decoder.decode(create_test_syndrome())
 
     assert result1 == result2
     assert convergence1 == convergence2

--- a/libs/qec/python/tests/test_decoder.py
+++ b/libs/qec/python/tests/test_decoder.py
@@ -204,5 +204,34 @@ def test_version():
     assert "CUDA-Q QEC Base Decoder" in decoder.get_version()
 
 
+def test_single_error_lut_opt_results():
+    # Test with invalid opt_results
+    invalid_args = {"opt_results": {"invalid_type": True}}
+    with pytest.raises(RuntimeError) as e:
+        decoder = qec.get_decoder("single_error_lut", H, **invalid_args)
+        decoder.decode(create_test_syndrome())
+    assert "Requested result types not available" in str(e.value)
+
+    # Test with valid opt_results
+    valid_args = {
+        "opt_results": {
+            "error_probability": True,
+            "syndrome_weight": True,
+            "decoding_time": False,
+            "num_repetitions": 5
+        }
+    }
+    decoder = qec.get_decoder("single_error_lut", H, **valid_args)
+    result = decoder.decode(create_test_syndrome())
+
+    # Verify opt_results
+    assert result.opt_results is not None
+    assert "error_probability" in result.opt_results
+    assert "syndrome_weight" in result.opt_results
+    assert "decoding_time" not in result.opt_results  # Was set to False
+    assert "num_repetitions" in result.opt_results
+    assert result.opt_results["num_repetitions"] == 5
+
+
 if __name__ == "__main__":
     pytest.main()

--- a/libs/qec/python/tests/test_decoder.py
+++ b/libs/qec/python/tests/test_decoder.py
@@ -67,11 +67,22 @@ def test_decoder_result_structure():
     decoder = qec.get_decoder('example_byod', H)
     result = decoder.decode(create_test_syndrome())
 
+    # Test basic structure
     assert hasattr(result, 'converged')
     assert hasattr(result, 'result')
+    assert hasattr(result, 'opt_results')
     assert isinstance(result.converged, bool)
     assert isinstance(result.result, list)
     assert len(result.result) == 10
+
+    # Test opt_results functionality
+    assert result.opt_results is None  # Default should be None
+
+    # Test that opt_results is preserved in async decode
+    async_result = decoder.decode_async(create_test_syndrome())
+    result = async_result.get()
+    assert hasattr(result, 'opt_results')
+    assert result.opt_results is None
 
 
 def test_decoder_plugin_initialization():

--- a/libs/qec/unittests/backend-specific/stim/test_qec_stim.cpp
+++ b/libs/qec/unittests/backend-specific/stim/test_qec_stim.cpp
@@ -437,7 +437,7 @@ TEST(QECCodeTester, checkNoisySampleMemoryCircuitAndDecodeStim) {
       syndrome.borrow(syndromes.data() + i * stride);
       printf("syndrome:\n");
       syndrome.dump();
-      auto [converged, v_result] = decoder->decode(syndrome);
+      auto [converged, v_result, opt] = decoder->decode(syndrome);
       cudaqx::tensor<uint8_t> result_tensor;
       cudaq::qec::convert_vec_soft_to_tensor_hard(v_result, result_tensor);
       printf("decode result:\n");
@@ -519,7 +519,7 @@ TEST(QECCodeTester, checkNoisySampleMemoryCircuitAndDecodeStim) {
         syndrome.borrow(syndromes.data() + stride * count);
         printf("syndrome:\n");
         syndrome.dump();
-        auto [converged, v_result] = decoder->decode(syndrome);
+        auto [converged, v_result, opt] = decoder->decode(syndrome);
         cudaqx::tensor<uint8_t> result_tensor;
         cudaq::qec::convert_vec_soft_to_tensor_hard(v_result, result_tensor);
 

--- a/libs/qec/unittests/test_decoders.cpp
+++ b/libs/qec/unittests/test_decoders.cpp
@@ -205,3 +205,38 @@ TEST(AsyncDecoderResultTest, MoveAssignmentTransfersFuture) {
   EXPECT_TRUE(second.fut.valid());
   EXPECT_FALSE(first.fut.valid());
 }
+
+TEST(DecoderResultTest, DefaultConstructor) {
+  cudaq::qec::decoder_result result;
+  EXPECT_FALSE(result.converged);
+  EXPECT_TRUE(result.result.empty());
+  EXPECT_FALSE(result.opt_results.has_value());
+}
+
+TEST(DecoderResultTest, OptResultsAssignment) {
+  cudaq::qec::decoder_result result;
+  cudaqx::heterogeneous_map opt_map;
+  opt_map.insert("test_key", 42);
+  result.opt_results = opt_map;
+
+  EXPECT_TRUE(result.opt_results.has_value());
+  EXPECT_EQ(result.opt_results->get<int>("test_key"), 42);
+}
+
+TEST(DecoderResultTest, EqualityOperator) {
+  cudaq::qec::decoder_result result1;
+  cudaq::qec::decoder_result result2;
+
+  // Test equality with no opt_results
+  EXPECT_TRUE(result1 == result2);
+
+  // Test inequality when one has opt_results
+  cudaqx::heterogeneous_map opt_map;
+  opt_map.insert("test_key", 42);
+  result1.opt_results = opt_map;
+  EXPECT_FALSE(result1 == result2);
+
+  // Test inequality when both have opt_results (even if same)
+  result2.opt_results = opt_map;
+  EXPECT_FALSE(result1 == result2);
+}


### PR DESCRIPTION
Hey all, 
I’d like to get your thoughts on a proposed change to the `decoder_result` interface. Currently, it holds two values: `converged` and `result`. We’re considering adding a third item — a heterogeneous map — to allow the decoder to return additional outputs such as BP history and BP iterations.

There are two options:

Option 1: Add the heterogeneous map and specialize `tuple_size`. This preserves backward compatibility and avoids making the change breaking.

Option 2: Add the heterogeneous map without specializing `tuple_size`. This introduces a breaking change, as structured bindings would now expect three elements.

Let me know your thoughts — I'm also open to other ideas or suggestions.

**Update:**
The decision was to adopt option 2 and expose all three fields to the python side. 
