### PR TITLE
Redundantly including Logger.h and FmtCore.h includes ahead of runtime refactor.

### DIFF
--- a/libs/qec/lib/decoder.cpp
+++ b/libs/qec/lib/decoder.cpp
@@ -7,6 +7,7 @@
  ******************************************************************************/
 
 #include "cudaq/qec/decoder.h"
+#include "common/FmtCore.h"
 #include "common/Logger.h"
 #include "cuda-qx/core/library_utils.h"
 #include "cudaq/qec/plugin_loader.h"

--- a/libs/qec/lib/decoders/sliding_window.cpp
+++ b/libs/qec/lib/decoders/sliding_window.cpp
@@ -7,6 +7,7 @@
  ******************************************************************************/
 
 #include "sliding_window.h"
+#include "common/FmtCore.h"
 #include "common/Logger.h"
 #include "cudaq/qec/pcm_utils.h"
 #include <cassert>

--- a/libs/qec/lib/realtime/realtime_decoding.cpp
+++ b/libs/qec/lib/realtime/realtime_decoding.cpp
@@ -7,6 +7,7 @@
  ******************************************************************************/
 
 #include "realtime_decoding.h"
+#include "common/FmtCore.h"
 #include "common/Logger.h"
 #include "cudaq/qec/decoder.h"
 #include "cudaq/qec/pcm_utils.h"

--- a/libs/qec/python/bindings/py_decoder.cpp
+++ b/libs/qec/python/bindings/py_decoder.cpp
@@ -6,6 +6,7 @@
  * the terms of the Apache License 2.0 which accompanies this distribution.    *
  ******************************************************************************/
 #include "common/ExecutionContext.h"
+#include "common/FmtCore.h"
 #include "common/Logger.h"
 #include "cudaq/platform.h"
 #include "cudaq/qec/decoder.h"


### PR DESCRIPTION
In https://github.com/NVIDIA/cuda-quantum/pull/3764, `Logger.h` will no longer be including `FmtCore.h`.
These changes explictly include `FmtCore.h`, ahead of  https://github.com/NVIDIA/cuda-quantum/pull/3764 being merged, in order to avoid build issues.
