### PR TITLE
Fix the build error in target cudaq-qec-realtime-decoding and test_trt_decoder

### DIFF
--- a/libs/qec/include/cudaq/qec/realtime/decoding_config.h
+++ b/libs/qec/include/cudaq/qec/realtime/decoding_config.h
@@ -9,6 +9,7 @@
 #pragma once
 
 #include "cuda-qx/core/heterogeneous_map.h"
+#include <cstdint>
 #include <optional>
 #include <string>
 #include <variant>

--- a/libs/qec/unittests/CMakeLists.txt
+++ b/libs/qec/unittests/CMakeLists.txt
@@ -64,6 +64,7 @@ if(CUDAQ_QEC_BUILD_TRT_DECODER AND CMAKE_SYSTEM_PROCESSOR MATCHES "(x86_64)|(AMD
   )
 
   target_include_directories(test_trt_decoder PRIVATE
+      ${TENSORRT_INCLUDE_DIR}
       ${CUDAToolkit_INCLUDE_DIRS}
   )
 


### PR DESCRIPTION
[Bug 5699017](https://nvbugs/5699017) [CUDA-QX] Fix the build error in target cudaq-qec-realtime-decoding and test_trt_decoder