### PR TITLE
Update test scripts to allow easy data generation

### DIFF
--- a/libs/qec/unittests/realtime/app_examples/CMakeLists.txt
+++ b/libs/qec/unittests/realtime/app_examples/CMakeLists.txt
@@ -7,6 +7,15 @@
 # ============================================================================ #
 
 #------------------------------------------------------------------------------#
+# Maintenance note: to generate QIR files and corresponding config files for
+# Quantinuum, you may manually run tests like the following:
+#    CUDAQ_DUMP_JIT_IR=1 KEEP_LOG_FILES=1 ctest -R quantinuum
+# The resulting files will be in:
+#    build/libs/qec/unittests/realtime/app_examples/config-*.yml
+#    build/libs/qec/unittests/realtime/app_examples/qir-*.ll
+#------------------------------------------------------------------------------#
+
+#------------------------------------------------------------------------------#
 # Surface code 1, fully local, regular Stim simulator
 add_executable(surface_code-1-local)
 

--- a/libs/qec/unittests/realtime/app_examples/surface_code-2-test.sh
+++ b/libs/qec/unittests/realtime/app_examples/surface_code-2-test.sh
@@ -42,6 +42,8 @@ NUM_SHOTS=1000
 # Get timestamp suffix in YYYY-MM-DD-HH-MM-SS, with random number appended using /dev/urandom.
 timestamp=$(date +%Y-%m-%d-%H-%M-%S)
 RNG_SUFFIX=$(od -An -N4 -i /dev/urandom | tr -d ' ')
+# Remove any negative sign.
+RNG_SUFFIX=$(echo $RNG_SUFFIX | sed 's/-//g')
 FULL_SUFFIX=$timestamp-$RNG_SUFFIX
 
 CONFIG_FILE=config-${FULL_SUFFIX}.yml
@@ -66,6 +68,14 @@ export CUDAQ_DUMP_JIT_IR=${CUDAQ_DUMP_JIT_IR:-0}
 echo Running $EXE_PATH2 --distance $DISTANCE --num_shots $NUM_SHOTS --load_dem $CONFIG_FILE
 $EXE_PATH2 --distance $DISTANCE --num_shots $NUM_SHOTS --load_dem $CONFIG_FILE |& tee load_dem-$FULL_SUFFIX.log
 
+# If CUDAQ_DUMP_JIT_IR is "1", then extract the QIR from the
+# load_dem-$FULL_SUFFIX.log file and place it in qir-$FULL_SUFFIX.ll.
+if [[ "${CUDAQ_DUMP_JIT_IR}" == "1" ]]; then
+  # The QIR starts with "ModuleID" and ends with "backwards_branching"
+  QIR=$(sed -n '/ModuleID/,/backwards_branching/p' load_dem-$FULL_SUFFIX.log)
+  echo "Writing QIR to qir-$FULL_SUFFIX.ll"
+  echo "$QIR" > qir-$FULL_SUFFIX.ll
+fi
 
 # Look for results like this in the output:
 # Number of non-zero values measured : 2

--- a/libs/qec/unittests/realtime/app_examples/surface_code-3-test.sh
+++ b/libs/qec/unittests/realtime/app_examples/surface_code-3-test.sh
@@ -43,6 +43,8 @@ NUM_SHOTS=1000
 # Get timestamp suffix in YYYY-MM-DD-HH-MM-SS, with random number appended using /dev/urandom.
 timestamp=$(date +%Y-%m-%d-%H-%M-%S)
 RNG_SUFFIX=$(od -An -N4 -i /dev/urandom | tr -d ' ')
+# Remove any negative sign.
+RNG_SUFFIX=$(echo $RNG_SUFFIX | sed 's/-//g')
 FULL_SUFFIX=$timestamp-$RNG_SUFFIX
 
 CONFIG_FILE=config-${FULL_SUFFIX}.yml
@@ -66,6 +68,14 @@ export CUDAQ_DUMP_JIT_IR=${CUDAQ_DUMP_JIT_IR:-0}
 echo Running $EXE_PATH2 --distance $DISTANCE --num_shots $NUM_SHOTS --load_dem $CONFIG_FILE
 $EXE_PATH2 --distance $DISTANCE --num_shots $NUM_SHOTS --load_dem $CONFIG_FILE  --p_spam $ERROR_RATE --state_prep $STATE_PREP  |& tee load_dem-$FULL_SUFFIX.log
 
+# If CUDAQ_DUMP_JIT_IR is "1", then extract the QIR from the
+# load_dem-$FULL_SUFFIX.log file and place it in qir-$FULL_SUFFIX.ll.
+if [[ "${CUDAQ_DUMP_JIT_IR}" == "1" ]]; then
+  # The QIR starts with "ModuleID" and ends with "backwards_branching"
+  QIR=$(sed -n '/ModuleID/,/backwards_branching/p' load_dem-$FULL_SUFFIX.log)
+  echo "Writing QIR to qir-$FULL_SUFFIX.ll"
+  echo "$QIR" > qir-$FULL_SUFFIX.ll
+fi
 
 # ------------------------------------------------------------------------------
 # Validation of decoder results using mismatch percentage:


### PR DESCRIPTION
This PR allows us to easily capture QIR data and config file data from our existing CMake tests. This is useful to be able to provide some regression test data to Quantinuum.