### PR TITLE
Follow-up to #208 - disable some tests for Python 3.10

### DIFF
--- a/.github/workflows/all_libs.yaml
+++ b/.github/workflows/all_libs.yaml
@@ -80,7 +80,7 @@ jobs:
       # ========================================================================
  
       - name: Install python requirements
-        run: pip install numpy pytest cupy-cuda12x cuquantum-python-cu12 quimb opt_einsum torch
+        run: pip install numpy pytest cupy-cuda12x cuquantum-cu12
 
       - name: Run Python tests
         run: cmake --build ${{ steps.build.outputs.build-dir }} --target run_python_tests

--- a/.github/workflows/all_libs.yaml
+++ b/.github/workflows/all_libs.yaml
@@ -34,16 +34,6 @@ jobs:
         run: |
           echo "pr_number=${{ fromJSON(steps.get-pr-info.outputs.pr-info).number }}" >> $GITHUB_OUTPUT
 
-      - name: Update to Python 3.11
-        run: |
-          # Install Python 3.11
-          apt update && apt install -y --no-install-recommends python3.11 python3.11-dev python3.11-venv
-          # Set Python 3.11 as the default Python version
-          update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.11 1
-          update-alternatives --install /usr/bin/python3-config python3-config /usr/bin/python3.11-config 1
-          # Migrate all Python 3.10 packages to Python 3.11
-          python3.10 -m pip freeze | python3.11 -m pip install -r /dev/stdin
-
       # ========================================================================
       # CUDA Quantum build
       # ========================================================================
@@ -90,7 +80,7 @@ jobs:
       # ========================================================================
  
       - name: Install python requirements
-        run: pip install numpy pytest cupy-cuda12x cuquantum-python-cu12 quimb opt_einsum torch
+        run: pip install numpy pytest cupy-cuda12x cuquantum-cu12
 
       - name: Run Python tests
         run: cmake --build ${{ steps.build.outputs.build-dir }} --target run_python_tests

--- a/.github/workflows/all_libs.yaml
+++ b/.github/workflows/all_libs.yaml
@@ -34,6 +34,16 @@ jobs:
         run: |
           echo "pr_number=${{ fromJSON(steps.get-pr-info.outputs.pr-info).number }}" >> $GITHUB_OUTPUT
 
+      - name: Update to Python 3.11
+        run: |
+          # Install Python 3.11
+          apt update && apt install -y --no-install-recommends python3.11 python3.11-dev python3.11-venv
+          # Set Python 3.11 as the default Python version
+          update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.11 1
+          update-alternatives --install /usr/bin/python3-config python3-config /usr/bin/python3.11-config 1
+          # Migrate all Python 3.10 packages to Python 3.11
+          python3.10 -m pip freeze | python3.11 -m pip install -r /dev/stdin
+
       # ========================================================================
       # CUDA Quantum build
       # ========================================================================
@@ -80,7 +90,7 @@ jobs:
       # ========================================================================
  
       - name: Install python requirements
-        run: pip install numpy pytest cupy-cuda12x cuquantum-cu12
+        run: pip install numpy pytest cupy-cuda12x cuquantum-python-cu12 quimb opt_einsum torch
 
       - name: Run Python tests
         run: cmake --build ${{ steps.build.outputs.build-dir }} --target run_python_tests

--- a/.github/workflows/all_libs.yaml
+++ b/.github/workflows/all_libs.yaml
@@ -80,7 +80,7 @@ jobs:
       # ========================================================================
  
       - name: Install python requirements
-        # Note: install quimb opt_einsum torch when we advance to Python 3.11
+        # Note: install tensor_network_decoder's dependencies quimb, opt_einsum, and torch when we advance to Python 3.11
         run: pip install numpy pytest cupy-cuda12x cuquantum-cu12
 
       - name: Run Python tests

--- a/.github/workflows/all_libs.yaml
+++ b/.github/workflows/all_libs.yaml
@@ -83,7 +83,12 @@ jobs:
         run: pip install numpy pytest cupy-cuda12x cuquantum-cu12
 
       - name: Run Python tests
