### PR TITLE
[uccsd/uccgsd] Update test tolerances

### DIFF
--- a/libs/solvers/python/tests/test_uccgsd.py
+++ b/libs/solvers/python/tests/test_uccgsd.py
@@ -68,7 +68,9 @@ def test_solvers_adapt_uccgsd_lih():
                                             operators)
 
     print(energy)
-    assert np.isclose(energy, -7.8638, atol=1e-4)
+    # Tolerance of 1e-4 was good enough most of the time, but a PySCF
+    # non-repeatability sometimes makes this fail w/ 1e-4, so we make it 1e-3.
+    assert np.isclose(energy, -7.8638, atol=1e-3)
 
 
 def test_solvers_adapt_uccgsd_N2():

--- a/libs/solvers/python/tests/test_uccsd.py
+++ b/libs/solvers/python/tests/test_uccsd.py
@@ -1,5 +1,5 @@
 # ============================================================================ #
-# Copyright (c) 2024 NVIDIA Corporation & Affiliates.                          #
+# Copyright (c) 2024 - 2025 NVIDIA Corporation & Affiliates.                   #
 # All rights reserved.                                                         #
 #                                                                              #
 # This source code and the accompanying materials are made available under     #
@@ -172,7 +172,10 @@ def test_uccsd_loops():
         repro_trial_state(repro_qubits, repro_num_electrons, repro_thetas)
 
     counts = cudaq.sample(repro, shots_count=1000)
-    assert len(counts) == 6
+    # There are normally 6 possible outcomes, but a PySCF non-repeatability
+    # sometimes makes this fail by producing more than 6 outcomes, so we do not
+    # check the length of the counts.
+    # assert len(counts) == 6
     assert '00000011' in counts
     assert '00000110' in counts
     assert '00010010' in counts


### PR DESCRIPTION
Updating to address non-repeatable tests:

https://github.com/NVIDIA/cudaqx/actions/runs/19416074410/job/55545607521#step:12:6541
```
FAILED libs/solvers/python/tests/test_uccgsd.py::test_solvers_adapt_uccgsd_lih - assert np.False_
 +  where np.False_ = <function isclose at 0x7d33747471f0>(-7.8636041028194565, -7.8638, atol=0.0001)
 +    where <function isclose at 0x7d33747471f0> = np.isclose
```

https://github.com/NVIDIA/cudaqx/actions/runs/19485800654/job/55767775297?pr=344#step:14:129
```
FAILED ../libs/solvers/python/tests/test_uccsd.py::test_uccsd_loops - assert 7 == 6
```