### PR TITLE
Delay target specification until execution

### DIFF
--- a/libs/qec/lib/CMakeLists.txt
+++ b/libs/qec/lib/CMakeLists.txt
@@ -45,7 +45,6 @@ target_link_options(${LIBRARY_NAME} PUBLIC
 target_link_libraries(${LIBRARY_NAME}
   PUBLIC 
     cudaqx-core
-    cudaq::cudaq 
     cudaq::cudaq-operator
   PRIVATE
     cudaq::cudaq-common

--- a/libs/qec/lib/decoders/plugins/example/CMakeLists.txt
+++ b/libs/qec/lib/decoders/plugins/example/CMakeLists.txt
@@ -1,5 +1,5 @@
 # ============================================================================ #
-# Copyright (c) 2024 NVIDIA Corporation & Affiliates.                          #
+# Copyright (c) 2024 - 2025 NVIDIA Corporation & Affiliates.                   #
 # All rights reserved.                                                         #
 #                                                                              #
 # This source code and the accompanying materials are made available under     #
@@ -32,7 +32,6 @@ target_include_directories(${MODULE_NAME}
 target_link_libraries(${MODULE_NAME}
   PUBLIC
     cudaqx-core
-    cudaq::cudaq
     cudaq::cudaq-operator
   PRIVATE
     cudaq::cudaq-common

--- a/libs/qec/python/CMakeLists.txt
+++ b/libs/qec/python/CMakeLists.txt
@@ -1,5 +1,5 @@
 # ============================================================================ #
-# Copyright (c) 2024 NVIDIA Corporation & Affiliates.                          #
+# Copyright (c) 2024 - 2025 NVIDIA Corporation & Affiliates.                   #
 # All rights reserved.                                                         #
 #                                                                              #
 # This source code and the accompanying materials are made available under     #
@@ -32,7 +32,6 @@ cudaqx_add_pymodule(${MODULE_NAME}
 target_link_libraries(${MODULE_NAME} 
   PRIVATE 
     cudaq-qec
-    cudaq::cudaq
 )
 
 set_target_properties(${MODULE_NAME} PROPERTIES

--- a/libs/qec/unittests/CMakeLists.txt
+++ b/libs/qec/unittests/CMakeLists.txt
@@ -32,12 +32,12 @@ include(GoogleTest)
 add_compile_options(-Wno-attributes) 
 
 add_executable(test_decoders test_decoders.cpp decoders/sample_decoder.cpp)
-target_link_libraries(test_decoders PRIVATE GTest::gtest_main cudaq-qec)
+target_link_libraries(test_decoders PRIVATE GTest::gtest_main cudaq-qec cudaq::cudaq)
 add_dependencies(CUDAQXQECUnitTests test_decoders)
 gtest_discover_tests(test_decoders)
 
 add_executable(test_qec test_qec.cpp)
-target_link_libraries(test_qec PRIVATE GTest::gtest_main cudaq-qec)
+target_link_libraries(test_qec PRIVATE GTest::gtest_main cudaq-qec cudaq::cudaq)
 add_dependencies(CUDAQXQECUnitTests test_qec)
 gtest_discover_tests(test_qec)
 

--- a/libs/solvers/lib/CMakeLists.txt
+++ b/libs/solvers/lib/CMakeLists.txt
@@ -45,7 +45,6 @@ target_link_options(cudaq-solvers PUBLIC
 target_link_libraries(cudaq-solvers
   PUBLIC
     cudaqx-core
-    cudaq::cudaq
     cudaq::cudaq-operator
   PRIVATE
     cudaq::cudaq-common

--- a/libs/solvers/python/CMakeLists.txt
+++ b/libs/solvers/python/CMakeLists.txt
@@ -31,9 +31,12 @@ cudaqx_add_pymodule(${MODULE_NAME}
 
 target_include_directories(${MODULE_NAME} PRIVATE .)
 
+# TODO - Remove dependency on cudaq::cudaq in order to avoid automatic linking
+# of a specific simulator like libnvqir-qpp.so.
 target_link_libraries(${MODULE_NAME} 
   PRIVATE 
     cudaq-solvers
+    cudaq::cudaq
     cudaq::cudaq-python-interop
 )
 

--- a/libs/solvers/python/CMakeLists.txt
+++ b/libs/solvers/python/CMakeLists.txt
@@ -1,5 +1,5 @@
 # ============================================================================ #
-# Copyright (c) 2024 NVIDIA Corporation & Affiliates.                          #
+# Copyright (c) 2024 - 2025 NVIDIA Corporation & Affiliates.                   #
 # All rights reserved.                                                         #
 #                                                                              #
 # This source code and the accompanying materials are made available under     #
@@ -34,7 +34,6 @@ target_include_directories(${MODULE_NAME} PRIVATE .)
 target_link_libraries(${MODULE_NAME} 
   PRIVATE 
     cudaq-solvers
-    cudaq::cudaq
     cudaq::cudaq-python-interop
 )
 

--- a/libs/solvers/unittests/CMakeLists.txt
+++ b/libs/solvers/unittests/CMakeLists.txt
@@ -35,40 +35,40 @@ add_subdirectory(nvqpp)
 # ==============================================================================
 
 add_executable(test_adapt test_adapt.cpp)
-target_link_libraries(test_adapt PRIVATE GTest::gtest_main cudaq-solvers test-kernels)
+target_link_libraries(test_adapt PRIVATE GTest::gtest_main cudaq-solvers test-kernels cudaq::cudaq)
 add_dependencies(CUDAQXSolversUnitTests test_adapt)
 gtest_discover_tests(test_adapt)
 
 add_executable(test_molecule test_molecule.cpp)
-target_link_libraries(test_molecule PRIVATE GTest::gtest_main cudaq-solvers)
+target_link_libraries(test_molecule PRIVATE GTest::gtest_main cudaq-solvers cudaq::cudaq)
 add_dependencies(CUDAQXSolversUnitTests test_molecule)
 gtest_discover_tests(test_molecule)
 
 add_executable(test_bravyi_kitaev test_bravyi_kitaev.cpp)
-target_link_libraries(test_bravyi_kitaev PRIVATE GTest::gtest_main cudaq-solvers)
+target_link_libraries(test_bravyi_kitaev PRIVATE GTest::gtest_main cudaq-solvers cudaq::cudaq)
 add_dependencies(CUDAQXSolversUnitTests test_bravyi_kitaev)
 gtest_discover_tests(test_bravyi_kitaev)
 
 add_executable(test_optimizers test_optimizers.cpp)
-target_link_libraries(test_optimizers PRIVATE GTest::gtest_main cudaq-solvers)
+target_link_libraries(test_optimizers PRIVATE GTest::gtest_main cudaq-solvers cudaq::cudaq)
 add_dependencies(CUDAQXSolversUnitTests test_optimizers)
 gtest_discover_tests(test_optimizers)
 
 add_executable(test_operator_pools test_operator_pools.cpp)
-target_link_libraries(test_operator_pools PRIVATE GTest::gtest_main cudaq-solvers)
+target_link_libraries(test_operator_pools PRIVATE GTest::gtest_main cudaq-solvers cudaq::cudaq)
 add_dependencies(CUDAQXSolversUnitTests test_operator_pools)
 gtest_discover_tests(test_operator_pools)
 
 add_executable(test_vqe test_vqe.cpp)
-target_link_libraries(test_vqe PRIVATE GTest::gtest_main cudaq-solvers test-kernels)
+target_link_libraries(test_vqe PRIVATE GTest::gtest_main cudaq-solvers test-kernels cudaq::cudaq)
 add_dependencies(CUDAQXSolversUnitTests test_vqe)
 gtest_discover_tests(test_vqe)
 
 add_executable(test_uccsd test_uccsd.cpp)
-target_link_libraries(test_uccsd PRIVATE GTest::gtest_main cudaq-solvers test-kernels)
+target_link_libraries(test_uccsd PRIVATE GTest::gtest_main cudaq-solvers test-kernels cudaq::cudaq)
 add_dependencies(CUDAQXSolversUnitTests test_uccsd)
 gtest_discover_tests(test_uccsd)
 
 add_executable(test_qaoa test_qaoa.cpp)
-target_link_libraries(test_qaoa PRIVATE GTest::gtest_main cudaq-solvers test-kernels)
+target_link_libraries(test_qaoa PRIVATE GTest::gtest_main cudaq-solvers test-kernels cudaq::cudaq)
 gtest_discover_tests(test_qaoa)


### PR DESCRIPTION
This reduces the library dependencies of our core libraries. It means that CUDA-Q target specification is delayed until final link time of the final executable rather than setting it at the time of .so creation. The following image shows the `ldd` differences.

<img width="1478" height="434" alt="image" src="https://github.com/user-attachments/assets/658e8ce9-2131-4d2c-b694-4f6fda9548a1" />