-        run: cmake --build ${{ steps.build.outputs.build-dir }} --target run_python_tests
+        run: |
+          # Skip the tensor network decoder tests. Once we advance to Python 3.11 for this test, we can restore this back to:
+          # cmake --build ${{ steps.build.outputs.build-dir }} --target run_python_tests
+          # But for now, we do this:
+          export PYTHONPATH="/cudaq-install:${{ steps.build.outputs.build-dir }}/python"
+          python3 -m pytest -v --ignore=python/tests/test_tensor_network_decoder.py libs/*/python/tests
 
       # ========================================================================
       # Run example tests

--- a/.github/workflows/all_libs.yaml
+++ b/.github/workflows/all_libs.yaml
@@ -80,15 +80,11 @@ jobs:
       # ========================================================================
  
       - name: Install python requirements
+        # Note: install quimb opt_einsum torch when we advance to Python 3.11
         run: pip install numpy pytest cupy-cuda12x cuquantum-cu12
 
       - name: Run Python tests
-        run: |
-          # Skip the tensor network decoder tests. Once we advance to Python 3.11 for this test, we can restore this back to:
-          # cmake --build ${{ steps.build.outputs.build-dir }} --target run_python_tests
-          # But for now, we do this:
-          export PYTHONPATH="/cudaq-install:${{ steps.build.outputs.build-dir }}/python"
-          python3 -m pytest -v --ignore=python/tests/test_tensor_network_decoder.py libs/*/python/tests
+        run: cmake --build ${{ steps.build.outputs.build-dir }} --target run_python_tests
 
       # ========================================================================
       # Run example tests

--- a/.github/workflows/all_libs_release.yaml
+++ b/.github/workflows/all_libs_release.yaml
@@ -120,7 +120,11 @@ jobs:
             export PYTHONPATH="/usr/local/cudaq:$HOME/.cudaqx"
             python3 -c "import cudaq_qec as qec; print(qec.__version__); d = qec.get_decoder('nv-qldpc-decoder', qec.get_code('steane').get_parity()); print(d.get_version())"
           fi
-          cmake --build ${{ steps.build.outputs.build-dir }} --target run_python_tests
+          # Skip the tensor network decoder tests. Once we advance to Python 3.11 for this test, we can restore this back to:
+          # cmake --build ${{ steps.build.outputs.build-dir }} --target run_python_tests
+          # But for now, we do this:
+          export PYTHONPATH="/cudaq-install:${{ steps.build.outputs.build-dir }}/python"
+          python3 -m pytest -v --ignore=python/tests/test_tensor_network_decoder.py libs/*/python/tests
         shell: bash
 
       # ========================================================================

--- a/.github/workflows/all_libs_release.yaml
+++ b/.github/workflows/all_libs_release.yaml
@@ -75,16 +75,6 @@ jobs:
           fi
         shell: bash
           
-      - name: Update to Python 3.11
-        run: |
-          # Install Python 3.11
-          apt update && apt install -y --no-install-recommends python3.11 python3.11-dev python3.11-venv
-          # Set Python 3.11 as the default Python version
-          update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.11 1
-          update-alternatives --install /usr/bin/python3-config python3-config /usr/bin/python3.11-config 1
-          # Migrate all Python 3.10 packages to Python 3.11
-          python3.10 -m pip freeze | python3.11 -m pip install -r /dev/stdin
-
       # ========================================================================
       # Build
       # ========================================================================
@@ -121,7 +111,7 @@ jobs:
       # ========================================================================
  
       - name: Install python requirements
-        run: pip install numpy pytest cupy-cuda12x cuquantum-python-cu12 quimb opt_einsum torch
+        run: pip install numpy pytest cupy-cuda12x cuquantum-cu12
 
       - name: Run Python tests
         run: |

--- a/.github/workflows/all_libs_release.yaml
+++ b/.github/workflows/all_libs_release.yaml
@@ -111,7 +111,7 @@ jobs:
       # ========================================================================
  
       - name: Install python requirements
-        run: pip install numpy pytest cupy-cuda12x cuquantum-python-cu12 quimb opt_einsum torch
+        run: pip install numpy pytest cupy-cuda12x cuquantum-cu12
 
       - name: Run Python tests
         run: |

--- a/.github/workflows/all_libs_release.yaml
+++ b/.github/workflows/all_libs_release.yaml
@@ -111,7 +111,7 @@ jobs:
       # ========================================================================
  
       - name: Install python requirements
-        # Note: install quimb opt_einsum torch when we advance to Python 3.11
+        # Note: install tensor_network_decoder's dependencies quimb, opt_einsum, and torch when we advance to Python 3.11
         run: pip install numpy pytest cupy-cuda12x cuquantum-cu12
 
       - name: Run Python tests

--- a/.github/workflows/all_libs_release.yaml
+++ b/.github/workflows/all_libs_release.yaml
@@ -75,6 +75,16 @@ jobs:
           fi
         shell: bash
           
+      - name: Update to Python 3.11
+        run: |
+          # Install Python 3.11
+          apt update && apt install -y --no-install-recommends python3.11 python3.11-dev python3.11-venv
+          # Set Python 3.11 as the default Python version
+          update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.11 1
+          update-alternatives --install /usr/bin/python3-config python3-config /usr/bin/python3.11-config 1
+          # Migrate all Python 3.10 packages to Python 3.11
+          python3.10 -m pip freeze | python3.11 -m pip install -r /dev/stdin
+
       # ========================================================================
       # Build
       # ========================================================================
@@ -111,7 +121,7 @@ jobs:
       # ========================================================================
  
       - name: Install python requirements
-        run: pip install numpy pytest cupy-cuda12x cuquantum-cu12
+        run: pip install numpy pytest cupy-cuda12x cuquantum-python-cu12 quimb opt_einsum torch
 
       - name: Run Python tests
         run: |

--- a/.github/workflows/all_libs_release.yaml
+++ b/.github/workflows/all_libs_release.yaml
@@ -111,6 +111,7 @@ jobs:
       # ========================================================================
  
       - name: Install python requirements
+        # Note: install quimb opt_einsum torch when we advance to Python 3.11
         run: pip install numpy pytest cupy-cuda12x cuquantum-cu12
 
       - name: Run Python tests
@@ -120,11 +121,7 @@ jobs:
             export PYTHONPATH="/usr/local/cudaq:$HOME/.cudaqx"
             python3 -c "import cudaq_qec as qec; print(qec.__version__); d = qec.get_decoder('nv-qldpc-decoder', qec.get_code('steane').get_parity()); print(d.get_version())"
           fi
-          # Skip the tensor network decoder tests. Once we advance to Python 3.11 for this test, we can restore this back to:
-          # cmake --build ${{ steps.build.outputs.build-dir }} --target run_python_tests
-          # But for now, we do this:
-          export PYTHONPATH="/cudaq-install:${{ steps.build.outputs.build-dir }}/python"
-          python3 -m pytest -v --ignore=python/tests/test_tensor_network_decoder.py libs/*/python/tests
+          cmake --build ${{ steps.build.outputs.build-dir }} --target run_python_tests
         shell: bash
 
       # ========================================================================

