### PR TITLE
Add CLI override flags and from_name to PipelineConfig

### DIFF
--- a/libs/qec/unittests/realtime/CMakeLists.txt
+++ b/libs/qec/unittests/realtime/CMakeLists.txt
@@ -47,6 +47,7 @@ if(TENSORRT_INCLUDE_DIR AND TENSORRT_LIBRARY AND TENSORRT_ONNX_PARSER_LIBRARY
     ${CMAKE_CURRENT_SOURCE_DIR}/../../include
     ${CMAKE_SOURCE_DIR}/libs/core/include
     ${CUDAQ_REALTIME_INCLUDE_DIR}
+    ${CMAKE_BINARY_DIR}/_deps/json-src/include
   )
 
   target_link_libraries(test_realtime_predecoder_w_pymatching PRIVATE
@@ -124,6 +125,7 @@ if (GPU_ROCE_TRANSCEIVER_LIB AND CUDAQ_REALTIME_INCLUDE_DIR AND
     ${CMAKE_SOURCE_DIR}/libs/core/include
     ${CUDAQ_REALTIME_INCLUDE_DIR}
     ${HOLOSCAN_SENSOR_BRIDGE_SOURCE_DIR}/src
+    ${CMAKE_BINARY_DIR}/_deps/json-src/include
   )
 
   target_link_libraries(hololink_predecoder_bridge PRIVATE

--- a/libs/qec/unittests/realtime/CMakeLists.txt
+++ b/libs/qec/unittests/realtime/CMakeLists.txt
@@ -47,7 +47,6 @@ if(TENSORRT_INCLUDE_DIR AND TENSORRT_LIBRARY AND TENSORRT_ONNX_PARSER_LIBRARY
     ${CMAKE_CURRENT_SOURCE_DIR}/../../include
     ${CMAKE_SOURCE_DIR}/libs/core/include
     ${CUDAQ_REALTIME_INCLUDE_DIR}
-    ${CMAKE_BINARY_DIR}/_deps/json-src/include
   )
 
   target_link_libraries(test_realtime_predecoder_w_pymatching PRIVATE
@@ -125,7 +124,6 @@ if (GPU_ROCE_TRANSCEIVER_LIB AND CUDAQ_REALTIME_INCLUDE_DIR AND
     ${CMAKE_SOURCE_DIR}/libs/core/include
     ${CUDAQ_REALTIME_INCLUDE_DIR}
     ${HOLOSCAN_SENSOR_BRIDGE_SOURCE_DIR}/src
-    ${CMAKE_BINARY_DIR}/_deps/json-src/include
   )
 
   target_link_libraries(hololink_predecoder_bridge PRIVATE

--- a/libs/qec/unittests/realtime/hololink_predecoder_bridge.cpp
+++ b/libs/qec/unittests/realtime/hololink_predecoder_bridge.cpp
@@ -102,26 +102,26 @@ int main(int argc, char *argv[]) {
           << "  --gpu=N               GPU device ID (default: 0)\n"
           << "  --timeout=N           Timeout in seconds (default: 60)\n"
           << "  --page-size=N         Ring buffer slot size (default: auto)\n"
-          << "  --num-pages=N         Ring buffer slots (default: 128)\n";
+          << "  --num-pages=N         Ring buffer slots (default: 128)\n\n"
+          << "Config overrides (applied after --config preset):\n"
+          << "  --distance=N          QEC code distance\n"
+          << "  --num-rounds=N        Syndrome measurement rounds\n"
+          << "  --onnx-filename=FILE  ONNX model filename\n"
+          << "  --num-predecoders=N   Parallel TRT instances\n"
+          << "  --num-workers=N       Pipeline GPU workers\n"
+          << "  --num-decode-workers=N  PyMatching threads\n"
+          << "  --label=NAME          Config label for reports\n";
       return 0;
     }
   }
 
-  PipelineConfig pcfg;
-  if (config_name == "d7")
-    pcfg = PipelineConfig::d7_r7();
-  else if (config_name == "d13")
-    pcfg = PipelineConfig::d13_r13();
-  else if (config_name == "d13_r104")
-    pcfg = PipelineConfig::d13_r104();
-  else if (config_name == "d21")
-    pcfg = PipelineConfig::d21_r21();
-  else if (config_name == "d31")
-    pcfg = PipelineConfig::d31_r31();
-  else {
+  auto pcfg_opt = PipelineConfig::from_name(config_name);
+  if (!pcfg_opt) {
     std::cerr << "ERROR: Unknown config: " << config_name << std::endl;
     return 1;
   }
+  PipelineConfig pcfg = *pcfg_opt;
+  pcfg.apply_cli_overrides(argc, argv);
 
   std::cout << "=== Hololink Predecoder + PyMatching Bridge ===" << std::endl;
   std::cout << "  Config: " << pcfg.label << std::endl;

--- a/libs/qec/unittests/realtime/hololink_predecoder_test.sh
+++ b/libs/qec/unittests/realtime/hololink_predecoder_test.sh
@@ -62,6 +62,9 @@ SPACING=""
 CONTROL_PORT=8193
 NUM_SHOTS=""
 
+# Pipeline config overrides (passed through to bridge binary)
+BRIDGE_OVERRIDES=()
+
 # ============================================================================
 # Argument Parsing
 # ============================================================================
@@ -102,6 +105,15 @@ Run options:
   --spacing N            Inter-shot spacing in microseconds
   --control-port N       Emulator UDP control port (default: 8193)
 
+Pipeline config overrides (applied after --config preset):
+  --distance=N           QEC code distance
+  --num-rounds=N         Syndrome measurement rounds
+  --onnx-filename=FILE   ONNX model filename
+  --num-predecoders=N    Parallel TRT instances
+  --num-workers=N        Pipeline GPU workers
+  --num-decode-workers=N PyMatching threads
+  --label=NAME           Config label for reports
+
   --help, -h             Show this help
 
 BRAM constraints (RAM_DEPTH=512):
@@ -132,6 +144,8 @@ while [[ $# -gt 0 ]]; do
         --num-shots)        NUM_SHOTS="$2"; shift ;;
         --spacing)          SPACING="$2"; shift ;;
         --control-port)     CONTROL_PORT="$2"; shift ;;
+        --distance=*|--num-rounds=*|--onnx-filename=*|--num-predecoders=*|--num-workers=*|--num-decode-workers=*|--label=*)
+            BRIDGE_OVERRIDES+=("$1") ;;
         --help|-h)          print_usage; exit 0 ;;
         *)
             echo "ERROR: Unknown option: $1" >&2
