### PR TITLE
Add optional CUDA graph resource inspection for AI predecoder

### DIFF
--- a/libs/qec/include/cudaq/qec/realtime/ai_predecoder_service.h
+++ b/libs/qec/include/cudaq/qec/realtime/ai_predecoder_service.h
@@ -11,6 +11,9 @@
 #include "cudaq/qec/realtime/ai_decoder_service.h"
 #include <atomic>
 #include <cuda/atomic>
+#include <iosfwd>
+#include <string>
+#include <vector>
 
 // Portable CPU Yield Macro for busy-polling (skip if already defined by
 // realtime API)
@@ -27,6 +30,29 @@
 #endif
 
 namespace cudaq::qec::realtime::experimental {
+
+/// @brief Per-kernel resource usage captured from the predecoder CUDA graph.
+struct kernel_resource_info {
+  std::string name;          ///< Kernel symbol name (demangled if available).
+  dim3 grid_dim;             ///< Grid dimensions from the graph node.
+  dim3 block_dim;            ///< Block dimensions from the graph node.
+  size_t static_shmem;       ///< Static shared memory per block (bytes).
+  size_t dynamic_shmem;      ///< Dynamic shared memory per block (bytes).
+  size_t local_mem;          ///< Local memory per thread (bytes).
+  size_t const_mem;          ///< Constant memory used by the kernel (bytes).
+  int num_regs;              ///< Registers per thread.
+  int max_threads_per_block; ///< Hardware max threads for this kernel.
+};
+
+/// @brief Aggregate resource usage for the predecoder CUDA graph.
+struct graph_resource_info {
+  size_t total_nodes = 0;
+  size_t kernel_nodes = 0;
+  size_t memcpy_nodes = 0;
+  size_t host_nodes = 0;
+  size_t other_nodes = 0;
+  std::vector<kernel_resource_info> kernels;
+};
 
 struct pre_decoder_job {
   int slot_idx;    ///< Worker/slot index (for release_job; always 0)
@@ -54,9 +80,18 @@ public:
 
   virtual ~ai_predecoder_service();
 
-  void capture_graph(cudaStream_t stream, bool device_launch);
+  /// @param stream CUDA stream to use for capture and warm-up inference.
+  /// @param device_launch If true, instantiate the graph for device launch.
+  /// @param collect_resources If true, walk the captured graph and populate
+  ///        graph_resources_ for later inspection via
+  ///        get_graph_resources() / print_graph_resources().  Off by default
+  ///        because graph introspection can perturb CUDA context state in
+  ///        ways that interfere with DOCA/Hololink GPU-RoCE setup on the
+  ///        FPGA bridge path.
+  void capture_graph(cudaStream_t stream, bool device_launch,
+                     bool collect_resources = false);
   void capture_graph(cudaStream_t stream) override {
-    capture_graph(stream, true);
+    capture_graph(stream, true, false);
   }
 
   bool poll_next_job(pre_decoder_job &out_job);
@@ -78,10 +113,26 @@ public:
 
   void **get_host_ring_ptrs() const { return h_ring_ptrs_; }
 
+  /// @brief Return the resource usage snapshot collected during capture_graph.
+  /// @details Fields are zero until capture_graph() has been called.
+  const graph_resource_info &get_graph_resources() const {
+    return graph_resources_;
+  }
+
+  /// @brief Print resource usage of the captured predecoder CUDA graph.
+  /// @param os Output stream to write to (e.g. std::cout).
+  /// @details Prints a per-kernel breakdown followed by aggregate totals
+  /// (node counts, total registers across launches, total shared memory,
+  /// total threads).  Safe to call only after capture_graph() has run.
+  void print_graph_resources(std::ostream &os) const;
+
 private:
   /// Passthrough constructor (delegates to base passthrough constructor).
   ai_predecoder_service(void **device_mailbox_slot, int queue_depth,
                         size_t input_bytes, size_t output_bytes);
+
+  /// Walk the captured CUDA graph and populate graph_resources_.
+  void collect_graph_resources(cudaGraph_t graph);
 
   int queue_depth_; // Always 1
 
@@ -92,6 +143,8 @@ private:
   cuda::atomic<int, cuda::thread_scope_system> *d_ready_flags_ = nullptr;
   void **d_ring_ptrs_ = nullptr;
   void *d_predecoder_outputs_ = nullptr;
+
+  graph_resource_info graph_resources_;
 };
 
 } // namespace cudaq::qec::realtime::experimental

--- a/libs/qec/include/cudaq/qec/realtime/ai_predecoder_service.h
+++ b/libs/qec/include/cudaq/qec/realtime/ai_predecoder_service.h
@@ -11,9 +11,6 @@
 #include "cudaq/qec/realtime/ai_decoder_service.h"
 #include <atomic>
 #include <cuda/atomic>
-#include <iosfwd>
-#include <string>
-#include <vector>
 
 // Portable CPU Yield Macro for busy-polling (skip if already defined by
 // realtime API)