--- a/.github/workflows/lib_qec.yaml
+++ b/.github/workflows/lib_qec.yaml
@@ -34,16 +34,6 @@ jobs:
         run: |
           echo "pr_number=${{ fromJSON(steps.get-pr-info.outputs.pr-info).number }}" >> $GITHUB_OUTPUT
 
-      - name: Update to Python 3.11
-        run: |
-          # Install Python 3.11
-          apt update && apt install -y --no-install-recommends python3.11 python3.11-dev python3.11-venv
-          # Set Python 3.11 as the default Python version
-          update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.11 1
-          update-alternatives --install /usr/bin/python3-config python3-config /usr/bin/python3.11-config 1
-          # Migrate all Python 3.10 packages to Python 3.11
-          python3.10 -m pip freeze | python3.11 -m pip install -r /dev/stdin
-
       # ========================================================================
       # CUDA Quantum build
       # ========================================================================
@@ -86,7 +76,7 @@ jobs:
       # ========================================================================
  
       - name: Install python requirements
-        run: pip install numpy pytest cupy-cuda12x cuquantum-python-cu12 quimb opt_einsum torch
+        run: pip install numpy pytest cupy-cuda12x cuquantum-cu12
 
       - name: Run Python tests
         run: cmake --build ${{ steps.build.outputs.build-dir }} --target run_python_tests

--- a/.github/workflows/lib_qec.yaml
+++ b/.github/workflows/lib_qec.yaml
@@ -34,6 +34,16 @@ jobs:
         run: |
           echo "pr_number=${{ fromJSON(steps.get-pr-info.outputs.pr-info).number }}" >> $GITHUB_OUTPUT
 
+      - name: Update to Python 3.11
+        run: |
+          # Install Python 3.11
+          apt update && apt install -y --no-install-recommends python3.11 python3.11-dev python3.11-venv
+          # Set Python 3.11 as the default Python version
+          update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.11 1
+          update-alternatives --install /usr/bin/python3-config python3-config /usr/bin/python3.11-config 1
+          # Migrate all Python 3.10 packages to Python 3.11
+          python3.10 -m pip freeze | python3.11 -m pip install -r /dev/stdin
+
       # ========================================================================
       # CUDA Quantum build
       # ========================================================================
@@ -76,7 +86,7 @@ jobs:
       # ========================================================================
  
       - name: Install python requirements
-        run: pip install numpy pytest cupy-cuda12x cuquantum-cu12
+        run: pip install numpy pytest cupy-cuda12x cuquantum-python-cu12 quimb opt_einsum torch
 
       - name: Run Python tests
         run: cmake --build ${{ steps.build.outputs.build-dir }} --target run_python_tests

