### PR TITLE
[ci] Update how to get cudaq::realtime

### DIFF
--- a/.github/actions/build-lib/build_all.sh
+++ b/.github/actions/build-lib/build_all.sh
@@ -9,7 +9,23 @@ if [ -z "$CUDAQ_REALTIME_ROOT" ]; then
   cd cuda-quantum
   git sparse-checkout init --cone
   git sparse-checkout set realtime
-  git checkout dc926b6da4dc08d0f1d8208b48aff5dadd773b3e # features/cudaq.realtime
+  git checkout b7eed833133c501a1a655905d1f58a175a0aa749 # features/cudaq.realtime
+  git apply <<'PATCH'
+diff --git a/realtime/lib/daemon/CMakeLists.txt b/realtime/lib/daemon/CMakeLists.txt
+index 2fe4b20092..5bd0e3f22f 100644
+--- a/realtime/lib/daemon/CMakeLists.txt
++++ b/realtime/lib/daemon/CMakeLists.txt
+@@ -68,4 +68,9 @@ if(CUDA_FOUND)
+     POSITION_INDEPENDENT_CODE ON
+     ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib
+   )
++
++  install(TARGETS cudaq-realtime-dispatch
++    COMPONENT realtime-lib
++    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
++  )
+ endif()
+PATCH
   cd realtime
   mkdir build && cd build
   cmake -G Ninja -DCMAKE_INSTALL_PREFIX="$CUDAQ_REALTIME_ROOT" ..

--- a/.github/actions/build-lib/build_qec.sh
+++ b/.github/actions/build-lib/build_qec.sh
@@ -10,7 +10,23 @@ if [ -z "$CUDAQ_REALTIME_ROOT" ]; then
   cd cuda-quantum
   git sparse-checkout init --cone
   git sparse-checkout set realtime
-  git checkout dc926b6da4dc08d0f1d8208b48aff5dadd773b3e # features/cudaq.realtime
+  git checkout b7eed833133c501a1a655905d1f58a175a0aa749 # features/cudaq.realtime
+  git apply <<'PATCH'
+diff --git a/realtime/lib/daemon/CMakeLists.txt b/realtime/lib/daemon/CMakeLists.txt
+index 2fe4b20092..5bd0e3f22f 100644
+--- a/realtime/lib/daemon/CMakeLists.txt
++++ b/realtime/lib/daemon/CMakeLists.txt
+@@ -68,4 +68,9 @@ if(CUDA_FOUND)
+     POSITION_INDEPENDENT_CODE ON
+     ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib
+   )
++
++  install(TARGETS cudaq-realtime-dispatch
++    COMPONENT realtime-lib
++    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
++  )
+ endif()
+PATCH
   cd realtime
   mkdir build && cd build
   cmake -G Ninja -DCMAKE_INSTALL_PREFIX="$CUDAQ_REALTIME_ROOT" ..

--- a/.github/workflows/pr_workflow.yaml
+++ b/.github/workflows/pr_workflow.yaml
@@ -52,7 +52,6 @@ jobs:
               - '**/*.py'
             build-all:
               - '.github/actions/build-lib/action.yaml'
-              - '.github/actions/build-lib/build_all.sh'
               - '.github/actions/build-lib/build_all.yaml'
               - '.github/workflows/all_libs.yaml'
               - 'cmake/Modules/**'


### PR DESCRIPTION
This is a minor CI update to build cudaq::realtime from source rather than having private binaries in a GitHub draft release.