### PR TITLE
[enhancement] QEC gpu python tests, follow-up #479

### DIFF
--- a/.github/workflows/lib_qec.yaml
+++ b/.github/workflows/lib_qec.yaml
@@ -161,6 +161,11 @@ jobs:
       actions: read
       contents: read
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          set-safe-directory: true
+
       - name: Download build artifacts
         uses: actions/download-artifact@v4
         with:
@@ -209,7 +214,5 @@ jobs:
       - name: Run GPU Python tests
         run: |
           PYTHONPATH="/cudaq-install:$GITHUB_WORKSPACE/build_qec/python" \
-            pytest -v libs/qec/python/tests/test_tensor_network_decoder.py \
-                      libs/qec/python/tests/test_dem_sampling.py \
-                      libs/qec/python/tests/test_trt_decoder.py
+            pytest -v libs/qec/python/tests/
 

--- a/.github/workflows/lib_qec.yaml
+++ b/.github/workflows/lib_qec.yaml
@@ -195,8 +195,21 @@ jobs:
           apt update
           apt install -y tensorrt-dev
 
-      - name: Run GPU tests
+      - name: Install Python GPU test requirements
+        run: |
+          cuda_no_dot=$(echo ${{ matrix.cuda_version }} | sed 's/\.//')
+          pip install torch==2.9.0 --index-url https://download.pytorch.org/whl/cu${cuda_no_dot}
+          pip install numpy pytest cupy-cuda${{ steps.config.outputs.cuda_major }}x cuquantum-cu${{ steps.config.outputs.cuda_major }} quimb opt_einsum nvidia-cublas "cuquantum-python-cu${{ steps.config.outputs.cuda_major }}>=26.3.0" "custabilizer-cu${{ steps.config.outputs.cuda_major }}>=0.3.0"
+
+      - name: Run GPU C++ tests
         run: |
           cd $GITHUB_WORKSPACE/build_qec
-          ctest --output-on-failure -R "GpuKernelsTest|test_realtime_decoding|test_realtime_pipeline|DemSamplingGPU"
+          ctest --output-on-failure -R "GpuKernelsTest|test_realtime_decoding|test_realtime_pipeline|DemSamplingGPU|TRTDecoder"
+
+      - name: Run GPU Python tests
+        run: |
+          PYTHONPATH="/cudaq-install:$GITHUB_WORKSPACE/build_qec/python" \
+            pytest -v libs/qec/python/tests/test_tensor_network_decoder.py \
+                      libs/qec/python/tests/test_dem_sampling.py \
+                      libs/qec/python/tests/test_trt_decoder.py
 

--- a/.github/workflows/lib_qec.yaml
+++ b/.github/workflows/lib_qec.yaml
@@ -161,6 +161,12 @@ jobs:
       actions: read
       contents: read
     steps:
+      - name: Install git for LFS
+        shell: bash
+        run: |
+          apt update
+          apt install -y --no-install-recommends git git-lfs
+
       - name: Checkout repository
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/lib_qec.yaml
+++ b/.github/workflows/lib_qec.yaml
@@ -165,6 +165,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           set-safe-directory: true
+          lfs: true # download assets file(s) for TRT tests
 
       - name: Download build artifacts
         uses: actions/download-artifact@v4


### PR DESCRIPTION
## Summary
Dependent on the merge of PR #479 .

- Add Python GPU test coverage to the QEC GPU CI job (`pr-build-gpu` in `lib_qec.yaml`)
- The GPU job previously only ran C++ tests via `ctest`. Python tests with GPU-dependent code paths (cuQuantum tensor network contractor, DEM sampling GPU backend, TRT decoder inference) were skipped on CPU runners and never executed on GPU runners.
- Install torch (CUDA wheel) and Python test dependencies on the GPU runner
- Add a `pytest` step targeting `test_tensor_network_decoder.py`, `test_dem_sampling.py`, and `test_trt_decoder.py`
- Expand the `ctest` regex to also include `TRTDecoder` C++ tests

## Test plan

- [ ] `pr-build-gpu` job runs successfully on amd64 and arm64
- [ ] "Run GPU Python tests" step shows previously-skipped cuQuantum/CUDA tests now running
- [ ] "Run GPU C++ tests" step includes TRTDecoder tests (amd64)
- [ ] No regressions in existing CPU test jobs (`pr-build`)