### PR TITLE
Remove unnecessary `MeasureCounts.h` include

### DIFF
--- a/libs/solvers/include/cudaq/solvers/qaoa.h
+++ b/libs/solvers/include/cudaq/solvers/qaoa.h
@@ -7,7 +7,7 @@
  ******************************************************************************/
 #pragma once
 
-#include "common/MeasureCounts.h"
+#include "common/SampleResult.h"
 #include "cudaq/spin_op.h"
 
 #include "cuda-qx/core/graph.h"

--- a/libs/solvers/include/cudaq/solvers/qaoa.h
+++ b/libs/solvers/include/cudaq/solvers/qaoa.h
@@ -7,7 +7,6 @@
  ******************************************************************************/
 #pragma once
 
-#include "common/SampleResult.h"
 #include "cudaq/spin_op.h"
 
 #include "cuda-qx/core/graph.h"


### PR DESCRIPTION
While testing a refactor for https://github.com/NVIDIA/cuda-quantum/pull/3043, I realized that the include is not necessary.

Hence, this PR removes that explicit include. As a result, https://github.com/NVIDIA/cuda-quantum/pull/3043 depends on this being merged :)    