### PR TITLE
Align CUDA-Q and CUDA-Q Realtime commits for 0.14.1

### DIFF
--- a/.cudaq_realtime_version
+++ b/.cudaq_realtime_version
@@ -1,6 +1,6 @@
 {
   "cudaq_realtime": {
     "repository": "NVIDIA/cuda-quantum",
-    "ref": "3bb10bc436b070a54a5e6dae75184315527b2a67"
+    "ref": "12dff9c0b6b4d03610a875cef89f2e566c65ffc5"
   }
 }

--- a/.cudaq_version
+++ b/.cudaq_version
@@ -1,6 +1,6 @@
 {
   "cudaq": {
     "repository": "NVIDIA/cuda-quantum",
-    "ref": "d84568366c3f9e9a33b3829ff43fb794b3a703ab"
+    "ref": "12dff9c0b6b4d03610a875cef89f2e566c65ffc5"
   }
 }


### PR DESCRIPTION
These commits are TOT from the new https://github.com/NVIDIA/cuda-quantum/tree/releases/v0.14.1 branch.