@@ -30,29 +27,6 @@
 #endif
 
 namespace cudaq::qec::realtime::experimental {
-
-/// @brief Per-kernel resource usage captured from the predecoder CUDA graph.
-struct kernel_resource_info {
-  std::string name;          ///< Kernel symbol name (demangled if available).
-  dim3 grid_dim;             ///< Grid dimensions from the graph node.
-  dim3 block_dim;            ///< Block dimensions from the graph node.
-  size_t static_shmem;       ///< Static shared memory per block (bytes).
-  size_t dynamic_shmem;      ///< Dynamic shared memory per block (bytes).
-  size_t local_mem;          ///< Local memory per thread (bytes).
-  size_t const_mem;          ///< Constant memory used by the kernel (bytes).
-  int num_regs;              ///< Registers per thread.
-  int max_threads_per_block; ///< Hardware max threads for this kernel.
-};
-
-/// @brief Aggregate resource usage for the predecoder CUDA graph.
-struct graph_resource_info {
-  size_t total_nodes = 0;
-  size_t kernel_nodes = 0;
-  size_t memcpy_nodes = 0;
-  size_t host_nodes = 0;
-  size_t other_nodes = 0;
-  std::vector<kernel_resource_info> kernels;
-};
 
 struct pre_decoder_job {
   int slot_idx;    ///< Worker/slot index (for release_job; always 0)
@@ -82,14 +56,14 @@ public:
 
   /// @param stream CUDA stream to use for capture and warm-up inference.
   /// @param device_launch If true, instantiate the graph for device launch.
-  /// @param collect_resources If true, walk the captured graph and populate
-  ///        graph_resources_ for later inspection via
-  ///        get_graph_resources() / print_graph_resources().  Off by default
-  ///        because graph introspection can perturb CUDA context state in
-  ///        ways that interfere with DOCA/Hololink GPU-RoCE setup on the
-  ///        FPGA bridge path.
+  /// @param save_graph If true, retain a clone of the captured CUDA graph
+  ///        template so it can be inspected later via
+  ///        get_captured_graph() (e.g. by the free functions in
+  ///        cudaq/qec/realtime/graph_resources.h).  Default is false; the
+  ///        service otherwise destroys the template immediately after
+  ///        instantiation.
   void capture_graph(cudaStream_t stream, bool device_launch,
-                     bool collect_resources = false);
+                     bool save_graph = false);
   void capture_graph(cudaStream_t stream) override {
     capture_graph(stream, true, false);
   }
@@ -113,26 +87,17 @@ public:
 
   void **get_host_ring_ptrs() const { return h_ring_ptrs_; }
 
-  /// @brief Return the resource usage snapshot collected during capture_graph.
-  /// @details Fields are zero until capture_graph() has been called.
-  const graph_resource_info &get_graph_resources() const {
-    return graph_resources_;
-  }
-
-  /// @brief Print resource usage of the captured predecoder CUDA graph.
-  /// @param os Output stream to write to (e.g. std::cout).
-  /// @details Prints a per-kernel breakdown followed by aggregate totals
-  /// (node counts, total registers across launches, total shared memory,
-  /// total threads).  Safe to call only after capture_graph() has run.
-  void print_graph_resources(std::ostream &os) const;
+  /// @brief Return the retained clone of the captured graph template.
+  /// @details Non-null only when capture_graph() was called with
+  /// save_graph=true.  Ownership stays with this service; callers must
+  /// NOT destroy the returned handle.  Intended for opt-in introspection
+  /// (e.g. cudaq::qec::realtime::experimental::collect_graph_resources).
+  cudaGraph_t get_captured_graph() const { return captured_graph_; }
 
 private:
   /// Passthrough constructor (delegates to base passthrough constructor).
   ai_predecoder_service(void **device_mailbox_slot, int queue_depth,
                         size_t input_bytes, size_t output_bytes);
-
-  /// Walk the captured CUDA graph and populate graph_resources_.
-  void collect_graph_resources(cudaGraph_t graph);
 
   int queue_depth_; // Always 1
 
@@ -144,7 +109,11 @@ private:
   void **d_ring_ptrs_ = nullptr;
   void *d_predecoder_outputs_ = nullptr;
 
-  graph_resource_info graph_resources_;
+  /// Optional clone of the captured cudaGraph_t template, retained only
+  /// when capture_graph() was called with save_graph=true.  Destroyed in
+  /// the destructor.  The instantiated graph_exec_ lives on the base
+  /// class ai_decoder_service.
+  cudaGraph_t captured_graph_ = nullptr;
 };
 
 } // namespace cudaq::qec::realtime::experimental

--- a/libs/qec/include/cudaq/qec/realtime/graph_resources.h
+++ b/libs/qec/include/cudaq/qec/realtime/graph_resources.h
@@ -8,24 +8,53 @@
 
 #pragma once
 
-#include <cstdint>
 #include <cuda_runtime.h>
+#include <iosfwd>
+#include <string>
+#include <vector>
 
