### PR TITLE
Add move constructor to `heterogeneous_map`

### DIFF
--- a/libs/core/include/cuda-qx/core/heterogeneous_map.h
+++ b/libs/core/include/cuda-qx/core/heterogeneous_map.h
@@ -55,15 +55,6 @@ public:
   /// @brief Default constructor
   heterogeneous_map() = default;
 
-  /// @brief Copy constructor
-  /// @param _other The map to copy from
-  heterogeneous_map(const heterogeneous_map &_other) { *this = _other; }
-
-  /// @brief Move constructor
-  /// @param _other The map to move from
-  heterogeneous_map(heterogeneous_map &&_other) noexcept
-      : items(std::move(_other.items)) {}
-
   /// @brief Constructor from initializer list
   /// @param list The initializer list of key-value pairs
   heterogeneous_map(
@@ -74,27 +65,6 @@ public:
 
   /// @brief Clear the map
   void clear() { items.clear(); }
-
-  /// @brief Assignment operator
-  /// @param _other The map to assign from
-  /// @return Reference to this map
-  heterogeneous_map &operator=(const heterogeneous_map &_other) {
-    if (this != &_other) {
-      clear();
-      items = _other.items;
-    }
-    return *this;
-  }
-
-  /// @brief Move assignment operator
-  /// @param _other The map to move from
-  /// @return Reference to this map
-  heterogeneous_map &operator=(heterogeneous_map &&_other) {
-    if (this != &_other) {
-      items = std::move(_other.items);
-    }
-    return *this;
-  }
 
   /// @brief Insert a key-value pair into the map
   /// @tparam T The type of the value

--- a/libs/core/include/cuda-qx/core/heterogeneous_map.h
+++ b/libs/core/include/cuda-qx/core/heterogeneous_map.h
@@ -59,6 +59,11 @@ public:
   /// @param _other The map to copy from
   heterogeneous_map(const heterogeneous_map &_other) { *this = _other; }
 
+  /// @brief Move constructor
+  /// @param _other The map to move from
+  heterogeneous_map(heterogeneous_map &&_other) noexcept
+      : items(std::move(_other.items)) {}
+
   /// @brief Constructor from initializer list
   /// @param list The initializer list of key-value pairs
   heterogeneous_map(
@@ -77,6 +82,16 @@ public:
     if (this != &_other) {
       clear();
       items = _other.items;
+    }
+    return *this;
+  }
+
+  /// @brief Move assignment operator
+  /// @param _other The map to move from
+  /// @return Reference to this map
+  heterogeneous_map &operator=(heterogeneous_map &&_other) {
+    if (this != &_other) {
+      items = std::move(_other.items);
     }
     return *this;
   }

--- a/libs/core/unittests/test_core.cpp
+++ b/libs/core/unittests/test_core.cpp
@@ -866,6 +866,55 @@ TEST(HeterogeneousMapTest, InitializerListConstructor) {
   EXPECT_DOUBLE_EQ(map.get<double>("double_key"), 3.14);
 }
 
+TEST(HeterogeneousMapTest, MoveConstructor) {
+  cudaqx::heterogeneous_map original_map;
+  original_map.insert("int_key", 42);
+  original_map.insert("string_key", std::string("hello"));
+  original_map.insert("double_key", 3.14);
+
+  EXPECT_EQ(original_map.size(), 3);
+
+  // Move construct new map
+  cudaqx::heterogeneous_map moved_map(std::move(original_map));
+
+  // Verify the moved map has the data
+  EXPECT_EQ(moved_map.size(), 3);
+  EXPECT_EQ(moved_map.get<int>("int_key"), 42);
+  EXPECT_EQ(moved_map.get<std::string>("string_key"), "hello");
+  EXPECT_DOUBLE_EQ(moved_map.get<double>("double_key"), 3.14);
+
+  // Original map should be empty after move
+  EXPECT_EQ(original_map.size(), 0);
+}
+
+TEST(HeterogeneousMapTest, MoveAssignmentOperator) {
+  cudaqx::heterogeneous_map source_map;
+  source_map.insert("int_key", 42);
+  source_map.insert("string_key", std::string("hello"));
+  source_map.insert("double_key", 3.14);
+
+  cudaqx::heterogeneous_map target_map;
+  target_map.insert("old_key", std::string("old_value"));
+
+  EXPECT_EQ(source_map.size(), 3);
+  EXPECT_EQ(target_map.size(), 1);
+
+  // Move assign
+  target_map = std::move(source_map);
+
+  // Verify the target map has the moved data
+  EXPECT_EQ(target_map.size(), 3);
+  EXPECT_EQ(target_map.get<int>("int_key"), 42);
+  EXPECT_EQ(target_map.get<std::string>("string_key"), "hello");
+  EXPECT_DOUBLE_EQ(target_map.get<double>("double_key"), 3.14);
+
+  // Old data should be gone
+  EXPECT_FALSE(target_map.contains("old_key"));
+
+  // Source map should be empty after move
+  EXPECT_EQ(source_map.size(), 0);
+}
+
 TEST(GraphTester, AddEdge) {
   cudaqx::graph g;
   g.add_edge(1, 2, 1.5);


### PR DESCRIPTION
This PR adds a move constructor and move assignment operator to `heterogeneous_map`, enabling the compiler to move rather than copy the map when it’s returned from a function. This addition should improve performance, particularly when returning large maps such as BP history via `decoder_result`.