### PR TITLE
Use 'tensor-network-decoder' in pip install instructions

### DIFF
--- a/docs/sphinx/examples/qec/python/tensor_network_decoder.py
+++ b/docs/sphinx/examples/qec/python/tensor_network_decoder.py
@@ -16,17 +16,17 @@ if sys.version_info < (3, 11):
 
 # [Begin Documentation]
 """
-Example usage of tensor_network_decoder from cudaq_qec.
+Example usage of tensor_network_decoder from cudaq-qec.
 
 This script demonstrates how to instantiate and use the tensor network decoder
 to decode a circuit level noise problem derived from a Stim surface code experiment.
 
-This example requires the `cudaq-qec` package and the optional tensor-network dependencies.
+This example requires the `cudaq-qec` package and the optional tensor-network-decoder dependencies.
 To install the required dependencies, run:
 
-pip install cudaq-qec[tensor_network_decoder]
+pip install cudaq-qec[tensor-network-decoder]
 
-Additionaly, you will need `stim` and `beliefmatching` packages:
+Additionaly, in this example, you will need `stim` and `beliefmatching` packages:
 pip install stim beliefmatching
 
 """

--- a/libs/qec/README.md
+++ b/libs/qec/README.md
@@ -19,7 +19,7 @@ not require a GPU to use, but some components are GPU-accelerated.
 
 Note: if you would like to use our Tensor Network Decoder, you will need
 additional dependencies installed. You can install them with
-`pip install cudaq-qec[tensor_network_decoder]`.
+`pip install cudaq-qec[tensor-network-decoder]`.
 
 ## Getting Started
 

--- a/libs/qec/python/bindings/py_decoder.cpp
+++ b/libs/qec/python/bindings/py_decoder.cpp
@@ -284,7 +284,7 @@ void bindDecoder(py::module &mod) {
           throw std::runtime_error(
               "Decoder 'tensor_network_decoder' is not available. "
               "To enable it, install the python module's dependencies via:\n\n"
-              "    pip install cudaq_qec[tensor_network_decoder]\n");
+              "    pip install cudaq-qec[tensor-network-decoder]\n");
         }
 
         py::buffer_info buf = H.request();

--- a/libs/qec/python/tests/test_tensor_network_decoder_negative.py
+++ b/libs/qec/python/tests/test_tensor_network_decoder_negative.py
@@ -35,7 +35,7 @@ def test_tensor_network_decoder_missing_dependencies():
 
     # Verify the error message contains the expected C++ message and installation instructions
     error_msg = str(excinfo.value)
-    assert "Decoder 'tensor_network_decoder' is not available" in error_msg and "pip install cudaq_qec[tensor_network_decoder]" in error_msg, f"Unexpected error message: {error_msg}"
+    assert "Decoder 'tensor_network_decoder' is not available" in error_msg and "pip install cudaq-qec[tensor-network-decoder]" in error_msg, f"Unexpected error message: {error_msg}"
 
     # Verify this is NOT a Python ImportError (which would indicate the graceful failure didn't work)
     assert not isinstance(


### PR DESCRIPTION
The name`tensor_network_decoder` from the `.toml` file is normalized to be `tensor-network-decoder` in the wheel's METADATA. Newer version of `pip` is able to resolve this difference and `pip install cudaq-qec[tensor_network_decoder]` will work correctly. 

However, if you use an older version of `pip/setuptools`, you'll see an error such as "cudaq-qec 0.4.0 does not provide the extra 'tensor_network_decoder'". A safer alternative is to use the exact name as appeared in the METADATA (the normalized name with dash instead of underscore) such that even earlier versions of `pip` will find the package and install the dependencies as needed. 