### PR TITLE
Change v100 runners to a100

### DIFF
--- a/.github/workflows/all_libs_release.yaml
+++ b/.github/workflows/all_libs_release.yaml
@@ -24,7 +24,7 @@ jobs:
       matrix:
         runner: [
           { arch: arm64, gpu: a100 },
-          { arch: amd64, gpu: v100 },
+          { arch: amd64, gpu: a100 },
         ]
     runs-on: linux-${{ matrix.runner.arch }}-gpu-${{ matrix.runner.gpu }}-latest-1
     container: 

--- a/.github/workflows/build_wheels.yaml
+++ b/.github/workflows/build_wheels.yaml
@@ -240,7 +240,7 @@ jobs:
       matrix:
         runner: [
           { arch: arm64, gpu: a100 },
-          { arch: amd64, gpu: v100 },
+          { arch: amd64, gpu: a100 },
         ]
         python: ['3.10', '3.11', '3.12', '3.13']
   


### PR DESCRIPTION
cuTensor 2.3 was just released (which is an indirect dependency of ours), and while it adds support for new hardware (good), it also deprecates some old hardware (like V100's). This PR updates our CI.

Build wheels job: https://github.com/NVIDIA/cudaqx/actions/runs/17056005698

We also need to update the docs to tell users how to pin cuTensor 2.2 if they want (separate PR).