### PR TITLE
docs: Remove CEO and UpCCGSD documentation

### DIFF
--- a/docs/sphinx/api/solvers/cpp_api.rst
+++ b/docs/sphinx/api/solvers/cpp_api.rst
@@ -7,8 +7,6 @@ CUDA-Q Solvers C++ API
 .. doxygenclass:: cudaq::solvers::spin_complement_gsd 
 .. doxygenclass:: cudaq::solvers::uccsd 
 .. doxygenclass:: cudaq::solvers::uccgsd 
-.. doxygenclass:: cudaq::solvers::ceo 
-.. doxygenclass:: cudaq::solvers::upccgsd
 
 .. doxygenclass:: cudaq::solvers::qaoa_pool 
 
@@ -73,10 +71,6 @@ CUDA-Q Solvers C++ API
 .. doxygenfunction:: cudaq::solvers::stateprep::uccsd(cudaq::qview<>, const std::vector<double>&, std::size_t)
 .. doxygenfunction:: cudaq::solvers::stateprep::get_uccgsd_pauli_lists
 .. doxygenfunction:: cudaq::solvers::stateprep::uccgsd(cudaq::qview<>, const std::vector<double>&, const std::vector<std::vector<cudaq::pauli_word>>&, const std::vector<std::vector<double>>&)
-.. doxygenfunction:: cudaq::solvers::stateprep::get_ceo_pauli_lists
-.. doxygenfunction:: cudaq::solvers::stateprep::ceo
-.. doxygenfunction:: cudaq::solvers::stateprep::get_upccgsd_pauli_lists
-.. doxygenfunction:: cudaq::solvers::stateprep::upccgsd(cudaq::qview<>, const std::vector<double>&, const std::vector<std::vector<cudaq::pauli_word>>&, const std::vector<std::vector<double>>&)
 
 
 .. doxygenstruct:: cudaq::solvers::qaoa_result

--- a/docs/sphinx/api/solvers/python_api.rst
+++ b/docs/sphinx/api/solvers/python_api.rst
@@ -28,10 +28,8 @@ CUDA-Q Solvers Python API
 .. autofunction:: cudaq_solvers.stateprep.get_num_uccsd_parameters
 .. autofunction:: cudaq_solvers.stateprep.get_uccsd_excitations    
 .. autofunction:: cudaq_solvers.stateprep.get_uccgsd_pauli_lists
-.. autofunction:: cudaq_solvers.stateprep.get_upccgsd_pauli_lists
 
 .. autofunction:: cudaq_solvers.stateprep.uccgsd
-.. autofunction:: cudaq_solvers.stateprep.upccgsd
 
 
 .. autofunction:: cudaq_solvers.get_num_qaoa_parameters

--- a/docs/sphinx/components/solvers/introduction.rst
+++ b/docs/sphinx/components/solvers/introduction.rst
@@ -495,8 +495,8 @@ CUDA-QX provides several pre-built operator pools for ADAPT-VQE:
 * **spin_complement_gsd**: Spin-complemented generalized singles and doubles.
     This operator pool combines generalized excitations with enforced spin symmetry. It is 
     more powerful than UCCSD because its generalized operators capture more electron correlation,
-     and it is more reliable than both UCCSD and UCCGSD because its spin-complemented 
-     construction prevents the unphysical "spin-symmetry breaking".
+    and it is more reliable than both UCCSD and UCCGSD because its spin-complemented 
+    construction prevents the unphysical "spin-symmetry breaking".
 * **uccsd**: UCCSD operators. 
     The standard, chemically-inspired ansatz. Excitation Space 
     is Restricted. It only includes single and double excitations 
@@ -509,18 +509,6 @@ CUDA-QX provides several pre-built operator pools for ADAPT-VQE:
     single and double excitations, regardless of their occupied/virtual status in the reference state.
     Capable of capturing both dynamic and static (strong) correlation
     but at the cost of increased circuit depth and parameter count.
-* **ceo**: CEO (Coupled Exchange Operator) pool.
-    This pool is based on qubit excitation operators, which preserve the particle number and 
-    Sz quantum numbers, but are not antisymmetric, which reduces their implementation cost 
-    compared to UCCGSD excitation operators. In CEO, the qubit excitation operators are 
-    combined to reduce the circuit implementation cost. It uses generalized qubit excitations
-    that are spin-dependent. See the CEO paper (https://arxiv.org/abs/2407.08696) for more details.
-* **upccgsd**: UCC generalized singles and paired doubles.
-    A structured, lower-depth variant of UCCGSD in which double excitations are restricted to paired electron 
-    transfers between spatial orbitals, following the UpCC (pair-cluster) construction.
-    While less expressive than full UCCGSD, it retains generalized spin-preserving singles 
-    and the most physically relevant pair-correlation channels, substantially reducing circuit depth and parameter count.
-    This makes UpCCGSD attractive for larger systems or hardware-constrained regimes where UCCGSD is too costly.
 * **qaoa**: QAOA mixer excitation operators
     It generates all possible single-qubit X and Y terms, along with all possible 
     two-qubit interaction terms (XX, YY, XY, YX, XZ, ZX, YZ, ZY) across every pair of qubits. 
@@ -549,15 +537,6 @@ CUDA-QX provides several pre-built operator pools for ADAPT-VQE:
         "uccgsd",
         num_orbitals=molecule.n_orbitals
     )
