### PR TITLE
Add license agreement notification to Docker image

### DIFF
--- a/docker/release/Dockerfile
+++ b/docker/release/Dockerfile
@@ -27,6 +27,11 @@ ARG TARGETARCH
 
 USER root
 
+# Update the copyright notification:
+RUN echo -e "This container also includes CUDA-Q QEC and CUDA-Q Solvers.\n"\
+"Use of this container implies consent to the NVIDIA Software License agreement at\n"\
+"https://github.com/NVIDIA/cudaqx/blob/main/libs/qec/LICENSE\n" >> "$CUDA_QUANTUM_PATH/Copyright.txt"
+
 # Determine the appropriate zip file
 COPY installed_files-${TARGETARCH}.zip /tmp/
 


### PR DESCRIPTION
I did local testing of this change with this:
```bash
$ cat cudaq.Dockerfile
FROM nvcr.io/nvidia/nightly/cuda-quantum:cu12-0.13.0

USER root
RUN echo -e "This container also includes CUDA-Q QEC and CUDA-Q Solvers.\n"\
"Use of this container implies consent to the NVIDIA Software License agreement at\n"\
"https://github.com/NVIDIA/cudaqx/blob/main/libs/qec/LICENSE\n" >> "$CUDA_QUANTUM_PATH/Copyright.txt"
USER cudaq

$ docker run -it --name bhowe-temp --rm bhowe-test-image
=========================
      NVIDIA CUDA-Q
=========================

Version: amd64-cu12-0.13.0

Copyright (c) 2025 NVIDIA Corporation & Affiliates
All rights reserved.

To run a command as administrator (user `root`), use `sudo <command>`.


This container also includes CUDA-Q QEC and CUDA-Q Solvers.
Use of this container implies consent to the NVIDIA Software License agreement at
https://github.com/NVIDIA/cudaqx/blob/main/libs/qec/LICENSE

cudaq@7cf299bcd0cb:~$
```