### PR TITLE
Don't throw error if optional TRT dependencies are not installed

### DIFF
--- a/libs/qec/lib/decoder.cpp
+++ b/libs/qec/lib/decoder.cpp
@@ -119,7 +119,10 @@ decoder::get(const std::string &name, const cudaqx::tensor<uint8_t> &H,
   auto &registry = get_registry();
   auto iter = registry.find(name);
   if (iter == registry.end())
-    throw std::runtime_error("invalid decoder requested: " + name);
+    throw std::runtime_error(
+        "invalid decoder requested: " + name +
+        ". Run with CUDAQ_LOG_LEVEL=info (environment variable) to see "
+        "additional plugin diagnostics at startup.");
   return iter->second(H, param_map);
 }
 

--- a/libs/qec/lib/plugin_loader.cpp
+++ b/libs/qec/lib/plugin_loader.cpp
@@ -7,6 +7,7 @@
  ******************************************************************************/
 
 #include "cudaq/qec/plugin_loader.h"
+#include "common/Logger.h"
 #include <filesystem>
 #include <iostream>
 
@@ -43,9 +44,14 @@ void load_plugins(const std::string &plugin_dir, PluginType type) {
             PluginHandle{std::unique_ptr<void, PluginDeleter>(raw_handle,
                                                               PluginDeleter()),
                          type});
+        CUDAQ_INFO("Successfully loaded plugin: {}", entry.path().string());
       } else {
-        std::cerr << "ERROR: Failed to load plugin: " << entry.path()
-                  << " Error: " << dlerror() << std::endl;
+        // The TRT decoder is an optional decoder that is not always available.
+        // Do not clutter up the console with error messages if it is not
+        // available. We only output an error message if info logging is
+        // enabled.
+        CUDAQ_INFO("Failed to load plugin {} Error: {}. Continuing anyway.",
+                   entry.path().string(), dlerror());
       }
     }
   }


### PR DESCRIPTION
Prior to this change, with the typical default installation of CUDA-Q QEC (i.e. `pip install cudaq-qec`), the addition of the TRT decoder would've caused error messages like this on every `import cudaq_qec as qec`.
```bash
ERROR: Failed to load plugin: "/__w/_tool/Python/3.11.14/arm64/lib/python3.11/site-packages/cudaq_qec/lib/decoder-plugins/libcudaq-qec-trt-decoder.so" Error: libnvinfer.so.10: cannot open shared object file: No such file or directory
```
This is strongly undesirable, so these changes silence the corresponding error message unless users are running with `CUDAQ_LOG_LEVEL=info`. Additionally, if a user calls `get_decoder` for a decoder that doesn't exist, we now tell them that they can run with `CUDAQ_LOG_LEVEL=info` to get more details.