--- a/.github/workflows/lib_qec.yaml
+++ b/.github/workflows/lib_qec.yaml
@@ -76,7 +76,7 @@ jobs:
       # ========================================================================
  
       - name: Install python requirements
-        # Note: install quimb opt_einsum torch when we advance to Python 3.11
+        # Note: install tensor_network_decoder's dependencies quimb, opt_einsum, and torch when we advance to Python 3.11
         run: pip install numpy pytest cupy-cuda12x cuquantum-cu12
 
       - name: Run Python tests

--- a/.github/workflows/lib_qec.yaml
+++ b/.github/workflows/lib_qec.yaml
@@ -76,15 +76,11 @@ jobs:
       # ========================================================================
  
       - name: Install python requirements
+        # Note: install quimb opt_einsum torch when we advance to Python 3.11
         run: pip install numpy pytest cupy-cuda12x cuquantum-cu12
 
       - name: Run Python tests
-        run: |
-          # Skip the tensor network decoder tests. Once we advance to Python 3.11 for this test, we can restore this back to:
-          # cmake --build ${{ steps.build.outputs.build-dir }} --target run_python_tests
-          # But for now, we do this:
-          export PYTHONPATH="/cudaq-install:${{ steps.build.outputs.build-dir }}/python"
-          python3 -m pytest -v --ignore=python/tests/test_tensor_network_decoder.py libs/qec/python/tests
+        run: cmake --build ${{ steps.build.outputs.build-dir }} --target run_python_tests
 
       # ========================================================================
       # Run example tests

--- a/.github/workflows/lib_qec.yaml
+++ b/.github/workflows/lib_qec.yaml
@@ -79,7 +79,12 @@ jobs:
         run: pip install numpy pytest cupy-cuda12x cuquantum-cu12
 
       - name: Run Python tests
-        run: cmake --build ${{ steps.build.outputs.build-dir }} --target run_python_tests
+        run: |
+          # Skip the tensor network decoder tests. Once we advance to Python 3.11 for this test, we can restore this back to:
+          # cmake --build ${{ steps.build.outputs.build-dir }} --target run_python_tests
+          # But for now, we do this:
+          export PYTHONPATH="/cudaq-install:${{ steps.build.outputs.build-dir }}/python"
+          python3 -m pytest -v --ignore=python/tests/test_tensor_network_decoder.py libs/qec/python/tests
 
       # ========================================================================
       # Run example tests

--- a/.github/workflows/lib_qec.yaml
+++ b/.github/workflows/lib_qec.yaml
@@ -76,7 +76,7 @@ jobs:
       # ========================================================================
  
       - name: Install python requirements
-        run: pip install numpy pytest cupy-cuda12x cuquantum-python-cu12 quimb opt_einsum torch
+        run: pip install numpy pytest cupy-cuda12x cuquantum-cu12
 
       - name: Run Python tests
         run: cmake --build ${{ steps.build.outputs.build-dir }} --target run_python_tests

--- a/.github/workflows/lib_solvers.yaml
+++ b/.github/workflows/lib_solvers.yaml
@@ -34,16 +34,6 @@ jobs:
         run: |
           echo "pr_number=${{ fromJSON(steps.get-pr-info.outputs.pr-info).number }}" >> $GITHUB_OUTPUT
 
-      - name: Update to Python 3.11
-        run: |
-          # Install Python 3.11
-          apt update && apt install -y --no-install-recommends python3.11 python3.11-dev python3.11-venv
-          # Set Python 3.11 as the default Python version
-          update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.11 1
-          update-alternatives --install /usr/bin/python3-config python3-config /usr/bin/python3.11-config 1
-          # Migrate all Python 3.10 packages to Python 3.11
-          python3.10 -m pip freeze | python3.11 -m pip install -r /dev/stdin
-
       # ========================================================================
       # CUDA Quantum build
       # ========================================================================
@@ -90,7 +80,7 @@ jobs:
       # ========================================================================
  
       - name: Install python requirements
-        run: pip install numpy pytest cupy-cuda12x cuquantum-python-cu12
+        run: pip install numpy pytest cupy-cuda12x cuquantum-cu12
 
       - name: Run Python tests
         run: cmake --build ${{ steps.build.outputs.build-dir }} --target run_python_tests

--- a/.github/workflows/lib_solvers.yaml
+++ b/.github/workflows/lib_solvers.yaml
@@ -80,7 +80,7 @@ jobs:
       # ========================================================================
  
       - name: Install python requirements
