### PR TITLE
Fix issue #258: added check and informative error message

### DIFF
--- a/libs/qec/lib/detector_error_model.cpp
+++ b/libs/qec/lib/detector_error_model.cpp
@@ -76,9 +76,9 @@ void detector_error_model::canonicalize_for_rounds(
   bool has_error_ids =
       error_ids.has_value() && error_ids->size() == error_rates.size();
 
-  if (row_indices > error_rates.size()) {
+  if (row_indices.size() > error_rates.size()) {
     throw std::runtime_error(
-        "canonicalize_for_rounds: row_indices (" + std::to_string(row_indices) +
+        "canonicalize_for_rounds: row_indices size (" + std::to_string(row_indices.size()) +
         ") is greater than the number of error rates (" +
         std::to_string(error_rates.size()) +
         "). This likely means either 'error_rates' was populated incorrectly "

--- a/libs/qec/lib/detector_error_model.cpp
+++ b/libs/qec/lib/detector_error_model.cpp
@@ -75,6 +75,16 @@ void detector_error_model::canonicalize_for_rounds(
   const auto num_cols = column_order.size();
   bool has_error_ids =
       error_ids.has_value() && error_ids->size() == error_rates.size();
+
+  if (row_indices > error_rates.size()) {
+    throw std::runtime_error(
+        "canonicalize_for_rounds: row_indices (" + std::to_string(row_indices) +
+        ") is greater than the number of error rates (" +
+        std::to_string(error_rates.size()) +
+        "). This likely means either 'error_rates' was populated incorrectly "
+        "or the detector_error_matrix  was computed incorrectly.");
+  }
+
   for (std::size_t c = 0; c < num_cols; c++) {
     auto column_index = column_order[c];
     auto &curr_row_indices = row_indices[column_index];

--- a/libs/qec/lib/detector_error_model.cpp
+++ b/libs/qec/lib/detector_error_model.cpp
@@ -78,7 +78,8 @@ void detector_error_model::canonicalize_for_rounds(
 
   if (row_indices.size() > error_rates.size()) {
     throw std::runtime_error(
-        "canonicalize_for_rounds: row_indices size (" + std::to_string(row_indices.size()) +
+        "canonicalize_for_rounds: row_indices size (" +
+        std::to_string(row_indices.size()) +
         ") is greater than the number of error rates (" +
         std::to_string(error_rates.size()) +
         "). This likely means either 'error_rates' was populated incorrectly "

--- a/libs/qec/unittests/test_qec.cpp
+++ b/libs/qec/unittests/test_qec.cpp
@@ -1548,6 +1548,42 @@ TEST(DetectorErrorModelTest, NumObservablesInCanonicalize) {
   EXPECT_EQ(dem.num_observables(), 1);
 }
 
+TEST(DetectorErrorModelTest, FailureOnEmptyErrorRatesCanonicalize) {
+cudaq::qec::detector_error_model dem;
+
+  // Set up a simple detector_error_matrix
+  std::vector<std::size_t> detector_shape = {
+      2, 3}; // 2 detectors, 3 error mechanisms
+  dem.detector_error_matrix = cudaqx::tensor<uint8_t>(detector_shape);
+  // Initialize with some data
+  dem.detector_error_matrix.at({0, 0}) = 1;
+  dem.detector_error_matrix.at({0, 1}) = 0;
+  dem.detector_error_matrix.at({0, 2}) = 1;
+  dem.detector_error_matrix.at({1, 0}) = 0;
+  dem.detector_error_matrix.at({1, 1}) = 1;
+  dem.detector_error_matrix.at({1, 2}) = 0;
+
+  // Set up observables_flips_matrix
+  std::vector<std::size_t> obs_shape = {1,
+                                        3}; // 1 observable, 3 error mechanisms
+  dem.observables_flips_matrix = cudaqx::tensor<uint8_t>(obs_shape);
+  dem.observables_flips_matrix.at({0, 0}) = 0;
+  dem.observables_flips_matrix.at({0, 1}) = 1;
+  dem.observables_flips_matrix.at({0, 2}) = 0;
+
+  // Set up error_rates
+  dem.error_rates = {};
+
+  // Before canonicalize: verify num_observables works
+  EXPECT_EQ(dem.num_observables(), 1);
+
+  EXPECT_THROW(
+      dem.canonicalize_for_rounds(2),
+      std::runtime_error
+  );
+
+}
+
 TEST(DetectorErrorModelTest, CanonicalizeWithoutErrorIds) {
   // This test covers the std::numeric_limits<std::size_t>::max() branch
   // when has_error_ids is false and duplicate columns need to be merged

--- a/libs/qec/unittests/test_qec.cpp
+++ b/libs/qec/unittests/test_qec.cpp
@@ -1549,7 +1549,7 @@ TEST(DetectorErrorModelTest, NumObservablesInCanonicalize) {
 }
 
 TEST(DetectorErrorModelTest, FailureOnEmptyErrorRatesCanonicalize) {
-cudaq::qec::detector_error_model dem;
+  cudaq::qec::detector_error_model dem;
 
   // Set up a simple detector_error_matrix
   std::vector<std::size_t> detector_shape = {
@@ -1577,11 +1577,7 @@ cudaq::qec::detector_error_model dem;
   // Before canonicalize: verify num_observables works
   EXPECT_EQ(dem.num_observables(), 1);
 
-  EXPECT_THROW(
-      dem.canonicalize_for_rounds(2),
-      std::runtime_error
-  );
-
+  EXPECT_THROW(dem.canonicalize_for_rounds(2), std::runtime_error);
 }
 
 TEST(DetectorErrorModelTest, CanonicalizeWithoutErrorIds) {


### PR DESCRIPTION
This PR fixes issue #258 by adding a validation check on the dimensions of the dem and the error rates and providing a clear, informative error message when the condition is not met. This improves error handling and helps users quickly identify the cause of the problem when the construction is made by hand in a custom QEC example.