### PR TITLE
docs(qec): remove automodule exclude-members for cudaq_qec Python API

### DIFF
--- a/docs/sphinx/api/qec/python_api.rst
+++ b/docs/sphinx/api/qec/python_api.rst
@@ -3,7 +3,6 @@ CUDA-Q QEC Python API
 
 .. automodule:: cudaq_qec
     :members:
-    :exclude-members: stabilizer_grid
 
 Code
 =============


### PR DESCRIPTION
We had excluded stabilizer_grid from automodule to avoid double-documenting it with the Surface autoclass; that interacted badly with our layout/Sphinx, so removed that exclusion and the page renders correctly again.


<img width="1978" height="1334" alt="Screenshot 2026-04-21 154124" src="https://github.com/user-attachments/assets/cd31c162-3ae7-476d-8dce-caacd920e351" />
