### PR TITLE
Improve Python binding speed for `DecoderResult`

### DIFF
--- a/libs/qec/python/bindings/py_decoder.cpp
+++ b/libs/qec/python/bindings/py_decoder.cpp
@@ -99,7 +99,13 @@ void bindDecoder(py::module &mod) {
         True if the decoder successfully found a valid correction chain,
         False if the decoder failed to converge or exceeded iteration limits.
     )pbdoc")
-      .def_readwrite("result", &decoder_result::result, R"pbdoc(
+      // Make this read-only and zero-copy.
+      .def_property_readonly(
+          "result",
+          [](const decoder_result &r) {
+            return py::array_t<float_t>(r.result.size(), r.result.data());
+          },
+          R"pbdoc(
         The decoded correction chain or recovery operation.
         
         Contains the sequence of corrections that should be applied to recover

--- a/libs/qec/python/bindings/py_decoder.cpp
+++ b/libs/qec/python/bindings/py_decoder.cpp
@@ -99,11 +99,15 @@ void bindDecoder(py::module &mod) {
         True if the decoder successfully found a valid correction chain,
         False if the decoder failed to converge or exceeded iteration limits.
     )pbdoc")
-      // Make this read-only and zero-copy.
-      .def_property_readonly(
+      // Make this zero-copy on read.
+      .def_property(
           "result",
           [](const decoder_result &r) {
             return py::array_t<float_t>(r.result.size(), r.result.data());
+          },
+          [](decoder_result &r, const py::array_t<float_t> &value) {
+            r.result =
+                std::vector<float_t>(value.data(), value.data() + value.size());
           },
           R"pbdoc(
         The decoded correction chain or recovery operation.

--- a/libs/qec/python/tests/test_decoder.py
+++ b/libs/qec/python/tests/test_decoder.py
@@ -46,7 +46,7 @@ def test_decoder_api():
         assert hasattr(r, 'converged')
         assert hasattr(r, 'result')
         assert isinstance(r.converged, bool)
-        assert isinstance(r.result, list)
+        assert isinstance(r.result, np.ndarray)
         assert len(r.result) == 10
 
     # Test decode_async
@@ -59,7 +59,7 @@ def test_decoder_api():
     assert hasattr(result, 'converged')
     assert hasattr(result, 'result')
     assert isinstance(result.converged, bool)
-    assert isinstance(result.result, list)
+    assert isinstance(result.result, np.ndarray)
     assert len(result.result) == 10
 
 
@@ -72,7 +72,7 @@ def test_decoder_result_structure():
     assert hasattr(result, 'result')
     assert hasattr(result, 'opt_results')
     assert isinstance(result.converged, bool)
-    assert isinstance(result.result, list)
+    assert isinstance(result.result, np.ndarray)
     assert len(result.result) == 10
 
     # Test opt_results functionality
@@ -133,7 +133,7 @@ def test_decoder_plugin_result_structure():
     assert hasattr(result, 'converged')
     assert hasattr(result, 'result')
     assert isinstance(result.converged, bool)
-    assert isinstance(result.result, list)
+    assert isinstance(result.result, np.ndarray)
 
 
 def test_decoder_result_values():


### PR DESCRIPTION
This change makes the `DecoderResult.result` field a lightweight wrapper around the C++ vector rather than converting it to and from a Python list on every access. ~~It also makes it read-only.~~ This change allows us to improve our Python decoding times. There is probably still room for additional improvement, but those might require more decoder interface changes (to allow for fewer copies). This one change is non-invasive and (relatively) high impact.

I made a local test to verify that these changes indeed speed things up. In that test, I commented out the true decode call in https://github.com/NVIDIA/cudaqx/blob/df6b3a06fa49e2dd6ed25ea965514e7d58faec2a/libs/qec/python/bindings/py_decoder.cpp#L152 and I replaced it with a dummy call just to stress test the Python bindings without measuring any true algorithmic decoder times.
```cpp
return decoder_result{true, std::vector<float_t>(decoder.get_block_size(), 0.0), std::nullopt};
```

Then I ran a modified version of `docs/sphinx/examples/qec/python/nv-qldpc-decoder.py` to measure the (fake) "decode" time for 10,000 shots of [[144,12,12]] data (approx 8700 error mechanisms).

### Before
```bash
$ python3 ... | grep Average
Average decoding time for 10000 shots was 0.6336370229721069 ms per shot
$ python3 ... | grep Average
Average decoding time for 10000 shots was 0.6271018743515014 ms per shot
$ python3 ... | grep Average
Average decoding time for 10000 shots was 0.6427229166030883 ms per shot
```
### After
```bash
$ python3 ... | grep Average
Average decoding time for 10000 shots was 0.209746789932251 ms per shot
$ python3 ... | grep Average
Average decoding time for 10000 shots was 0.18778672218322753 ms per shot
$ python3 ... | grep Average
Average decoding time for 10000 shots was 0.2099606513977051 ms per shot
```