### PR TITLE
Fix invalid reference to cudaqx-config on QEC Introduction docs page

### DIFF
--- a/docs/sphinx/components/qec/introduction.rst
+++ b/docs/sphinx/components/qec/introduction.rst
@@ -298,10 +298,19 @@ to prototype and develop new codes.
                qec.Code.__init__(self, **kwargs)
 
                # Define stabilizer generators
-               self.stabilizers = qec.Stabilizers([
+               stabilizers_str = [
                    "XXXXIII", "IXXIXXI", "IIXXIXX",
                    "ZZZZIII", "IZZIZZI", "IIZZIZZ"
-               ])
+               ]
+               self.stabilizers = [
+                   cudaq.SpinOperator.from_word(s) for s in stabilizers_str
+               ]
+
+               # Define observables
+               obs_str = ["IIIIXXX", "IIIIZZZ"]
+               self.pauli_observables = [
+                   cudaq.SpinOperator.from_word(p) for p in obs_str
+               ]
 
                # Register quantum kernels
                self.operation_encodings = {
@@ -321,21 +330,23 @@ to prototype and develop new codes.
            def get_num_ancilla_qubits(self):
                return 6
 
-4. **Install the Code**:
+           def get_num_x_stabilizers(self):
+               return 3
 
-   Install your Python-implemented code using :code:`cudaqx-config`:
+           def get_num_z_stabilizers(self):
+               return 3
 
-   .. code-block:: bash
-
-       cudaqx-config --install-code my_steane.py
-
-5. **Using the Code**:
+4. **Using the Code**:
 
    The code can now be used like any other CUDA-Q QEC code:
 
    .. code-block:: python
 
        import cudaq_qec as qec
+       # Either import your code directly (e.g. "import my_steane", assuming
+       # your my_steane.py file is in the same directory), or you can paste the
+       # above code here without importing the file.
+       import my_steane
 
        # Create instance of your code
        code = qec.get_code('py-steane-example')

--- a/docs/sphinx/components/qec/introduction.rst
+++ b/docs/sphinx/components/qec/introduction.rst
@@ -243,115 +243,36 @@ to prototype and develop new codes.
 
    Create a new file (e.g., :code:`my_steane.py`) with your code implementation:
 
-   .. code-block:: python
-
-       import cudaq
-       import cudaq_qec as qec
-       from cudaq_qec import patch
+   .. literalinclude:: ../../examples/qec/python/my_steane.py
+      :language: python
+      :start-after: [Begin Documentation1]
+      :end-before: [End Documentation1]
 
 2. **Define Quantum Kernels**:
 
    Implement the required quantum kernels using the :code:`@cudaq.kernel` decorator:
 
-   .. code-block:: python
-
-       @cudaq.kernel
-       def prep0(logicalQubit: patch):
-           h(logicalQubit.data[0], logicalQubit.data[4], logicalQubit.data[6])
-           x.ctrl(logicalQubit.data[0], logicalQubit.data[1])
-           x.ctrl(logicalQubit.data[4], logicalQubit.data[5])
-           # ... additional initialization gates ...
-
-       @cudaq.kernel
-       def stabilizer(logicalQubit: patch,
-                     x_stabilizers: list[int],
-                     z_stabilizers: list[int]) -> list[bool]:
-           # Measure X stabilizers
-           h(logicalQubit.ancx)
-           for xi in range(len(logicalQubit.ancx)):
-               for di in range(len(logicalQubit.data)):
-                   if x_stabilizers[xi * len(logicalQubit.data) + di] == 1:
-                       x.ctrl(logicalQubit.ancx[xi], logicalQubit.data[di])
-           h(logicalQubit.ancx)
-
-           # Measure Z stabilizers
-           for zi in range(len(logicalQubit.ancz)):
-               for di in range(len(logicalQubit.data)):
-                   if z_stabilizers[zi * len(logicalQubit.data) + di] == 1:
-                       x.ctrl(logicalQubit.data[di], logicalQubit.ancz[zi])
-
-           # Get and reset ancillas
-           results = mz(logicalQubit.ancz, logicalQubit.ancx)
-           reset(logicalQubit.ancx)
-           reset(logicalQubit.ancz)
-           return results
+   .. literalinclude:: ../../examples/qec/python/my_steane.py
+      :language: python
+      :start-after: [Begin Documentation2]
+      :end-before: [End Documentation2]
 
 3. **Implement the Code Class**:
 
    Create a class decorated with :code:`@qec.code` that implements the required interface:
 
-   .. code-block:: python
-
-       @qec.code('py-steane-example')
-       class MySteaneCodeImpl:
-           def __init__(self, **kwargs):
-               qec.Code.__init__(self, **kwargs)
-
-               # Define stabilizer generators
-               stabilizers_str = [
-                   "XXXXIII", "IXXIXXI", "IIXXIXX",
-                   "ZZZZIII", "IZZIZZI", "IIZZIZZ"
-               ]
-               self.stabilizers = [
-                   cudaq.SpinOperator.from_word(s) for s in stabilizers_str
-               ]
-
-               # Define observables
-               obs_str = ["IIIIXXX", "IIIIZZZ"]
-               self.pauli_observables = [
-                   cudaq.SpinOperator.from_word(p) for p in obs_str
-               ]
-
-               # Register quantum kernels
-               self.operation_encodings = {
-                   qec.operation.prep0: prep0,
-                   qec.operation.stabilizer_round: stabilizer
-               }
-
-           def get_num_data_qubits(self):
-               return 7
-
-           def get_num_ancilla_x_qubits(self):
-               return 3
-
-           def get_num_ancilla_z_qubits(self):
-               return 3
-
-           def get_num_ancilla_qubits(self):
-               return 6
-
-           def get_num_x_stabilizers(self):
-               return 3
-
-           def get_num_z_stabilizers(self):
-               return 3
+   .. literalinclude:: ../../examples/qec/python/my_steane.py
+      :language: python
+      :start-after: [Begin Documentation3]
+      :end-before: [End Documentation3]
 
 4. **Using the Code**:
 
    The code can now be used like any other CUDA-Q QEC code:
 
-   .. code-block:: python
-
-       import cudaq_qec as qec
-       # Either import your code directly (e.g. "import my_steane", assuming
-       # your my_steane.py file is in the same directory), or you can paste the
-       # above code here without importing the file.
-       import my_steane
-
-       # Create instance of your code
-       code = qec.get_code('py-steane-example')
-
-       # Use the code for various numerical experiments
+   .. literalinclude:: ../../examples/qec/python/my_steane_test.py
+      :language: python
+      :start-after: [Begin Documentation]
 
 Key Points
 ^^^^^^^^^^^

--- a/docs/sphinx/examples/qec/python/my_steane.py
+++ b/docs/sphinx/examples/qec/python/my_steane.py
@@ -1,0 +1,92 @@
+# ============================================================================ #
+# Copyright (c) 2025 NVIDIA Corporation & Affiliates.                          #
+# All rights reserved.                                                         #
+#                                                                              #
+# This source code and the accompanying materials are made available under     #
+# the terms of the Apache License 2.0 which accompanies this distribution.     #
+# ============================================================================ #
+
+# [Begin Documentation1]
+import cudaq
+import cudaq_qec as qec
+from cudaq_qec import patch
+# [End Documentation1]
+
+# [Begin Documentation2]
+@cudaq.kernel
+def prep0(logicalQubit: patch):
+    h(logicalQubit.data[0], logicalQubit.data[4], logicalQubit.data[6])
+    x.ctrl(logicalQubit.data[0], logicalQubit.data[1])
+    x.ctrl(logicalQubit.data[4], logicalQubit.data[5])
+    # ... additional initialization gates ...
+
+@cudaq.kernel
+def stabilizer(logicalQubit: patch,
+                x_stabilizers: list[int],
+                z_stabilizers: list[int]) -> list[bool]:
+    # Measure X stabilizers
+    h(logicalQubit.ancx)
+    for xi in range(len(logicalQubit.ancx)):
+        for di in range(len(logicalQubit.data)):
+            if x_stabilizers[xi * len(logicalQubit.data) + di] == 1:
+                x.ctrl(logicalQubit.ancx[xi], logicalQubit.data[di])
+    h(logicalQubit.ancx)
+
+    # Measure Z stabilizers
+    for zi in range(len(logicalQubit.ancz)):
+        for di in range(len(logicalQubit.data)):
+            if z_stabilizers[zi * len(logicalQubit.data) + di] == 1:
+                x.ctrl(logicalQubit.data[di], logicalQubit.ancz[zi])
+
+    # Get and reset ancillas
+    results = mz(logicalQubit.ancz, logicalQubit.ancx)
+    reset(logicalQubit.ancx)
+    reset(logicalQubit.ancz)
+    return results
+# [End Documentation2]
+
+# [Begin Documentation3]
+@qec.code('py-steane-example')
+class MySteaneCodeImpl:
+    def __init__(self, **kwargs):
+        qec.Code.__init__(self, **kwargs)
+
+        # Define stabilizer generators
+        stabilizers_str = [
+            "XXXXIII", "IXXIXXI", "IIXXIXX",
+            "ZZZZIII", "IZZIZZI", "IIZZIZZ"
+        ]
+        self.stabilizers = [
+            cudaq.SpinOperator.from_word(s) for s in stabilizers_str
+        ]
+
+        # Define observables
+        obs_str = ["IIIIXXX", "IIIIZZZ"]
+        self.pauli_observables = [
+            cudaq.SpinOperator.from_word(p) for p in obs_str
+        ]
+
+        # Register quantum kernels
+        self.operation_encodings = {
+            qec.operation.prep0: prep0,
+            qec.operation.stabilizer_round: stabilizer
+        }
+
+    def get_num_data_qubits(self):
+        return 7
+
+    def get_num_ancilla_x_qubits(self):
+        return 3
+
+    def get_num_ancilla_z_qubits(self):
+        return 3
+
+    def get_num_ancilla_qubits(self):
+        return 6
+
+    def get_num_x_stabilizers(self):
+        return 3
+
+    def get_num_z_stabilizers(self):
+        return 3
+# [End Documentation3]

--- a/docs/sphinx/examples/qec/python/my_steane_test.py
+++ b/docs/sphinx/examples/qec/python/my_steane_test.py
@@ -1,0 +1,19 @@
+# ============================================================================ #
+# Copyright (c) 2025 NVIDIA Corporation & Affiliates.                          #
+# All rights reserved.                                                         #
+#                                                                              #
+# This source code and the accompanying materials are made available under     #
+# the terms of the Apache License 2.0 which accompanies this distribution.     #
+# ============================================================================ #
+
+# [Begin Documentation]
+import cudaq_qec as qec
+# Either import your code directly (e.g. "import my_steane", assuming
+# your my_steane.py file is in the same directory), or you can paste the
+# above code here without importing the file.
+import my_steane
+
+# Create instance of your code
+code = qec.get_code('py-steane-example')
+
+# Use the code for various numerical experiments


### PR DESCRIPTION
Fixes #246 

Also moves code to standalone files so that CI will run them to validate them.