### PR TITLE
Fix address sanitizer issue

### DIFF
--- a/libs/core/lib/tensor_impls/xtensor_impl.cpp
+++ b/libs/core/lib/tensor_impls/xtensor_impl.cpp
@@ -97,7 +97,7 @@ public:
     auto size = std::accumulate(shape.begin(), shape.end(), 1,
                                 std::multiplies<size_t>());
     if (m_data)
-      std::free(m_data);
+      delete[] m_data;
 
     m_data = new Scalar[size];
     std::copy(d, d + size, m_data);
@@ -306,7 +306,7 @@ public:
   /// @brief Destructor for xtensor
   ~xtensor() {
     if (ownsData)
-      delete m_data;
+      delete[] m_data;
   }
 };
 


### PR DESCRIPTION
Worked this with @cketcham2333 ...

Prior to this change, if I compile `test_core` with address sanitization support, I got these errors below. And after this PR, these errors go away. It's unclear if these errors would impact us under normal conditions or not because normally `Scalar` is a primitive type that does not have a destructor.

```
[root@7f73dd4d39b8 build (main *)]# /workspaces/cudaqx/build/libs/core/unittests/test_core
Running main() from /workspaces/cudaqx/build/_deps/googletest-src/googletest/src/gtest_main.cc
[==========] Running 60 tests from 5 test suites.
[----------] Global test environment set-up.
[----------] 3 tests from CoreTester
[ RUN      ] CoreTester.checkSimpleExtensionPoint
[       OK ] CoreTester.checkSimpleExtensionPoint (0 ms)
[ RUN      ] CoreTester.checkSimpleExtensionPointWithArgs
[       OK ] CoreTester.checkSimpleExtensionPointWithArgs (0 ms)
[ RUN      ] CoreTester.checkTensorSimple
=================================================================
==2245907==ERROR: AddressSanitizer: alloc-dealloc-mismatch (operator new [] vs operator delete) on 0x603000002260
    #0 0x787578f2e24f in operator delete(void*, unsigned long) ../../../../src/libsanitizer/asan/asan_new_delete.cpp:172
    #1 0x588d9cd2e053 in cudaqx::xtensor<std::complex<double> >::~xtensor() /workspaces/cudaqx/libs/core/lib/tensor_impls/xtensor_impl.cpp:309
    #2 0x588d9cd2e08f in cudaqx::xtensor<std::complex<double> >::~xtensor() /workspaces/cudaqx/libs/core/lib/tensor_impls/xtensor_impl.cpp:310
    #3 0x588d9cd014cc in std::_Sp_counted_ptr<cudaqx::details::tensor_impl<std::complex<double> >*, (__gnu_cxx::_Lock_policy)2>::_M_dispose() (/workspaces/cudaqx/build/libs/core/unittests/test_core+0x1154cc)
    #4 0x588d9cca8baf in std::_Sp_counted_base<(__gnu_cxx::_Lock_policy)2>::_M_release() (/workspaces/cudaqx/build/libs/core/unittests/test_core+0xbcbaf)
    #5 0x588d9cc8b953 in std::__shared_count<(__gnu_cxx::_Lock_policy)2>::~__shared_count() (/workspaces/cudaqx/build/libs/core/unittests/test_core+0x9f953)
    #6 0x588d9cc882db in std::__shared_ptr<cudaqx::details::tensor_impl<std::complex<double> >, (__gnu_cxx::_Lock_policy)2>::~__shared_ptr() (/workspaces/cudaqx/build/libs/core/unittests/test_core+0x9c2db)
    #7 0x588d9cc882fb in std::shared_ptr<cudaqx::details::tensor_impl<std::complex<double> > >::~shared_ptr() (/workspaces/cudaqx/build/libs/core/unittests/test_core+0x9c2fb)
    #8 0x588d9cc8831b in cudaqx::tensor<std::complex<double> >::~tensor() (/workspaces/cudaqx/build/libs/core/unittests/test_core+0x9c31b)
    #9 0x588d9cc1430b in CoreTester_checkTensorSimple_Test::TestBody() /workspaces/cudaqx/libs/core/unittests/test_core.cpp:184
    #10 0x588d9ce540a6 in void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /workspaces/cudaqx/build/_deps/googletest-src/googletest/src/gtest.cc:2664
    #11 0x588d9ce4bed4 in void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /workspaces/cudaqx/build/_deps/googletest-src/googletest/src/gtest.cc:2700
    #12 0x588d9ce24321 in testing::Test::Run() /workspaces/cudaqx/build/_deps/googletest-src/googletest/src/gtest.cc:2739
    #13 0x588d9ce24db1 in testing::TestInfo::Run() /workspaces/cudaqx/build/_deps/googletest-src/googletest/src/gtest.cc:2885
    #14 0x588d9ce2575e in testing::TestSuite::Run() /workspaces/cudaqx/build/_deps/googletest-src/googletest/src/gtest.cc:3063
    #15 0x588d9ce3671b in testing::internal::UnitTestImpl::RunAllTests() /workspaces/cudaqx/build/_deps/googletest-src/googletest/src/gtest.cc:6054
    #16 0x588d9ce550b1 in bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /workspaces/cudaqx/build/_deps/googletest-src/googletest/src/gtest.cc:2664
    #17 0x588d9ce4d264 in bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /workspaces/cudaqx/build/_deps/googletest-src/googletest/src/gtest.cc:2700
    #18 0x588d9ce3483b in testing::UnitTest::Run() /workspaces/cudaqx/build/_deps/googletest-src/googletest/src/gtest.cc:5594
    #19 0x588d9cd03d3d in RUN_ALL_TESTS() /workspaces/cudaqx/build/_deps/googletest-src/googletest/include/gtest/gtest.h:2334
    #20 0x588d9cd03cb6 in main /workspaces/cudaqx/build/_deps/googletest-src/googletest/src/gtest_main.cc:64
    #21 0x787578942d8f in __libc_start_call_main ../sysdeps/nptl/libc_start_call_main.h:58
    #22 0x787578942e3f in __libc_start_main_impl ../csu/libc-start.c:392
    #23 0x588d9cc0cd04 in _start (/workspaces/cudaqx/build/libs/core/unittests/test_core+0x20d04)

0x603000002260 is located 0 bytes inside of 32-byte region [0x603000002260,0x603000002280)
allocated by thread T0 here:
    #0 0x787578f2d357 in operator new[](unsigned long) ../../../../src/libsanitizer/asan/asan_new_delete.cpp:102
    #1 0x588d9ccae724 in cudaqx::details::tensor_impl<std::complex<double> >::get(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::vector<unsigned long, std::allocator<unsigned long> > const&) (/workspaces/cudaqx/build/libs/core/unittests/test_core+0xc2724)
    #2 0x588d9cc90d94 in cudaqx::tensor<std::complex<double> >::tensor(std::vector<unsigned long, std::allocator<unsigned long> > const&) (/workspaces/cudaqx/build/libs/core/unittests/test_core+0xa4d94)
    #3 0x588d9cc1324c in CoreTester_checkTensorSimple_Test::TestBody() /workspaces/cudaqx/libs/core/unittests/test_core.cpp:172
    #4 0x588d9ce540a6 in void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /workspaces/cudaqx/build/_deps/googletest-src/googletest/src/gtest.cc:2664
    #5 0x588d9ce4bed4 in void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /workspaces/cudaqx/build/_deps/googletest-src/googletest/src/gtest.cc:2700
    #6 0x588d9ce24321 in testing::Test::Run() /workspaces/cudaqx/build/_deps/googletest-src/googletest/src/gtest.cc:2739
    #7 0x588d9ce24db1 in testing::TestInfo::Run() /workspaces/cudaqx/build/_deps/googletest-src/googletest/src/gtest.cc:2885
    #8 0x588d9ce2575e in testing::TestSuite::Run() /workspaces/cudaqx/build/_deps/googletest-src/googletest/src/gtest.cc:3063
    #9 0x588d9ce3671b in testing::internal::UnitTestImpl::RunAllTests() /workspaces/cudaqx/build/_deps/googletest-src/googletest/src/gtest.cc:6054
    #10 0x588d9ce550b1 in bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /workspaces/cudaqx/build/_deps/googletest-src/googletest/src/gtest.cc:2664
    #11 0x588d9ce4d264 in bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /workspaces/cudaqx/build/_deps/googletest-src/googletest/src/gtest.cc:2700
    #12 0x588d9ce3483b in testing::UnitTest::Run() /workspaces/cudaqx/build/_deps/googletest-src/googletest/src/gtest.cc:5594
    #13 0x588d9cd03d3d in RUN_ALL_TESTS() /workspaces/cudaqx/build/_deps/googletest-src/googletest/include/gtest/gtest.h:2334
    #14 0x588d9cd03cb6 in main /workspaces/cudaqx/build/_deps/googletest-src/googletest/src/gtest_main.cc:64
    #15 0x787578942d8f in __libc_start_call_main ../sysdeps/nptl/libc_start_call_main.h:58

SUMMARY: AddressSanitizer: alloc-dealloc-mismatch ../../../../src/libsanitizer/asan/asan_new_delete.cpp:172 in operator delete(void*, unsigned long)
==2245907==HINT: if you don't care about these errors you may set ASAN_OPTIONS=alloc_dealloc_mismatch=0
==2245907==ABORTING
```