### PR TITLE
Fix GQE invalid CUDA handle / AcceleratorError when moving model to GPU

### DIFF
--- a/libs/solvers/python/cudaq_solvers/gqe_algorithm/gqe.py
+++ b/libs/solvers/python/cudaq_solvers/gqe_algorithm/gqe.py
@@ -377,6 +377,9 @@ def gqe(cost, pool, config=None, **kwargs):
 
     # Don't let someone override the vocab_size
     cfg.vocab_size = len(pool)
+    if torch.cuda.is_available():
+        torch.cuda.init()
+        torch.empty(1, device="cuda")
     cudaqTarget = cudaq.get_target()
     numQPUs = cudaqTarget.num_qpus()
     model = Transformer(


### PR DESCRIPTION
This PR resolves cudaErrorInvalidResourceHandle / torch.AcceleratorError when running GQE on GPU (e.g. GPT2LMHeadModel(...).to("cuda")) by initializing PyTorch’s CUDA stack and performing a minimal GPU allocation before building the transformer, instead of relying on `conftest.py` preloads and bundled libcudart symlinks.

This should fix https://nvbugspro.nvidia.com/bug/5801752
