### PR TITLE
Reduce size of cudaqx-dev image and make TensorRT dependency checking automatic

### DIFF
--- a/docker/build_env/cudaqx.dev.Dockerfile
+++ b/docker/build_env/cudaqx.dev.Dockerfile
@@ -23,17 +23,6 @@ RUN apt-get update && CUDA_DASH=$(echo $cuda_version | tr '.' '-') \
   && python3 -m pip install "cmake<4" --user \
   && apt-get autoremove -y --purge && apt-get clean && rm -rf /var/lib/apt/lists/*
 
-# Install tensorrt-dev, unless this is CUDA 12 w/ arm64
-RUN CUDA_MAJOR_VERSION=$(echo $cuda_version | cut -d . -f1); \
-  ARCH="${ARCH:-$(dpkg --print-architecture)}"; \
-  if [ "$CUDA_MAJOR_VERSION" != "12" ] || [ "$ARCH" = "amd64" ]; then \
-    apt-get update \
-    && apt-cache search tensorrt | awk '{print "Package: "$1"\nPin: version *+cuda'${cuda_version}'\nPin-Priority: 1001\n"}' | tee /etc/apt/preferences.d/tensorrt-cuda${cuda_version}.pref > /dev/null \
-    && apt update \
-    && apt-get install -y tensorrt-dev \
-    && apt-get autoremove -y --purge && apt-get clean && rm -rf /var/lib/apt/lists/*; \
-  fi
-
 COPY .cudaq_version /cudaq_version
 
 ENV CUDAQ_INSTALL_PREFIX=/usr/local/cudaq

--- a/libs/qec/CMakeLists.txt
+++ b/libs/qec/CMakeLists.txt
@@ -61,8 +61,15 @@ option(CUDAQX_QEC_INSTALL_PYTHON
        "Install python files alongside the library."
        ${CUDAQX_INSTALL_PYTHON})
 
-# Option to control TRT decoder build (default: ON)
-option(CUDAQ_QEC_BUILD_TRT_DECODER "Build the TensorRT decoder plugin" ON)
+# TRT decoder plugin: tri-state (ON, OFF, AUTO).
+#   AUTO (default): build the plugin if TensorRT is detected; otherwise skip
+#                   it silently (with a STATUS message).
+#   ON           : require TensorRT; configure fails if it cannot be found.
+#   OFF          : do not build the plugin and do not search for TensorRT.
+set(CUDAQ_QEC_BUILD_TRT_DECODER "AUTO" CACHE STRING
+    "Build the TensorRT decoder plugin (ON, OFF, AUTO)")
+set_property(CACHE CUDAQ_QEC_BUILD_TRT_DECODER
+             PROPERTY STRINGS "AUTO" "ON" "OFF")
 
 # Find and configure LLVM, Clang and MLIR
 # ==============================================================================

--- a/libs/qec/lib/CMakeLists.txt
+++ b/libs/qec/lib/CMakeLists.txt
@@ -60,8 +60,16 @@ add_library(${LIBRARY_NAME} SHARED ${QEC_SOURCES})
 add_subdirectory(decoders/plugins/example)
 add_subdirectory(decoders/plugins/pymatching)
 
-if(CUDAQ_QEC_BUILD_TRT_DECODER)
+# The TRT decoder plugin honors the tri-state `CUDAQ_QEC_BUILD_TRT_DECODER`
+# cache variable (AUTO/ON/OFF) declared in the parent CMakeLists.txt.  Skip
+# descending entirely when the user explicitly opted out; otherwise let the
+# subdirectory handle dependency detection and publish the result via the
+# `CUDAQ_QEC_TRT_DECODER_ENABLED` cache variable.
+if(NOT CUDAQ_QEC_BUILD_TRT_DECODER STREQUAL "OFF")
   add_subdirectory(decoders/plugins/trt_decoder)
+else()
+  set(CUDAQ_QEC_TRT_DECODER_ENABLED FALSE CACHE INTERNAL
+      "Whether the TRT decoder plugin is being built")
 endif()
 
 add_subdirectory(codes)

--- a/libs/qec/lib/decoders/plugins/trt_decoder/CMakeLists.txt
+++ b/libs/qec/lib/decoders/plugins/trt_decoder/CMakeLists.txt
@@ -51,8 +51,55 @@ find_library(TENSORRT_ONNX_LIBRARY nvonnxparser
     NO_DEFAULT_PATH
 )
 
-# Only build the module if TensorRT is found
+# Resolve the tri-state `CUDAQ_QEC_BUILD_TRT_DECODER` option (AUTO / ON / OFF)
+# against the dependency-detection results above:
+#   AUTO -> enable the plugin iff TensorRT was found (silent skip otherwise).
+#   ON   -> enable the plugin and hard-fail if TensorRT was not found.
+#   OFF  -> the parent CMakeLists.txt does not descend here, but handle it
+#           defensively in case this subdirectory is added directly.
+# The outcome is published via the `CUDAQ_QEC_TRT_DECODER_ENABLED` cache
+# variable so that other parts of the build (e.g. the unit-tests) can react.
 if(TENSORRT_INCLUDE_DIR AND TENSORRT_LIBRARY AND TENSORRT_ONNX_LIBRARY)
+    set(_trt_found TRUE)
+else()
+    set(_trt_found FALSE)
+endif()
+
+if(CUDAQ_QEC_BUILD_TRT_DECODER STREQUAL "AUTO")
+    set(_trt_enabled ${_trt_found})
+    if(NOT _trt_found)
+        message(STATUS
+            "TensorRT not found; auto-disabling the ${MODULE_NAME} plugin.\n"
+            "  TENSORRT_INCLUDE_DIR : ${TENSORRT_INCLUDE_DIR}\n"
+            "  TENSORRT_LIBRARY     : ${TENSORRT_LIBRARY}\n"
+            "  TENSORRT_ONNX_LIBRARY: ${TENSORRT_ONNX_LIBRARY}\n"
+            "Set -DTENSORRT_ROOT=<path> to enable it, or pass "
+            "-DCUDAQ_QEC_BUILD_TRT_DECODER=OFF to silence this message.")
+    endif()
+elseif(CUDAQ_QEC_BUILD_TRT_DECODER STREQUAL "ON")
+    if(NOT _trt_found)
+        message(FATAL_ERROR
+            "CUDAQ_QEC_BUILD_TRT_DECODER=ON but TensorRT could not be found.\n"
+            "  TENSORRT_INCLUDE_DIR : ${TENSORRT_INCLUDE_DIR}\n"
+            "  TENSORRT_LIBRARY     : ${TENSORRT_LIBRARY}\n"
+            "  TENSORRT_ONNX_LIBRARY: ${TENSORRT_ONNX_LIBRARY}\n"
+            "Set -DTENSORRT_ROOT=<path> to point at a TensorRT install, "
+            "or pass -DCUDAQ_QEC_BUILD_TRT_DECODER=AUTO to fall back to "
+            "auto-detection (default), or =OFF to disable the plugin.")
+    endif()
+    set(_trt_enabled TRUE)
+elseif(CUDAQ_QEC_BUILD_TRT_DECODER STREQUAL "OFF")
+    set(_trt_enabled FALSE)
+else()
+    message(FATAL_ERROR
+        "Invalid value for CUDAQ_QEC_BUILD_TRT_DECODER: "
+        "'${CUDAQ_QEC_BUILD_TRT_DECODER}'. Expected one of: AUTO, ON, OFF.")
+endif()
+
+set(CUDAQ_QEC_TRT_DECODER_ENABLED ${_trt_enabled} CACHE INTERNAL
+    "Whether the TRT decoder plugin is being built")
+
+if(CUDAQ_QEC_TRT_DECODER_ENABLED)
     message(STATUS "TensorRT found: ${TENSORRT_INCLUDE_DIR}")
     message(STATUS "TensorRT library: ${TENSORRT_LIBRARY}")
     message(STATUS "TensorRT ONNX parser: ${TENSORRT_ONNX_LIBRARY}")
@@ -132,12 +179,6 @@ if(TENSORRT_INCLUDE_DIR AND TENSORRT_LIBRARY AND TENSORRT_ONNX_LIBRARY)
       COMPONENT qec-lib-plugins
       LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}/decoder-plugins
     )
-
-else()
-    message(WARNING "TensorRT not found. Skipping ${MODULE_NAME} build.")
-    message(WARNING "TENSORRT_INCLUDE_DIR: ${TENSORRT_INCLUDE_DIR}")
-    message(WARNING "TENSORRT_LIBRARY: ${TENSORRT_LIBRARY}")
-    message(WARNING "TENSORRT_ONNX_LIBRARY: ${TENSORRT_ONNX_LIBRARY}")
 endif()
 
 

--- a/libs/qec/unittests/CMakeLists.txt
+++ b/libs/qec/unittests/CMakeLists.txt
@@ -57,7 +57,7 @@ gtest_discover_tests(test_dem_sampling)
 
 
 # TensorRT decoder test is only built for x86 architectures
-if(CUDAQ_QEC_BUILD_TRT_DECODER AND CMAKE_SYSTEM_PROCESSOR MATCHES "(x86_64)|(AMD64|amd64)|(^i.86$)")
+if(CUDAQ_QEC_TRT_DECODER_ENABLED AND CMAKE_SYSTEM_PROCESSOR MATCHES "(x86_64)|(AMD64|amd64)|(^i.86$)")
   add_executable(test_trt_decoder ./decoders/trt_decoder/test_trt_decoder.cpp)
 
   # Find TensorRT for the test


### PR DESCRIPTION
`CUDAQ_QEC_BUILD_TRT_DECODER` was a boolean option defaulting to ON, which meant a default build on a machine without TensorRT emitted a series of CMake errors unless the user explicitly disabled it.

Convert it to a tri-state CACHE STRING with values `AUTO / ON / OFF`
(default `AUTO`):

  - `AUTO`: probe for TensorRT; build the plugin if found, otherwise skip it silently with a single STATUS message explaining how to enable it.
  - `ON`  : probe for TensorRT; FATAL_ERROR if it cannot be found.
  - `OFF` : skip the plugin and do not probe for TensorRT.

Note: this should reduce the size of our cudaqx-dev image by >5GB.