-namespace cudaq::qec::realtime {
+namespace cudaq::qec::realtime::experimental {
 
-/// Resources returned by decoder::capture_decode_graph().
-///
-/// The decoder plugin captures a CUDA graph internally and populates this
-/// struct.  The host dispatcher (libcudaq-realtime-host-dispatch) uses
-/// graph_exec / stream to launch the graph, and writes per-slot I/O
-/// addresses into h_mailbox before each launch.  function_id is used by
-/// the host dispatcher to route RPC requests to the correct graph worker.
-struct graph_resources {
-  cudaGraphExec_t graph_exec = nullptr;
-  cudaStream_t stream = nullptr;
-  void **d_mailbox = nullptr; ///< device-mapped pinned pointer
-  void **h_mailbox = nullptr; ///< host pointer to same pinned memory
-  uint32_t function_id = 0;
+/// @brief Per-kernel resource usage captured from a CUDA graph.
+struct kernel_resource_info {
+  std::string name; ///< Kernel symbol name (demangled if available).
+  dim3 grid_dim;    ///< Grid dimensions from the graph node.
+  dim3 block_dim;   ///< Block dimensions from the graph node.
+  std::size_t static_shmem = 0;  ///< Static shared memory per block (bytes).
+  std::size_t dynamic_shmem = 0; ///< Dynamic shared memory per block (bytes).
+  std::size_t local_mem = 0;     ///< Local memory per thread (bytes).
+  std::size_t const_mem = 0; ///< Constant memory used by the kernel (bytes).
+  int num_regs = 0;          ///< Registers per thread.
+  int max_threads_per_block = 0; ///< Hardware max threads for this kernel.
 };
 
-} // namespace cudaq::qec::realtime
+/// @brief Aggregate resource usage for a CUDA graph.
+struct graph_resource_info {
+  std::size_t total_nodes = 0;
+  std::size_t kernel_nodes = 0;
+  std::size_t memcpy_nodes = 0;
+  std::size_t host_nodes = 0;
+  std::size_t other_nodes = 0;
+  std::vector<kernel_resource_info> kernels;
+};
+
+/// @brief Walk a captured CUDA graph and return per-kernel resource usage.
+/// @param graph  A captured (not-yet-destroyed) CUDA graph handle.
+/// @returns An empty graph_resource_info if @p graph is null or traversal
+///          fails, otherwise populated aggregate + per-kernel info.
+///
+/// @warning This routine uses the CUDA driver API
+/// (@c cuGraphKernelNodeGetParams, @c cuFuncGetAttribute, @c cuFuncGetName)
+/// to introspect kernels launched by external libraries such as TensorRT.
+/// Those calls perturb the primary CUDA context state and can interfere
+/// with DOCA / GPU-RoCE setup on the FPGA bridge path.  Callers that
+/// share a CUDA context with DOCA-based transports must NOT invoke this
+/// function.
+graph_resource_info collect_graph_resources(cudaGraph_t graph);
+
+/// @brief Pretty-print graph resource usage to an output stream.
+/// @param os   Output stream (e.g. @c std::cout).
+/// @param info Collected info from @c collect_graph_resources.
+void print_graph_resources(std::ostream &os, const graph_resource_info &info);
+
+} // namespace cudaq::qec::realtime::experimental

--- a/libs/qec/lib/realtime/ai_predecoder_service.cu
+++ b/libs/qec/lib/realtime/ai_predecoder_service.cu
@@ -8,15 +8,9 @@
 
 #include "cudaq/qec/realtime/ai_predecoder_service.h"
 #include "cudaq/qec/realtime/nvtx_helpers.h"
-#include <cstdlib>
-#include <cuda.h>
 #include <cuda/atomic>
-#include <cxxabi.h>
-#include <iomanip>
-#include <ostream>
 #include <stdexcept>
 #include <string>
-#include <vector>
 
 #define SERVICE_CUDA_CHECK(call)                                               \
   do {                                                                         \
@@ -128,11 +122,14 @@ ai_predecoder_service::~ai_predecoder_service() {
     cudaFreeHost(h_predecoder_outputs_);
     h_predecoder_outputs_ = nullptr;
   }
+  if (captured_graph_) {
+    cudaGraphDestroy(captured_graph_);
+    captured_graph_ = nullptr;
+  }
 }
 
 void ai_predecoder_service::capture_graph(cudaStream_t stream,
-                                          bool device_launch,
-                                          bool collect_resources) {
+                                          bool device_launch, bool save_graph) {
   bool has_trt = (context_ != nullptr);
 
   if (has_trt) {
@@ -167,12 +164,17 @@ void ai_predecoder_service::capture_graph(cudaStream_t stream,
 
   SERVICE_CUDA_CHECK(cudaStreamEndCapture(stream, &graph));
 
-  // Optionally collect resource usage from the captured graph before
-  // instantiation.  Skipped by default because graph introspection can
-  // perturb CUDA context state in ways that interfere with DOCA/Hololink
-  // GPU-RoCE setup on the FPGA bridge path.
-  if (collect_resources)
-    collect_graph_resources(graph);
+  // Optionally retain a clone of the captured graph template for opt-in
+  // introspection (see cudaq/qec/realtime/graph_resources.h).  This
+  // service otherwise destroys the template immediately after
+  // instantiation -- the graph_exec_ is all that's needed at runtime.
+  if (save_graph) {
+    if (captured_graph_) {
+      cudaGraphDestroy(captured_graph_);
+      captured_graph_ = nullptr;
+    }
+    SERVICE_CUDA_CHECK(cudaGraphClone(&captured_graph_, graph));
+  }
 
   if (device_launch) {
     cudaError_t inst_err = cudaGraphInstantiateWithFlags(
@@ -222,179 +224,6 @@ void ai_predecoder_service::release_job(int /* slot_idx */) {
   // PyMatching done: 2 (Processing) -> 0 (Idle)
   sys_flags[0].store(0, cuda::std::memory_order_release);
   NVTX_POP();
-}
-
-// =============================================================================
-// Graph resource introspection
-// =============================================================================
-
-static std::string demangle_symbol(const char *mangled) {
-  if (!mangled)
-    return "<unknown>";
-  int status = 0;
-  char *out = abi::__cxa_demangle(mangled, nullptr, nullptr, &status);
-  std::string name = (status == 0 && out) ? std::string(out) : mangled;
-  std::free(out);
-  return name;
-}
-
-void ai_predecoder_service::collect_graph_resources(cudaGraph_t graph) {
-  graph_resources_ = {};
-  if (!graph)
-    return;
-
-  size_t num_nodes = 0;
-  if (cudaGraphGetNodes(graph, nullptr, &num_nodes) != cudaSuccess ||
-      num_nodes == 0)
-    return;
-
-  std::vector<cudaGraphNode_t> nodes(num_nodes);
-  if (cudaGraphGetNodes(graph, nodes.data(), &num_nodes) != cudaSuccess)
-    return;
-
-  graph_resources_.total_nodes = num_nodes;
-
-  for (auto node : nodes) {
-    cudaGraphNodeType type;
-    if (cudaGraphNodeGetType(node, &type) != cudaSuccess)
-      continue;
-
-    switch (type) {
-    case cudaGraphNodeTypeKernel:
-      ++graph_resources_.kernel_nodes;
-      break;
-    case cudaGraphNodeTypeMemcpy:
-      ++graph_resources_.memcpy_nodes;
-      continue;
-    case cudaGraphNodeTypeHost:
-      ++graph_resources_.host_nodes;
-      continue;
-    default:
-      ++graph_resources_.other_nodes;
-      continue;
-    }
-
-    kernel_resource_info info{};
-
-    // Try runtime API first (works for kernels launched via <<<>>>).
-    cudaKernelNodeParams params{};
-    if (cudaGraphKernelNodeGetParams(node, &params) == cudaSuccess) {
-      info.grid_dim = params.gridDim;
-      info.block_dim = params.blockDim;
-      info.dynamic_shmem = params.sharedMemBytes;
-
-      const char *mangled = nullptr;
-      if (params.func)
-        cudaFuncGetName(&mangled, params.func);
-      info.name = demangle_symbol(mangled);
-
-      cudaFuncAttributes attr{};
-      if (params.func &&
-          cudaFuncGetAttributes(&attr, params.func) == cudaSuccess) {
-        info.static_shmem = attr.sharedSizeBytes;
-        info.local_mem = attr.localSizeBytes;
-        info.const_mem = attr.constSizeBytes;
-        info.num_regs = attr.numRegs;
-        info.max_threads_per_block = attr.maxThreadsPerBlock;
-      }
-    } else {
-      // Fall back to driver API for TRT-internal kernels launched via
-      // cuLaunchKernel.  WARNING: this can perturb CUDA context state in
-      // ways that interfere with DOCA/Hololink GPU-RoCE setup, so the
-      // caller should only opt into resource collection (via capture_graph's
-      // collect_resources=true) on the software benchmark path.
-      CUDA_KERNEL_NODE_PARAMS drv_params{};
-      if (cuGraphKernelNodeGetParams(reinterpret_cast<CUgraphNode>(node),
-                                     &drv_params) == CUDA_SUCCESS) {
-        info.grid_dim =
-            dim3(drv_params.gridDimX, drv_params.gridDimY, drv_params.gridDimZ);
-        info.block_dim = dim3(drv_params.blockDimX, drv_params.blockDimY,
-                              drv_params.blockDimZ);
-        info.dynamic_shmem = drv_params.sharedMemBytes;
-
-        CUfunction func = drv_params.func;
-        if (func) {
-          const char *raw_name = nullptr;
-          if (cuFuncGetName(&raw_name, func) == CUDA_SUCCESS)
-            info.name = demangle_symbol(raw_name);
-
-          int regs = 0;
-          if (cuFuncGetAttribute(&regs, CU_FUNC_ATTRIBUTE_NUM_REGS, func) ==
-              CUDA_SUCCESS)
-            info.num_regs = regs;
-
-          int sshmem = 0;
-          if (cuFuncGetAttribute(&sshmem, CU_FUNC_ATTRIBUTE_SHARED_SIZE_BYTES,
-                                 func) == CUDA_SUCCESS)
-            info.static_shmem = static_cast<size_t>(sshmem);
-
-          int lmem = 0;
-          if (cuFuncGetAttribute(&lmem, CU_FUNC_ATTRIBUTE_LOCAL_SIZE_BYTES,
-                                 func) == CUDA_SUCCESS)
-            info.local_mem = static_cast<size_t>(lmem);
-
-          int cmem = 0;
-          if (cuFuncGetAttribute(&cmem, CU_FUNC_ATTRIBUTE_CONST_SIZE_BYTES,
-                                 func) == CUDA_SUCCESS)
-            info.const_mem = static_cast<size_t>(cmem);
-
-          int max_threads = 0;
-          if (cuFuncGetAttribute(&max_threads,
-                                 CU_FUNC_ATTRIBUTE_MAX_THREADS_PER_BLOCK,
-                                 func) == CUDA_SUCCESS)
-            info.max_threads_per_block = max_threads;
-        }
-        if (info.name.empty())
-          info.name = "<unknown-driver-kernel>";
-      } else {
-        info.name = "<introspection-failed>";
-      }
-    }
-
-    graph_resources_.kernels.push_back(std::move(info));
-  }
-}
-
-void ai_predecoder_service::print_graph_resources(std::ostream &os) const {
-  const auto &g = graph_resources_;
-  os << "[GraphResources] total_nodes=" << g.total_nodes
-     << " kernels=" << g.kernel_nodes << " memcpy=" << g.memcpy_nodes
-     << " host=" << g.host_nodes << " other=" << g.other_nodes << "\n";
-
-  size_t total_regs_per_launch = 0;
-  size_t total_shmem_per_launch = 0;
-  size_t total_threads = 0;
-
-  for (size_t i = 0; i < g.kernels.size(); ++i) {
-    const auto &k = g.kernels[i];
-    size_t blocks =
-        static_cast<size_t>(k.grid_dim.x) * k.grid_dim.y * k.grid_dim.z;
-    size_t threads_per_block =
-        static_cast<size_t>(k.block_dim.x) * k.block_dim.y * k.block_dim.z;
-    size_t launch_threads = blocks * threads_per_block;
-    size_t launch_regs = launch_threads * static_cast<size_t>(k.num_regs);
-    size_t launch_shmem = blocks * (k.static_shmem + k.dynamic_shmem);
-
-    total_regs_per_launch += launch_regs;
-    total_shmem_per_launch += launch_shmem;
-    total_threads += launch_threads;
-
-    os << "  [" << i << "] " << k.name << "\n"
-       << "      grid=(" << k.grid_dim.x << "," << k.grid_dim.y << ","
-       << k.grid_dim.z << ") block=(" << k.block_dim.x << "," << k.block_dim.y
-       << "," << k.block_dim.z << ")"
-       << " threads=" << launch_threads << "\n"
-       << "      regs/thread=" << k.num_regs << " local/thread=" << k.local_mem
-       << "B"
-       << " shmem/block=" << (k.static_shmem + k.dynamic_shmem)
-       << "B (static=" << k.static_shmem << " dynamic=" << k.dynamic_shmem
-       << ")"
-       << " max_threads_per_block=" << k.max_threads_per_block << "\n";
-  }
-
-  os << "  Total launch: threads=" << total_threads
-     << " regs=" << total_regs_per_launch << " shmem=" << total_shmem_per_launch
-     << "B\n";
 }
 
 } // namespace cudaq::qec::realtime::experimental

--- a/libs/qec/lib/realtime/ai_predecoder_service.cu
+++ b/libs/qec/lib/realtime/ai_predecoder_service.cu
@@ -9,9 +9,14 @@
 #include "cudaq/qec/realtime/ai_predecoder_service.h"
 #include "cudaq/qec/realtime/nvtx_helpers.h"
 #include <cstdlib>
+#include <cuda.h>
 #include <cuda/atomic>
+#include <cxxabi.h>
+#include <iomanip>
+#include <ostream>
 #include <stdexcept>
 #include <string>
+#include <vector>
 
 #define SERVICE_CUDA_CHECK(call)                                               \
   do {                                                                         \
@@ -126,7 +131,8 @@ ai_predecoder_service::~ai_predecoder_service() {
 }
 
 void ai_predecoder_service::capture_graph(cudaStream_t stream,
-                                          bool device_launch) {
+                                          bool device_launch,
+                                          bool collect_resources) {
   bool has_trt = (context_ != nullptr);
 
   if (has_trt) {
@@ -160,6 +166,13 @@ void ai_predecoder_service::capture_graph(cudaStream_t stream,
       static_cast<atomic_int_sys *>(d_ready_flags_));
 
   SERVICE_CUDA_CHECK(cudaStreamEndCapture(stream, &graph));
+
+  // Optionally collect resource usage from the captured graph before
+  // instantiation.  Skipped by default because graph introspection can
+  // perturb CUDA context state in ways that interfere with DOCA/Hololink
+  // GPU-RoCE setup on the FPGA bridge path.
+  if (collect_resources)
+    collect_graph_resources(graph);
 
   if (device_launch) {
     cudaError_t inst_err = cudaGraphInstantiateWithFlags(
@@ -209,6 +222,179 @@ void ai_predecoder_service::release_job(int /* slot_idx */) {
   // PyMatching done: 2 (Processing) -> 0 (Idle)
   sys_flags[0].store(0, cuda::std::memory_order_release);
   NVTX_POP();
+}
+
+// =============================================================================
+// Graph resource introspection
+// =============================================================================
+
+static std::string demangle_symbol(const char *mangled) {
+  if (!mangled)
+    return "<unknown>";
+  int status = 0;
+  char *out = abi::__cxa_demangle(mangled, nullptr, nullptr, &status);
+  std::string name = (status == 0 && out) ? std::string(out) : mangled;
+  std::free(out);
+  return name;
+}
+
+void ai_predecoder_service::collect_graph_resources(cudaGraph_t graph) {
+  graph_resources_ = {};
+  if (!graph)
+    return;
+
+  size_t num_nodes = 0;
+  if (cudaGraphGetNodes(graph, nullptr, &num_nodes) != cudaSuccess ||
+      num_nodes == 0)
+    return;
+
+  std::vector<cudaGraphNode_t> nodes(num_nodes);
+  if (cudaGraphGetNodes(graph, nodes.data(), &num_nodes) != cudaSuccess)
+    return;
+
+  graph_resources_.total_nodes = num_nodes;
+
+  for (auto node : nodes) {
+    cudaGraphNodeType type;
+    if (cudaGraphNodeGetType(node, &type) != cudaSuccess)
+      continue;
+
+    switch (type) {
+    case cudaGraphNodeTypeKernel:
+      ++graph_resources_.kernel_nodes;
+      break;
+    case cudaGraphNodeTypeMemcpy:
+      ++graph_resources_.memcpy_nodes;
+      continue;
+    case cudaGraphNodeTypeHost:
+      ++graph_resources_.host_nodes;
+      continue;
+    default:
+      ++graph_resources_.other_nodes;
+      continue;
+    }
+
+    kernel_resource_info info{};
+
+    // Try runtime API first (works for kernels launched via <<<>>>).
+    cudaKernelNodeParams params{};
+    if (cudaGraphKernelNodeGetParams(node, &params) == cudaSuccess) {
+      info.grid_dim = params.gridDim;
+      info.block_dim = params.blockDim;
+      info.dynamic_shmem = params.sharedMemBytes;
+
+      const char *mangled = nullptr;
+      if (params.func)
+        cudaFuncGetName(&mangled, params.func);
+      info.name = demangle_symbol(mangled);
+
+      cudaFuncAttributes attr{};
+      if (params.func &&
+          cudaFuncGetAttributes(&attr, params.func) == cudaSuccess) {
+        info.static_shmem = attr.sharedSizeBytes;
+        info.local_mem = attr.localSizeBytes;
+        info.const_mem = attr.constSizeBytes;
+        info.num_regs = attr.numRegs;
+        info.max_threads_per_block = attr.maxThreadsPerBlock;
+      }
+    } else {
+      // Fall back to driver API for TRT-internal kernels launched via
+      // cuLaunchKernel.  WARNING: this can perturb CUDA context state in
+      // ways that interfere with DOCA/Hololink GPU-RoCE setup, so the
+      // caller should only opt into resource collection (via capture_graph's
+      // collect_resources=true) on the software benchmark path.
+      CUDA_KERNEL_NODE_PARAMS drv_params{};
+      if (cuGraphKernelNodeGetParams(reinterpret_cast<CUgraphNode>(node),
+                                     &drv_params) == CUDA_SUCCESS) {
+        info.grid_dim =
+            dim3(drv_params.gridDimX, drv_params.gridDimY, drv_params.gridDimZ);
+        info.block_dim = dim3(drv_params.blockDimX, drv_params.blockDimY,
+                              drv_params.blockDimZ);
+        info.dynamic_shmem = drv_params.sharedMemBytes;
+
+        CUfunction func = drv_params.func;
+        if (func) {
+          const char *raw_name = nullptr;
+          if (cuFuncGetName(&raw_name, func) == CUDA_SUCCESS)
+            info.name = demangle_symbol(raw_name);
+
+          int regs = 0;
+          if (cuFuncGetAttribute(&regs, CU_FUNC_ATTRIBUTE_NUM_REGS, func) ==
+              CUDA_SUCCESS)
+            info.num_regs = regs;
+
+          int sshmem = 0;
+          if (cuFuncGetAttribute(&sshmem, CU_FUNC_ATTRIBUTE_SHARED_SIZE_BYTES,
+                                 func) == CUDA_SUCCESS)
+            info.static_shmem = static_cast<size_t>(sshmem);
+
+          int lmem = 0;
+          if (cuFuncGetAttribute(&lmem, CU_FUNC_ATTRIBUTE_LOCAL_SIZE_BYTES,
+                                 func) == CUDA_SUCCESS)
+            info.local_mem = static_cast<size_t>(lmem);
+
+          int cmem = 0;
+          if (cuFuncGetAttribute(&cmem, CU_FUNC_ATTRIBUTE_CONST_SIZE_BYTES,
+                                 func) == CUDA_SUCCESS)
+            info.const_mem = static_cast<size_t>(cmem);
+
+          int max_threads = 0;
+          if (cuFuncGetAttribute(&max_threads,
+                                 CU_FUNC_ATTRIBUTE_MAX_THREADS_PER_BLOCK,
+                                 func) == CUDA_SUCCESS)
+            info.max_threads_per_block = max_threads;
+        }
+        if (info.name.empty())
+          info.name = "<unknown-driver-kernel>";
+      } else {
+        info.name = "<introspection-failed>";
+      }
+    }
+
+    graph_resources_.kernels.push_back(std::move(info));
+  }
+}
+
+void ai_predecoder_service::print_graph_resources(std::ostream &os) const {
+  const auto &g = graph_resources_;
+  os << "[GraphResources] total_nodes=" << g.total_nodes
+     << " kernels=" << g.kernel_nodes << " memcpy=" << g.memcpy_nodes
+     << " host=" << g.host_nodes << " other=" << g.other_nodes << "\n";
+
+  size_t total_regs_per_launch = 0;
+  size_t total_shmem_per_launch = 0;
+  size_t total_threads = 0;
+
+  for (size_t i = 0; i < g.kernels.size(); ++i) {
+    const auto &k = g.kernels[i];
+    size_t blocks =
+        static_cast<size_t>(k.grid_dim.x) * k.grid_dim.y * k.grid_dim.z;
+    size_t threads_per_block =
+        static_cast<size_t>(k.block_dim.x) * k.block_dim.y * k.block_dim.z;
+    size_t launch_threads = blocks * threads_per_block;
+    size_t launch_regs = launch_threads * static_cast<size_t>(k.num_regs);
+    size_t launch_shmem = blocks * (k.static_shmem + k.dynamic_shmem);
+
+    total_regs_per_launch += launch_regs;
+    total_shmem_per_launch += launch_shmem;
+    total_threads += launch_threads;
+
+    os << "  [" << i << "] " << k.name << "\n"
+       << "      grid=(" << k.grid_dim.x << "," << k.grid_dim.y << ","
+       << k.grid_dim.z << ") block=(" << k.block_dim.x << "," << k.block_dim.y
+       << "," << k.block_dim.z << ")"
+       << " threads=" << launch_threads << "\n"
+       << "      regs/thread=" << k.num_regs << " local/thread=" << k.local_mem
+       << "B"
+       << " shmem/block=" << (k.static_shmem + k.dynamic_shmem)
+       << "B (static=" << k.static_shmem << " dynamic=" << k.dynamic_shmem
+       << ")"
+       << " max_threads_per_block=" << k.max_threads_per_block << "\n";
+  }
+
+  os << "  Total launch: threads=" << total_threads
+     << " regs=" << total_regs_per_launch << " shmem=" << total_shmem_per_launch
+     << "B\n";
 }
 
 } // namespace cudaq::qec::realtime::experimental

--- a/libs/qec/lib/realtime/graph_resources.cu
+++ b/libs/qec/lib/realtime/graph_resources.cu
@@ -1,0 +1,197 @@
+/*******************************************************************************
+ * Copyright (c) 2026 NVIDIA Corporation & Affiliates.                         *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+#include "cudaq/qec/realtime/graph_resources.h"
+
+#include <cstdlib>
+#include <cuda.h>
+#include <cuda_runtime.h>
+#include <cxxabi.h>
+#include <ostream>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace cudaq::qec::realtime::experimental {
+
+namespace {
+
+std::string demangle_symbol(const char *mangled) {
+  if (!mangled)
+    return "<unknown>";
+  int status = 0;
+  char *out = abi::__cxa_demangle(mangled, nullptr, nullptr, &status);
+  std::string name = (status == 0 && out) ? std::string(out) : mangled;
+  std::free(out);
+  return name;
+}
+
+} // namespace
+
+graph_resource_info collect_graph_resources(cudaGraph_t graph) {
+  graph_resource_info result{};
+  if (!graph)
+    return result;
+
+  std::size_t num_nodes = 0;
+  if (cudaGraphGetNodes(graph, nullptr, &num_nodes) != cudaSuccess ||
+      num_nodes == 0)
+    return result;
+
+  std::vector<cudaGraphNode_t> nodes(num_nodes);
+  if (cudaGraphGetNodes(graph, nodes.data(), &num_nodes) != cudaSuccess)
+    return result;
+
+  result.total_nodes = num_nodes;
+
+  for (auto node : nodes) {
+    cudaGraphNodeType type;
+    if (cudaGraphNodeGetType(node, &type) != cudaSuccess)
+      continue;
+
+    switch (type) {
+    case cudaGraphNodeTypeKernel:
+      ++result.kernel_nodes;
+      break;
+    case cudaGraphNodeTypeMemcpy:
+      ++result.memcpy_nodes;
+      continue;
+    case cudaGraphNodeTypeHost:
+      ++result.host_nodes;
+      continue;
+    default:
+      ++result.other_nodes;
+      continue;
+    }
+
+    kernel_resource_info info{};
+
+    // Try runtime API first (works for kernels launched via <<<>>>).
+    cudaKernelNodeParams params{};
+    if (cudaGraphKernelNodeGetParams(node, &params) == cudaSuccess) {
+      info.grid_dim = params.gridDim;
+      info.block_dim = params.blockDim;
+      info.dynamic_shmem = params.sharedMemBytes;
+
+      const char *mangled = nullptr;
+      if (params.func)
+        cudaFuncGetName(&mangled, params.func);
+      info.name = demangle_symbol(mangled);
+
+      cudaFuncAttributes attr{};
+      if (params.func &&
+          cudaFuncGetAttributes(&attr, params.func) == cudaSuccess) {
+        info.static_shmem = attr.sharedSizeBytes;
+        info.local_mem = attr.localSizeBytes;
+        info.const_mem = attr.constSizeBytes;
+        info.num_regs = attr.numRegs;
+        info.max_threads_per_block = attr.maxThreadsPerBlock;
+      }
+    } else {
+      // Fall back to driver API for TRT-internal kernels launched via
+      // cuLaunchKernel.  WARNING: these driver calls perturb CUDA context
+      // state in ways that interfere with DOCA/Hololink GPU-RoCE setup, so
+      // callers that share a CUDA context with DOCA-based transports must
+      // NOT invoke this function.
+      CUDA_KERNEL_NODE_PARAMS drv_params{};
+      if (cuGraphKernelNodeGetParams(reinterpret_cast<CUgraphNode>(node),
+                                     &drv_params) == CUDA_SUCCESS) {
+        info.grid_dim =
+            dim3(drv_params.gridDimX, drv_params.gridDimY, drv_params.gridDimZ);
+        info.block_dim = dim3(drv_params.blockDimX, drv_params.blockDimY,
+                              drv_params.blockDimZ);
+        info.dynamic_shmem = drv_params.sharedMemBytes;
+
+        CUfunction func = drv_params.func;
+        if (func) {
+          const char *raw_name = nullptr;
+          if (cuFuncGetName(&raw_name, func) == CUDA_SUCCESS)
+            info.name = demangle_symbol(raw_name);
+
+          int regs = 0;
+          if (cuFuncGetAttribute(&regs, CU_FUNC_ATTRIBUTE_NUM_REGS, func) ==
+              CUDA_SUCCESS)
+            info.num_regs = regs;
+
+          int sshmem = 0;
+          if (cuFuncGetAttribute(&sshmem, CU_FUNC_ATTRIBUTE_SHARED_SIZE_BYTES,
+                                 func) == CUDA_SUCCESS)
+            info.static_shmem = static_cast<std::size_t>(sshmem);
+
+          int lmem = 0;
+          if (cuFuncGetAttribute(&lmem, CU_FUNC_ATTRIBUTE_LOCAL_SIZE_BYTES,
+                                 func) == CUDA_SUCCESS)
+            info.local_mem = static_cast<std::size_t>(lmem);
+
+          int cmem = 0;
+          if (cuFuncGetAttribute(&cmem, CU_FUNC_ATTRIBUTE_CONST_SIZE_BYTES,
+                                 func) == CUDA_SUCCESS)
+            info.const_mem = static_cast<std::size_t>(cmem);
+
+          int max_threads = 0;
+          if (cuFuncGetAttribute(&max_threads,
+                                 CU_FUNC_ATTRIBUTE_MAX_THREADS_PER_BLOCK,
+                                 func) == CUDA_SUCCESS)
+            info.max_threads_per_block = max_threads;
+        }
+        if (info.name.empty())
+          info.name = "<unknown-driver-kernel>";
+      } else {
+        info.name = "<introspection-failed>";
+      }
+    }
+
+    result.kernels.push_back(std::move(info));
+  }
+
+  return result;
+}
+
+void print_graph_resources(std::ostream &os, const graph_resource_info &g) {
+  os << "[GraphResources] total_nodes=" << g.total_nodes
+     << " kernels=" << g.kernel_nodes << " memcpy=" << g.memcpy_nodes
+     << " host=" << g.host_nodes << " other=" << g.other_nodes << "\n";
+
+  std::size_t total_regs_per_launch = 0;
+  std::size_t total_shmem_per_launch = 0;
+  std::size_t total_threads = 0;
+
+  for (std::size_t i = 0; i < g.kernels.size(); ++i) {
+    const auto &k = g.kernels[i];
+    std::size_t blocks =
+        static_cast<std::size_t>(k.grid_dim.x) * k.grid_dim.y * k.grid_dim.z;
+    std::size_t threads_per_block =
+        static_cast<std::size_t>(k.block_dim.x) * k.block_dim.y * k.block_dim.z;
+    std::size_t launch_threads = blocks * threads_per_block;
+    std::size_t launch_regs =
+        launch_threads * static_cast<std::size_t>(k.num_regs);
+    std::size_t launch_shmem = blocks * (k.static_shmem + k.dynamic_shmem);
+
+    total_regs_per_launch += launch_regs;
+    total_shmem_per_launch += launch_shmem;
+    total_threads += launch_threads;
+
+    os << "  [" << i << "] " << k.name << "\n"
+       << "      grid=(" << k.grid_dim.x << "," << k.grid_dim.y << ","
+       << k.grid_dim.z << ") block=(" << k.block_dim.x << "," << k.block_dim.y
+       << "," << k.block_dim.z << ")"
+       << " threads=" << launch_threads << "\n"
+       << "      regs/thread=" << k.num_regs << " local/thread=" << k.local_mem
+       << "B"
+       << " shmem/block=" << (k.static_shmem + k.dynamic_shmem)
+       << "B (static=" << k.static_shmem << " dynamic=" << k.dynamic_shmem
+       << ")"
+       << " max_threads_per_block=" << k.max_threads_per_block << "\n";
+  }
+
+  os << "  Total launch: threads=" << total_threads
+     << " regs=" << total_regs_per_launch << " shmem=" << total_shmem_per_launch
+     << "B\n";
+}
+
+} // namespace cudaq::qec::realtime::experimental

--- a/libs/qec/unittests/CMakeLists.txt
+++ b/libs/qec/unittests/CMakeLists.txt
@@ -305,7 +305,6 @@ if(CUDAQ_REALTIME_ROOT AND CMAKE_CUDA_COMPILER)
       target_link_libraries(test_realtime_pipeline PRIVATE
         GTest::gtest_main
         CUDA::cudart
-        CUDA::cuda_driver
         ${TENSORRT_LIBRARY_FOR_PIPELINE}
         ${TENSORRT_ONNX_PARSER_FOR_PIPELINE}
         ${CUDAQ_REALTIME_LIBRARY}

--- a/libs/qec/unittests/CMakeLists.txt
+++ b/libs/qec/unittests/CMakeLists.txt
@@ -305,6 +305,7 @@ if(CUDAQ_REALTIME_ROOT AND CMAKE_CUDA_COMPILER)
       target_link_libraries(test_realtime_pipeline PRIVATE
         GTest::gtest_main
         CUDA::cudart
+        CUDA::cuda_driver
         ${TENSORRT_LIBRARY_FOR_PIPELINE}
         ${TENSORRT_ONNX_PARSER_FOR_PIPELINE}
         ${CUDAQ_REALTIME_LIBRARY}

--- a/libs/qec/unittests/realtime/CMakeLists.txt
+++ b/libs/qec/unittests/realtime/CMakeLists.txt
@@ -26,6 +26,7 @@ if(TENSORRT_INCLUDE_DIR AND TENSORRT_LIBRARY AND TENSORRT_ONNX_PARSER_LIBRARY
     predecoder_pipeline_common.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/../../lib/realtime/ai_decoder_service.cu
     ${CMAKE_CURRENT_SOURCE_DIR}/../../lib/realtime/ai_predecoder_service.cu
+    ${CMAKE_CURRENT_SOURCE_DIR}/../../lib/realtime/graph_resources.cu
   )
 
   set_target_properties(test_realtime_predecoder_w_pymatching PROPERTIES
@@ -144,7 +145,6 @@ if (GPU_ROCE_TRANSCEIVER_LIB AND CUDAQ_REALTIME_INCLUDE_DIR AND
     $<$<BOOL:${_CUDAQ_LIBRARY}>:${_CUDAQ_LIBRARY}>
     $<$<BOOL:${_NVQIR_LIBRARY}>:${_NVQIR_LIBRARY}>
     CUDA::cudart
-    CUDA::cuda_driver
     ${DOCA_VERBS_LIB}
     ${DOCA_GPUNETIO_LIB}
     ${DOCA_COMMON_LIB}

--- a/libs/qec/unittests/realtime/CMakeLists.txt
+++ b/libs/qec/unittests/realtime/CMakeLists.txt
@@ -51,6 +51,7 @@ if(TENSORRT_INCLUDE_DIR AND TENSORRT_LIBRARY AND TENSORRT_ONNX_PARSER_LIBRARY
 
   target_link_libraries(test_realtime_predecoder_w_pymatching PRIVATE
     CUDA::cudart
+    CUDA::cuda_driver
     ${TENSORRT_LIBRARY}
     ${TENSORRT_ONNX_PARSER_LIBRARY}
     ${CUDAQ_REALTIME_LIBRARY}

--- a/libs/qec/unittests/realtime/hololink_predecoder_bridge.cpp
+++ b/libs/qec/unittests/realtime/hololink_predecoder_bridge.cpp
@@ -167,20 +167,21 @@ int main(int argc, char *argv[]) {
         model_path, d_mailbox_bank + i, 1, save_path);
     cudaStream_t cap;
     BRIDGE_CUDA_CHECK(cudaStreamCreate(&cap));
-    // Intentionally pass collect_resources=false even if the user
-    // requested --print-graph-resources: CUDA driver-API introspection
-    // during graph capture perturbs the primary context in ways that break
-    // DOCA/Hololink GPU-RoCE on the FPGA bridge path.  Use the benchmark
-    // (test_realtime_predecoder_w_pymatching) with --print-graph-resources
-    // for graph inspection.
-    pd->capture_graph(cap, false, /*collect_resources=*/false);
+    // Do not retain the captured graph: the bridge must not invoke
+    // CUDA driver-API graph introspection (cuGraphKernelNodeGetParams,
+    // cuFuncGetAttribute, ...), because those calls perturb the primary
+    // context in ways that break DOCA/Hololink GPU-RoCE on the FPGA
+    // bridge path.  Use the benchmark (test_realtime_predecoder_w_pymatching)
+    // with --print-graph-resources for graph inspection.
+    pd->capture_graph(cap, false, /*save_graph=*/false);
     BRIDGE_CUDA_CHECK(cudaStreamDestroy(cap));
     predecoders.push_back(std::move(pd));
   }
   if (print_graph_resources) {
     std::cerr << "[WARN] --print-graph-resources is not supported by the "
-                 "FPGA bridge (introspection breaks DOCA GPU-RoCE). "
-                 "Use the software benchmark to inspect graph resources."
+                 "FPGA bridge (driver-API graph introspection breaks DOCA "
+                 "GPU-RoCE). Use the software benchmark to inspect graph "
+                 "resources."
               << std::endl;
   }
 

--- a/libs/qec/unittests/realtime/hololink_predecoder_bridge.cpp
+++ b/libs/qec/unittests/realtime/hololink_predecoder_bridge.cpp
@@ -65,6 +65,7 @@ int main(int argc, char *argv[]) {
   size_t page_size = 0;
   unsigned num_pages = 128;
   std::string data_dir;
+  bool print_graph_resources = false;
 
   for (int i = 1; i < argc; i++) {
     std::string arg = argv[i];
@@ -86,6 +87,8 @@ int main(int argc, char *argv[]) {
       num_pages = std::stoul(arg.substr(12));
     else if (arg.find("--data-dir=") == 0)
       data_dir = arg.substr(11);
+    else if (arg == "--print-graph-resources")
+      print_graph_resources = true;
     else if (arg == "--help" || arg == "-h") {
       std::cout
           << "Usage: " << argv[0] << " [options]\n\n"
@@ -102,7 +105,9 @@ int main(int argc, char *argv[]) {
           << "  --gpu=N               GPU device ID (default: 0)\n"
           << "  --timeout=N           Timeout in seconds (default: 60)\n"
           << "  --page-size=N         Ring buffer slot size (default: auto)\n"
-          << "  --num-pages=N         Ring buffer slots (default: 128)\n";
+          << "  --num-pages=N         Ring buffer slots (default: 128)\n"
+          << "  --print-graph-resources  Print predecoder CUDA graph resource "
+             "usage\n";
       return 0;
     }
   }
@@ -162,9 +167,21 @@ int main(int argc, char *argv[]) {
         model_path, d_mailbox_bank + i, 1, save_path);
     cudaStream_t cap;
     BRIDGE_CUDA_CHECK(cudaStreamCreate(&cap));
-    pd->capture_graph(cap, false);
+    // Intentionally pass collect_resources=false even if the user
+    // requested --print-graph-resources: CUDA driver-API introspection
+    // during graph capture perturbs the primary context in ways that break
+    // DOCA/Hololink GPU-RoCE on the FPGA bridge path.  Use the benchmark
+    // (test_realtime_predecoder_w_pymatching) with --print-graph-resources
+    // for graph inspection.
+    pd->capture_graph(cap, false, /*collect_resources=*/false);
     BRIDGE_CUDA_CHECK(cudaStreamDestroy(cap));
     predecoders.push_back(std::move(pd));
+  }
+  if (print_graph_resources) {
+    std::cerr << "[WARN] --print-graph-resources is not supported by the "
+                 "FPGA bridge (introspection breaks DOCA GPU-RoCE). "
+                 "Use the software benchmark to inspect graph resources."
+              << std::endl;
   }
 
   const size_t model_input_bytes = predecoders[0]->get_input_size();

--- a/libs/qec/unittests/realtime/test_realtime_predecoder_w_pymatching.cpp
+++ b/libs/qec/unittests/realtime/test_realtime_predecoder_w_pymatching.cpp
@@ -32,6 +32,7 @@
 #include <unistd.h>
 
 #include "cudaq/qec/realtime/ai_decoder_service.h"
+#include "cudaq/qec/realtime/graph_resources.h"
 #include "cudaq/realtime/daemon/dispatcher/host_dispatcher.h"
 
 #define CUDA_CHECK(call)                                                       \
@@ -183,17 +184,21 @@ int main(int argc, char *argv[]) {
 
     cudaStream_t capture_stream;
     CUDA_CHECK(cudaStreamCreate(&capture_stream));
-    // Only collect resources on predecoder 0 when requested; skipping it on
-    // the others avoids the cost of graph introspection on every worker.
+    // Only retain the captured-graph clone on predecoder 0 when resource
+    // inspection is requested; skipping it on the others avoids cloning
+    // the graph on every worker.
     pd->capture_graph(capture_stream, false,
-                      /*collect_resources=*/print_graph_resources && i == 0);
+                      /*save_graph=*/print_graph_resources && i == 0);
     CUDA_CHECK(cudaStreamDestroy(capture_stream));
 
     std::cout << "[Setup] Predecoder " << i << " (GPU " << gpu
               << "): input_size=" << pd->get_input_size()
               << " output_size=" << pd->get_output_size() << "\n";
     if (print_graph_resources && i == 0) {
-      pd->print_graph_resources(std::cout);
+      auto info = cudaq::qec::realtime::experimental::collect_graph_resources(
+          pd->get_captured_graph());
+      cudaq::qec::realtime::experimental::print_graph_resources(std::cout,
+                                                                info);
     }
     predecoders.push_back(std::move(pd));
   }

--- a/libs/qec/unittests/realtime/test_realtime_predecoder_w_pymatching.cpp
+++ b/libs/qec/unittests/realtime/test_realtime_predecoder_w_pymatching.cpp
@@ -67,6 +67,7 @@ int main(int argc, char *argv[]) {
   StreamingConfig scfg;
 
   int num_gpus = 1;
+  bool print_graph_resources = false;
 
   // Scan for named flags (can appear anywhere)
   for (int i = 1; i < argc; ++i) {
@@ -74,6 +75,8 @@ int main(int argc, char *argv[]) {
       scfg.data_dir = argv[i + 1];
     } else if (std::string(argv[i]) == "--num-gpus" && i + 1 < argc) {
       num_gpus = std::stoi(argv[i + 1]);
+    } else if (std::string(argv[i]) == "--print-graph-resources") {
+      print_graph_resources = true;
     }
   }
   // Multi-GPU dispatch is not yet supported: the host dispatcher thread
@@ -180,12 +183,18 @@ int main(int argc, char *argv[]) {
 
     cudaStream_t capture_stream;
     CUDA_CHECK(cudaStreamCreate(&capture_stream));
-    pd->capture_graph(capture_stream, false);
+    // Only collect resources on predecoder 0 when requested; skipping it on
+    // the others avoids the cost of graph introspection on every worker.
+    pd->capture_graph(capture_stream, false,
+                      /*collect_resources=*/print_graph_resources && i == 0);
     CUDA_CHECK(cudaStreamDestroy(capture_stream));
 
     std::cout << "[Setup] Predecoder " << i << " (GPU " << gpu
               << "): input_size=" << pd->get_input_size()
               << " output_size=" << pd->get_output_size() << "\n";
+    if (print_graph_resources && i == 0) {
+      pd->print_graph_resources(std::cout);
+    }
     predecoders.push_back(std::move(pd));
   }
   CUDA_CHECK(cudaSetDevice(0));


### PR DESCRIPTION
Add ai_predecoder_service::print_graph_resources() that walks the captured cuGraph and reports per-kernel grid/block dims, register usage, shared memory, and launch totals, plus a node-type summary.

Collection is opt-in via a new collect_resources parameter on capture_graph() because it uses the CUDA driver API to introspect TRT kernels, which perturbs primary-context state and breaks DOCA-based GPU-RoCE on the FPGA bridge. Only the software benchmark exposes a --print-graph-resources flag; the FPGA bridge ignores it and prints a warning.