-        run: pip install numpy pytest cupy-cuda12x cuquantum-python-cu12
+        run: pip install numpy pytest cupy-cuda12x cuquantum-cu12
 
       - name: Run Python tests
         run: cmake --build ${{ steps.build.outputs.build-dir }} --target run_python_tests

--- a/.github/workflows/lib_solvers.yaml
+++ b/.github/workflows/lib_solvers.yaml
@@ -34,6 +34,16 @@ jobs:
         run: |
           echo "pr_number=${{ fromJSON(steps.get-pr-info.outputs.pr-info).number }}" >> $GITHUB_OUTPUT
 
+      - name: Update to Python 3.11
+        run: |
+          # Install Python 3.11
+          apt update && apt install -y --no-install-recommends python3.11 python3.11-dev python3.11-venv
+          # Set Python 3.11 as the default Python version
+          update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.11 1
+          update-alternatives --install /usr/bin/python3-config python3-config /usr/bin/python3.11-config 1
+          # Migrate all Python 3.10 packages to Python 3.11
+          python3.10 -m pip freeze | python3.11 -m pip install -r /dev/stdin
+
       # ========================================================================
       # CUDA Quantum build
       # ========================================================================
@@ -80,7 +90,7 @@ jobs:
       # ========================================================================
  
       - name: Install python requirements
-        run: pip install numpy pytest cupy-cuda12x cuquantum-cu12
+        run: pip install numpy pytest cupy-cuda12x cuquantum-python-cu12
 
       - name: Run Python tests
         run: cmake --build ${{ steps.build.outputs.build-dir }} --target run_python_tests

--- a/libs/qec/python/tests/test_tensor_network_decoder.py
+++ b/libs/qec/python/tests/test_tensor_network_decoder.py
@@ -6,19 +6,26 @@
 # the terms of the Apache License 2.0 which accompanies this distribution.     #
 # ============================================================================ #
 
-import numpy as np
+import sys
 import pytest
-from quimb.tensor import TensorNetwork
+
+import numpy as np
 import cudaq_qec as qec
 
-from cudaq_qec.plugins.decoders.tensor_network_utils.tensor_network_factory import (
-    tensor_network_from_parity_check, tensor_network_from_single_syndrome,
-    prepare_syndrome_data_batch, tensor_network_from_syndrome_batch,
-    tensor_network_from_logical_observable)
-from cudaq_qec.plugins.decoders.tensor_network_utils.contractors import (
-    optimize_path, cutn_contractor, ContractorConfig, contractor,
-    cutn_contractor)
-from cudaq_qec.plugins.decoders.tensor_network_utils.noise_models import factorized_noise_model, error_pairs_noise_model
+if sys.version_info >= (3, 11):
+    from quimb.tensor import TensorNetwork
+
+    from cudaq_qec.plugins.decoders.tensor_network_utils.tensor_network_factory import (
+        tensor_network_from_parity_check, tensor_network_from_single_syndrome,
+        prepare_syndrome_data_batch, tensor_network_from_syndrome_batch,
+        tensor_network_from_logical_observable)
+    from cudaq_qec.plugins.decoders.tensor_network_utils.contractors import (
+        optimize_path, cutn_contractor, ContractorConfig, contractor,
+        cutn_contractor)
+    from cudaq_qec.plugins.decoders.tensor_network_utils.noise_models import factorized_noise_model, error_pairs_noise_model
+
+pytestmark = pytest.mark.skipif(sys.version_info < (3, 11),
+                                reason="Requires Python >= 3.11")
 
 
 def is_nvidia_gpu_available():

--- a/scripts/ci/test_wheels.sh
+++ b/scripts/ci/test_wheels.sh
@@ -46,12 +46,11 @@ wheel_file=$(ls /wheels/cudaq_qec-*-cp${python_version_no_dot}-cp${python_versio
 if [ $python_version == "3.10" ]; then
   echo "Installing QEC library without tensor network decoder"
   ${python} -m pip install "${wheel_file}"
-  ${python} -m pytest -v -s libs/qec/python/tests/ --ignore=libs/qec/python/tests/test_tensor_network_decoder.py
 else
   echo "Installing QEC library with tensor network decoder"
   ${python} -m pip install "${wheel_file}[tn_decoder]"
-  ${python} -m pytest -v -s libs/qec/python/tests/
 fi
+${python} -m pytest -v -s libs/qec/python/tests/
 
 # Solvers library
 # ======================================


### PR DESCRIPTION
Disable the tn_decoder tests for Python 3.10. tn_decoder is not supported for Python 3.10 because cuquantum-python-cu12 is unsupported for 3.10.