### PR TITLE
Update examples to show how to use decoder_result API

### DIFF
--- a/docs/sphinx/examples/qec/python/circuit_level_noise.py
+++ b/docs/sphinx/examples/qec/python/circuit_level_noise.py
@@ -67,7 +67,9 @@ for shot in range(0, nShots):
     for syndrome in syndromes[shot]:
         print("syndrome:", syndrome)
         # Decode the syndrome
-        convergence, result, opt = decoder.decode(syndrome)
+        results = decoder.decode(syndrome)
+        convergence = results.converged
+        result = results.result
         data_prediction = np.array(result, dtype=np.uint8)
 
         # see if the decoded result anti-commutes with the observables

--- a/docs/sphinx/examples/qec/python/code_capacity_noise.py
+++ b/docs/sphinx/examples/qec/python/code_capacity_noise.py
@@ -41,7 +41,9 @@ for i in range(nShots):
     print(f"syndrome: {syndrome}")
 
     # Decode the syndrome to predict what happened to the data
-    convergence, result, opt = decoder.decode(syndrome)
+    results = decoder.decode(syndrome)
+    convergence = results.converged
+    result = results.result
     data_prediction = np.array(result, dtype=np.uint8)
     print(f"data_prediction: {data_prediction}")
 

--- a/docs/sphinx/examples/qec/python/nv-qldpc-decoder.py
+++ b/docs/sphinx/examples/qec/python/nv-qldpc-decoder.py
@@ -167,7 +167,9 @@ def run_decoder(filename, num_shots, run_as_batched):
             obs_truth = j["trials"][i]["obs_truth"]
 
             t0 = time.time()
-            bp_converged, dec_result = nv_dec_gpu_and_cpu.decode(syndrome)
+            results = nv_dec_gpu_and_cpu.decode(syndrome)
+            bp_converged = results.converged
+            dec_result = results.result
             t1 = time.time()
             trial_diff = t1 - t0
             decoding_time += trial_diff

--- a/docs/sphinx/examples/qec/python/pseudo_threshold.py
+++ b/docs/sphinx/examples/qec/python/pseudo_threshold.py
@@ -38,7 +38,9 @@ for p in PERates:
         syndrome = Hz @ data % 2
 
         # Decode the syndrome
-        convergence, result, opt = decoder.decode(syndrome)
+        results = decoder.decode(syndrome)
+        convergence = results.converged
+        result = results.result
         data_prediction = np.array(result)
 
         predicted_observable = observable @ data_prediction % 2

--- a/docs/sphinx/examples/qec/python/repetition_code_fine_grain_noise.py
+++ b/docs/sphinx/examples/qec/python/repetition_code_fine_grain_noise.py
@@ -159,7 +159,9 @@ for shot, outcome in enumerate(result.get_sequential_data()):
     print("syndrome:", syndrome)
 
     # Decode the syndrome
-    convergence, result, opt = decoder.decode(syndrome)
+    results = decoder.decode(syndrome)
+    convergence = results.converged
+    result = results.result
     data_prediction = np.array(result, dtype=np.uint8)
 
     # See if the decoded result anti-commutes with the observables


### PR DESCRIPTION
This PR addresses concerns mentioned in #175. Examples showing direct unpacking of `decoder_result` are removed.