-    upccgsd_ops = solvers.get_operator_pool(
-        "upccgsd",                      
-        num_orbitals=molecule.n_orbitals
-)
-
-    ceo_ops = solvers.get_operator_pool(
-        "ceo",
-        num_orbitals=molecule.n_orbitals
-    )
 
 Available Ansatz
 ^^^^^^^^^^^^^^^^^^
@@ -566,8 +545,6 @@ CUDA-QX provides several state preparations ansatz for VQE.
 
 * **uccsd**: UCCSD operators
 * **uccgsd**: UCC generalized singles and doubles
-* **ceo**: CEO (Coupled Exchange Operator) ansatz
-* **upccgsd**: UCC generalized singles and paired doubles
 
 .. code-block:: python
 
@@ -609,48 +586,6 @@ CUDA-QX provides several state preparations ansatz for VQE.
             x(q[i])
         solvers.stateprep.uccgsd(q, thetas, pauliWordsList, coefficientsList)
     
-    # Using UpCCGSD ansatz
-    geometry = [('H', (0., 0., 0.)), ('H', (0., 0., .7474))]
-    molecule = solvers.create_molecule(geometry, 'sto-3g', 0, 0, casci=True)
-
-    numQubits = molecule.n_orbitals * 2
-    numElectrons = molecule.n_electrons
-
-    # Get grouped Pauli words and coefficients from UpCCGSD pool
-    pauliWordsList, coefficientsList = solvers.stateprep.get_upccgsd_pauli_lists(
-        numQubits, only_doubles=False)
-    
-    @cudaq.kernel
-    def ansatz(numQubits: int, numElectrons: int, thetas: list[float],
-               pauliWordsList: list[list[cudaq.pauli_word]],
-               coefficientsList: list[list[float]]):
-        q = cudaq.qvector(numQubits)
-        for i in range(numElectrons):
-            x(q[i])
-        solvers.stateprep.upccgsd(q, thetas, pauliWordsList, coefficientsList)
-
-    
-    # Using CEO ansatz
-    geometry = [('H', (0., 0., 0.)), ('H', (0., 0., .7474))]
-    molecule = solvers.create_molecule(geometry, 'sto-3g', 0, 0, casci=True)
-
-    numOrbitals = molecule.n_orbitals
-    numQubits = 2 * numOrbitals
-    numElectrons = molecule.n_electrons
-
-    # Get grouped Pauli words and coefficients from CEO pool
-    pauliWordsList, coefficientsList = solvers.stateprep.get_ceo_pauli_lists(numOrbitals)
-    
-    @cudaq.kernel
-    def ansatz(numQubits: int, numElectrons: int, thetas: list[float],
-               pauliWordsList: list[list[cudaq.pauli_word]],
-               coefficientsList: list[list[float]]):
-        q = cudaq.qvector(numQubits)
-        for i in range(numElectrons):
-            x(q[i])
-        solvers.stateprep.ceo(q, thetas, pauliWordsList, coefficientsList)
-
-
 Algorithm Parameters
 ^^^^^^^^^^^^^^^^^^^^^^
 


### PR DESCRIPTION
Remove all documentation references for CEO (Coupled Exchange Operator) and UpCCGSD (Unitary Paired CCGSD) operator pools and ansatz from the Solvers component documentation.

Changes:
- Remove CEO and UpCCGSD from C++ API documentation (cpp_api.rst)
- Remove UpCCGSD from Python API documentation (python_api.rst)
- Remove CEO and UpCCGSD operator pool descriptions from introduction
- Remove CEO and UpCCGSD ansatz code examples from introduction
- Fix indentation error in spin_complement_gsd description

The underlying C++ implementations remain in the codebase but are no longer documented in the user-facing API reference.

Files modified:
- docs/sphinx/api/solvers/cpp_api.rst (6 lines removed)
- docs/sphinx/api/solvers/python_api.rst (2 lines removed)
- docs/sphinx/components/solvers/introduction.rst (67 lines removed)