@@ -573,6 +587,7 @@ run_emulated() {
         --timeout="$TIMEOUT" \
         --page-size="$PAGE_SIZE" \
         --num-pages="$NUM_PAGES" \
+        "${BRIDGE_OVERRIDES[@]}" \
         > >(tee "$bridge_log") 2>&1 &
     local bridge_pid=$!
     PIDS_TO_KILL+=("$bridge_pid")
@@ -654,6 +669,7 @@ run_fpga() {
         --timeout="$TIMEOUT" \
         --page-size="$PAGE_SIZE" \
         --num-pages="$NUM_PAGES" \
+        "${BRIDGE_OVERRIDES[@]}" \
         > >(tee "$bridge_log") 2>&1 &
     local bridge_pid=$!
     PIDS_TO_KILL+=("$bridge_pid")

--- a/libs/qec/unittests/realtime/predecoder_pipeline_common.cpp
+++ b/libs/qec/unittests/realtime/predecoder_pipeline_common.cpp
@@ -18,30 +18,6 @@
 #include <iostream>
 #include <stdexcept>
 
-#include <nlohmann/json.hpp>
-
-// =============================================================================
-// PipelineConfig::from_json
-// =============================================================================
-
-PipelineConfig PipelineConfig::from_json(const std::string &json_str) {
-  try {
-    auto j = nlohmann::json::parse(json_str);
-    PipelineConfig cfg;
-    cfg.label = j.value("label", std::string("custom"));
-    cfg.distance = j.at("distance").get<int>();
-    cfg.num_rounds = j.at("num_rounds").get<int>();
-    cfg.onnx_filename = j.at("onnx_filename").get<std::string>();
-    cfg.num_predecoders = j.at("num_predecoders").get<int>();
-    cfg.num_workers = j.at("num_workers").get<int>();
-    cfg.num_decode_workers = j.at("num_decode_workers").get<int>();
-    return cfg;
-  } catch (const nlohmann::json::exception &e) {
-    throw std::runtime_error(std::string("PipelineConfig JSON error: ") +
-                             e.what());
-  }
-}
-
 // =============================================================================
 // PipelineConfig::from_name
 // =============================================================================

--- a/libs/qec/unittests/realtime/predecoder_pipeline_common.cpp
+++ b/libs/qec/unittests/realtime/predecoder_pipeline_common.cpp
@@ -16,6 +16,79 @@
 
 #include <fstream>
 #include <iostream>
+#include <stdexcept>
+
+#include <nlohmann/json.hpp>
+
+// =============================================================================
+// PipelineConfig::from_json
+// =============================================================================
+
+PipelineConfig PipelineConfig::from_json(const std::string &json_str) {
+  try {
+    auto j = nlohmann::json::parse(json_str);
+    PipelineConfig cfg;
+    cfg.label = j.value("label", std::string("custom"));
+    cfg.distance = j.at("distance").get<int>();
+    cfg.num_rounds = j.at("num_rounds").get<int>();
+    cfg.onnx_filename = j.at("onnx_filename").get<std::string>();
+    cfg.num_predecoders = j.at("num_predecoders").get<int>();
+    cfg.num_workers = j.at("num_workers").get<int>();
+    cfg.num_decode_workers = j.at("num_decode_workers").get<int>();
+    return cfg;
+  } catch (const nlohmann::json::exception &e) {
+    throw std::runtime_error(std::string("PipelineConfig JSON error: ") +
+                             e.what());
+  }
+}
+
+// =============================================================================
+// PipelineConfig::from_name
+// =============================================================================
+
+std::optional<PipelineConfig>
+PipelineConfig::from_name(const std::string &name) {
+  if (name == "d7")
+    return d7_r7();
+  if (name == "d13")
+    return d13_r13();
+  if (name == "d13_r104")
+    return d13_r104();
+  if (name == "d21")
+    return d21_r21();
+  if (name == "d21_r42")
+    return d21_r42();
+  if (name == "d31")
+    return d31_r31();
+  return std::nullopt;
+}
+
+// =============================================================================
+// PipelineConfig::apply_cli_overrides
+// =============================================================================
+
+void PipelineConfig::apply_cli_overrides(int argc, char *argv[]) {
+  for (int i = 1; i < argc; ++i) {
+    std::string arg = argv[i];
+    auto val_of = [&](const std::string &prefix) -> std::string {
+      return arg.substr(prefix.size());
+    };
+    if (arg.find("--distance=") == 0)
+      distance = std::stoi(val_of("--distance="));
+    else if (arg.find("--num-rounds=") == 0)
+      num_rounds = std::stoi(val_of("--num-rounds="));
+    else if (arg.find("--onnx-filename=") == 0)
+      onnx_filename = val_of("--onnx-filename=");
+    else if (arg.find("--num-predecoders=") == 0)
+      num_predecoders = std::stoi(val_of("--num-predecoders="));
+    else if (arg.find("--num-workers=") == 0)
+      num_workers = std::stoi(val_of("--num-workers="));
+    else if (arg.find("--num-decode-workers=") == 0)
+      num_decode_workers = std::stoi(val_of("--num-decode-workers="));
+    else if (arg.find("--label=") == 0)
+      label = val_of("--label=");
+  }
+}
 
 // =============================================================================
 // Pre-launch DMA copy callback

--- a/libs/qec/unittests/realtime/predecoder_pipeline_common.h
+++ b/libs/qec/unittests/realtime/predecoder_pipeline_common.h
@@ -23,6 +23,7 @@
 #include <cstring>
 #include <memory>
 #include <mutex>
+#include <optional>
 #include <queue>
 #include <string>
 #include <vector>
@@ -141,6 +142,33 @@ struct PipelineConfig {
     return {"d31_r31_Z", 31, 31, "model1_d31_r31_unified_Z_batch1.onnx",
             16,          16, 32};
   }
+
+  /// @brief Construct a PipelineConfig from a JSON string.
+  ///
+  /// Required fields: distance, num_rounds, onnx_filename, num_predecoders,
+  /// num_workers, num_decode_workers.  Optional: label (defaults to "custom").
+  ///
+  /// @param json_str JSON object as a string.
+  /// @return Populated PipelineConfig.
+  /// @throws std::runtime_error if parsing fails or required fields are
+  /// missing.
+  static PipelineConfig from_json(const std::string &json_str);
+
+  /// @brief Apply command-line overrides to this config.
+  ///
+  /// Scans argv for --distance=, --num-rounds=, --onnx-filename=,
+  /// --num-predecoders=, --num-workers=, --num-decode-workers=, and
+  /// --label= flags.  Any flag found overrides the corresponding field.
+  /// Unknown flags are silently ignored (handled by the caller).
+  ///
+  /// @param argc Argument count.
+  /// @param argv Argument vector.
+  void apply_cli_overrides(int argc, char *argv[]);
+
+  /// @brief Select a named preset config.
+  /// @param name One of: d7, d13, d13_r104, d21, d21_r42, d31.
+  /// @return The matching config, or std::nullopt if name is unrecognized.
+  static std::optional<PipelineConfig> from_name(const std::string &name);
 };
 
 /// @brief Round a value up to the next power of two.

--- a/libs/qec/unittests/realtime/test_realtime_predecoder_w_pymatching.cpp
+++ b/libs/qec/unittests/realtime/test_realtime_predecoder_w_pymatching.cpp
@@ -93,29 +93,30 @@ int main(int argc, char *argv[]) {
   if (argc > 3 && std::isdigit(argv[3][0]))
     scfg.duration_s = std::stoi(argv[3]);
 
-  PipelineConfig config;
-  if (config_name == "d7") {
-    config = PipelineConfig::d7_r7();
-  } else if (config_name == "d13") {
-    config = PipelineConfig::d13_r13();
-  } else if (config_name == "d13_r104") {
-    config = PipelineConfig::d13_r104();
-  } else if (config_name == "d21") {
-    config = PipelineConfig::d21_r21();
-  } else if (config_name == "d31") {
-    config = PipelineConfig::d31_r31();
-  } else {
+  auto config_opt = PipelineConfig::from_name(config_name);
+  if (!config_opt) {
     std::cerr << "Usage: " << argv[0]
-              << " [d7|d13|d13_r104|d21|d31] [rate_us] [duration_s]\n"
+              << " [d7|d13|d13_r104|d21|d21_r42|d31] [rate_us] [duration_s]\n"
               << "  d7       - distance 7, 7 rounds (default)\n"
               << "  d13      - distance 13, 13 rounds\n"
               << "  d13_r104 - distance 13, 104 rounds\n"
               << "  d21      - distance 21, 21 rounds\n"
+              << "  d21_r42  - distance 21, 42 rounds\n"
               << "  d31      - distance 31, 31 rounds\n"
               << "  rate_us    - inter-arrival time in us (0 = open-loop)\n"
-              << "  duration_s - test duration in seconds (default: 5)\n";
+              << "  duration_s - test duration in seconds (default: 5)\n"
+              << "\nOverride flags (applied after preset):\n"
+              << "  --distance=N          QEC code distance\n"
+              << "  --num-rounds=N        Syndrome measurement rounds\n"
+              << "  --onnx-filename=FILE  ONNX model filename\n"
+              << "  --num-predecoders=N   Parallel TRT instances\n"
+              << "  --num-workers=N       Pipeline GPU workers\n"
+              << "  --num-decode-workers=N  PyMatching threads\n"
+              << "  --label=NAME          Config label for reports\n";
     return 1;
   }
+  PipelineConfig config = *config_opt;
+  config.apply_cli_overrides(argc, argv);
 
   int device_count = 0;
   CUDA_CHECK(cudaGetDeviceCount(&device_count));


### PR DESCRIPTION
PipelineConfig fields (distance, num_rounds, onnx_filename, etc.) can now be overridden at runtime via --flag=value args, applied after the named preset. Both drivers and the orchestration script pass these through. Refactors preset lookup into from_name() returning std::optional.