### PR TITLE
Update libraries for upstream CUDA-Q changes (LLVM22)

### DIFF
--- a/.cudaq_realtime_version
+++ b/.cudaq_realtime_version
@@ -1,6 +1,6 @@
 {
   "cudaq_realtime": {
-    "repository": "bmhowe23/cuda-quantum",
-    "ref": "79559a26de00db696989f9fc98730558576fda9a"
+    "repository": "NVIDIA/cuda-quantum",
+    "ref": "e47b30b4d50385b97284fb124f33d3e370107fb2"
   }
 }

--- a/.cudaq_realtime_version
+++ b/.cudaq_realtime_version
@@ -1,6 +1,6 @@
 {
   "cudaq_realtime": {
     "repository": "NVIDIA/cuda-quantum",
-    "ref": "e47b30b4d50385b97284fb124f33d3e370107fb2"
+    "ref": "ce8ba8d9e8d5a9ea422efb8984e014c8c61d3910"
   }
 }

--- a/.cudaq_realtime_version
+++ b/.cudaq_realtime_version
@@ -1,6 +1,6 @@
 {
   "cudaq_realtime": {
     "repository": "NVIDIA/cuda-quantum",
-    "ref": "ce8ba8d9e8d5a9ea422efb8984e014c8c61d3910"
+    "ref": "e47b30b4d50385b97284fb124f33d3e370107fb2"
   }
 }

--- a/.cudaq_realtime_version
+++ b/.cudaq_realtime_version
@@ -1,6 +1,6 @@
 {
   "cudaq_realtime": {
-    "repository": "NVIDIA/cuda-quantum",
-    "ref": "e412f672acfe6e7ee8dd3e1c08b738d97274ac09"
+    "repository": "bmhowe23/cuda-quantum",
+    "ref": "79559a26de00db696989f9fc98730558576fda9a"
   }
 }

--- a/.cudaq_version
+++ b/.cudaq_version
@@ -1,6 +1,6 @@
 {
   "cudaq": {
-    "repository": "bmhowe23/cuda-quantum",
-    "ref": "79559a26de00db696989f9fc98730558576fda9a"
+    "repository": "NVIDIA/cuda-quantum",
+    "ref": "e47b30b4d50385b97284fb124f33d3e370107fb2"
   }
 }

--- a/.cudaq_version
+++ b/.cudaq_version
@@ -1,6 +1,6 @@
 {
   "cudaq": {
-    "repository": "NVIDIA/cuda-quantum",
-    "ref": "6d418871ed6a39163558cd558da3bce721cd6623"
+    "repository": "bmhowe23/cuda-quantum",
+    "ref": "79559a26de00db696989f9fc98730558576fda9a"
   }
 }

--- a/.cudaq_version
+++ b/.cudaq_version
@@ -1,6 +1,6 @@
 {
   "cudaq": {
     "repository": "NVIDIA/cuda-quantum",
-    "ref": "ce8ba8d9e8d5a9ea422efb8984e014c8c61d3910"
+    "ref": "e47b30b4d50385b97284fb124f33d3e370107fb2"
   }
 }

--- a/.cudaq_version
+++ b/.cudaq_version
@@ -1,6 +1,6 @@
 {
   "cudaq": {
     "repository": "NVIDIA/cuda-quantum",
-    "ref": "108efd2dd2d17e2a50edafd6f4f6cc8f12a29a68"
+    "ref": "6d418871ed6a39163558cd558da3bce721cd6623"
   }
 }

--- a/.cudaq_version
+++ b/.cudaq_version
@@ -1,6 +1,6 @@
 {
   "cudaq": {
     "repository": "NVIDIA/cuda-quantum",
-    "ref": "e47b30b4d50385b97284fb124f33d3e370107fb2"
+    "ref": "ce8ba8d9e8d5a9ea422efb8984e014c8c61d3910"
   }
 }

--- a/.cudaq_version
+++ b/.cudaq_version
@@ -1,6 +1,6 @@
 {
   "cudaq": {
     "repository": "NVIDIA/cuda-quantum",
-    "ref": "4b1138ff80eaffdeb1d365b977f7da1b76240f22"
+    "ref": "108efd2dd2d17e2a50edafd6f4f6cc8f12a29a68"
   }
 }

--- a/.github/actions/build-lib/action.yaml
+++ b/.github/actions/build-lib/action.yaml
@@ -41,7 +41,7 @@ runs:
     - name: Compilation cache key
       id: ccache-key
       run: |
-        echo "main=ccache-${{ inputs.lib }}-cu${{ inputs.cuda_version }}-gcc11-${{ inputs.platform }}" >> $GITHUB_OUTPUT
+        echo "main=ccache-${{ inputs.lib }}-cu${{ inputs.cuda_version }}-gcc12-${{ inputs.platform }}" >> $GITHUB_OUTPUT
         if [[ -n "${{ inputs.pr-number }}" ]]; then
           echo "pr=-pr${{ inputs.pr-number }}" >> $GITHUB_OUTPUT
         fi

--- a/.github/actions/build-lib/build_all.sh
+++ b/.github/actions/build-lib/build_all.sh
@@ -20,4 +20,4 @@ cmake -S . -B "$1" \
   -DCMAKE_INSTALL_PREFIX="$2" \
   $_rt_flag
 
-cmake --build "$1" --target install
+cmake --build "$1" --target install -j

--- a/.github/actions/build-lib/build_all.sh
+++ b/.github/actions/build-lib/build_all.sh
@@ -9,8 +9,8 @@ fi
 
 cmake -S . -B "$1" \
   -DCMAKE_BUILD_TYPE=Release \
-  -DCMAKE_C_COMPILER=gcc-11 \
-  -DCMAKE_CXX_COMPILER=g++-11 \
+  -DCMAKE_C_COMPILER=gcc-12 \
+  -DCMAKE_CXX_COMPILER=g++-12 \
   -DCMAKE_C_COMPILER_LAUNCHER=ccache \
   -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
   -DCUDAQ_DIR=/cudaq-install/lib/cmake/cudaq/ \

--- a/.github/actions/build-lib/build_all.sh
+++ b/.github/actions/build-lib/build_all.sh
@@ -7,7 +7,6 @@ if [ -n "$CUDAQ_REALTIME_ROOT" ]; then
   _rt_flag="-DCUDAQ_REALTIME_ROOT=$CUDAQ_REALTIME_ROOT"
 fi
 
-export FC=gfortran
 cmake -S . -B "$1" \
   -DCMAKE_BUILD_TYPE=Release \
   -DCMAKE_C_COMPILER=gcc-12 \

--- a/.github/actions/build-lib/build_all.sh
+++ b/.github/actions/build-lib/build_all.sh
@@ -7,6 +7,7 @@ if [ -n "$CUDAQ_REALTIME_ROOT" ]; then
   _rt_flag="-DCUDAQ_REALTIME_ROOT=$CUDAQ_REALTIME_ROOT"
 fi
 
+export FC=gfortran
 cmake -S . -B "$1" \
   -DCMAKE_BUILD_TYPE=Release \
   -DCMAKE_C_COMPILER=gcc-12 \

--- a/.github/actions/build-lib/build_qec.sh
+++ b/.github/actions/build-lib/build_qec.sh
@@ -131,4 +131,4 @@ cmake -S libs/qec -B "$1" \
   -DHOLOSCAN_SENSOR_BRIDGE_SOURCE_DIR=$HSB_ROOT \
   -DHOLOSCAN_SENSOR_BRIDGE_BUILD_DIR=$HSB_BUILD
 
-cmake --build "$1" --target install
+cmake --build "$1" --target install -j

--- a/.github/actions/build-lib/build_qec.sh
+++ b/.github/actions/build-lib/build_qec.sh
@@ -113,6 +113,9 @@ fi
 HSB_ROOT=/tmp/holoscan-sensor-bridge
 HSB_BUILD=${HSB_ROOT}/build
 
+echo "cmake --version"
+cmake --version
+
 cmake -S libs/qec -B "$1" \
   -DCMAKE_BUILD_TYPE=Release \
   -DCMAKE_C_COMPILER=gcc-12 \

--- a/.github/actions/build-lib/build_qec.sh
+++ b/.github/actions/build-lib/build_qec.sh
@@ -113,6 +113,7 @@ fi
 HSB_ROOT=/tmp/holoscan-sensor-bridge
 HSB_BUILD=${HSB_ROOT}/build
 
+export FC=gfortran
 cmake -S libs/qec -B "$1" \
   -DCMAKE_BUILD_TYPE=Release \
   -DCMAKE_C_COMPILER=gcc-12 \

--- a/.github/actions/build-lib/build_qec.sh
+++ b/.github/actions/build-lib/build_qec.sh
@@ -113,9 +113,6 @@ fi
 HSB_ROOT=/tmp/holoscan-sensor-bridge
 HSB_BUILD=${HSB_ROOT}/build
 
-echo "cmake --version"
-cmake --version
-
 cmake -S libs/qec -B "$1" \
   -DCMAKE_BUILD_TYPE=Release \
   -DCMAKE_C_COMPILER=gcc-12 \

--- a/.github/actions/build-lib/build_qec.sh
+++ b/.github/actions/build-lib/build_qec.sh
@@ -28,7 +28,7 @@ if [ -z "$CUDAQ_REALTIME_ROOT" ]; then
     ninja-build curl pkg-config
   # HSB -> find_package(holoscan) -> rapids_logger requires cmake >= 3.30.4;
   # the CI container ships cmake 3.28.
-  pip install cmake
+  pip install 'cmake<4'
   export PATH="$(python3 -c 'import cmake,os;print(os.path.join(os.path.dirname(cmake.__file__),"data","bin"))'):$PATH"
 
   # Add DOCA repo and install only the GPUNetIO dev package (not doca-all)

--- a/.github/actions/build-lib/build_qec.sh
+++ b/.github/actions/build-lib/build_qec.sh
@@ -115,8 +115,8 @@ HSB_BUILD=${HSB_ROOT}/build
 
 cmake -S libs/qec -B "$1" \
   -DCMAKE_BUILD_TYPE=Release \
-  -DCMAKE_C_COMPILER=gcc-11 \
-  -DCMAKE_CXX_COMPILER=g++-11 \
+  -DCMAKE_C_COMPILER=gcc-12 \
+  -DCMAKE_CXX_COMPILER=g++-12 \
   -DCMAKE_C_COMPILER_LAUNCHER=ccache \
   -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
   -DCUDAQ_DIR=/cudaq-install/lib/cmake/cudaq/ \

--- a/.github/actions/build-lib/build_qec.sh
+++ b/.github/actions/build-lib/build_qec.sh
@@ -113,7 +113,6 @@ fi
 HSB_ROOT=/tmp/holoscan-sensor-bridge
 HSB_BUILD=${HSB_ROOT}/build
 
-export FC=gfortran
 cmake -S libs/qec -B "$1" \
   -DCMAKE_BUILD_TYPE=Release \
   -DCMAKE_C_COMPILER=gcc-12 \

--- a/.github/actions/build-lib/build_solvers.sh
+++ b/.github/actions/build-lib/build_solvers.sh
@@ -1,6 +1,5 @@
 #!/bin/sh
 
-export FC=gfortran
 cmake -S libs/solvers -B "$1" \
   -DCMAKE_BUILD_TYPE=Release \
   -DCMAKE_C_COMPILER=gcc-12 \

--- a/.github/actions/build-lib/build_solvers.sh
+++ b/.github/actions/build-lib/build_solvers.sh
@@ -2,8 +2,8 @@
 
 cmake -S libs/solvers -B "$1" \
   -DCMAKE_BUILD_TYPE=Release \
-  -DCMAKE_C_COMPILER=gcc-11 \
-  -DCMAKE_CXX_COMPILER=g++-11 \
+  -DCMAKE_C_COMPILER=gcc-12 \
+  -DCMAKE_CXX_COMPILER=g++-12 \
   -DCMAKE_C_COMPILER_LAUNCHER=ccache \
   -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
   -DCUDAQ_DIR=/cudaq-install/lib/cmake/cudaq/ \

--- a/.github/actions/build-lib/build_solvers.sh
+++ b/.github/actions/build-lib/build_solvers.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
 
+export FC=gfortran
 cmake -S libs/solvers -B "$1" \
   -DCMAKE_BUILD_TYPE=Release \
   -DCMAKE_C_COMPILER=gcc-12 \

--- a/.github/actions/build-lib/build_solvers.sh
+++ b/.github/actions/build-lib/build_solvers.sh
@@ -11,5 +11,5 @@ cmake -S libs/solvers -B "$1" \
   -DCUDAQX_BINDINGS_PYTHON=ON \
   -DCMAKE_INSTALL_PREFIX="$2"
 
-cmake --build "$1" --target install
+cmake --build "$1" --target install -j
 

--- a/.github/actions/get-cudaq-build/action.yaml
+++ b/.github/actions/get-cudaq-build/action.yaml
@@ -134,7 +134,7 @@ runs:
         CUQUANTUM_INSTALL_PREFIX: /cudaq-install
         CUTENSOR_INSTALL_PREFIX: /cudaq-install
         CUDAQ_INSTALL_PREFIX: /cudaq-install
-      run: bash ${{ env.cudaq-build-script }} Release ccache gcc-11 g++-11 
+      run: bash ${{ env.cudaq-build-script }} Release ccache gcc-12 g++-12
       shell: bash --noprofile --norc -euo pipefail {0}
 
     # ==========================================================================

--- a/.github/actions/get-cudaq-build/build_cudaq.sh
+++ b/.github/actions/get-cudaq-build/build_cudaq.sh
@@ -1,80 +1,30 @@
 #!/bin/bash
 
 # ============================================================================ #
-# Copyright (c) 2022 - 2025 NVIDIA Corporation & Affiliates.                   #
+# Copyright (c) 2022 - 2026 NVIDIA Corporation & Affiliates.                   #
 # All rights reserved.                                                         #
 #                                                                              #
 # This source code and the accompanying materials are made available under     #
 # the terms of the Apache License 2.0 which accompanies this distribution.     #
 # ============================================================================ #
 
+# Thin wrapper that delegates to cudaq/scripts/build_cudaq.sh. Translates the
+# positional-args contract used by .github/actions/get-cudaq-build/action.yaml
+# into the env-var + flag interface expected by upstream.
 BUILD_TYPE=${1:-"Release"}
-LAUNCHER=${2:-""}
+LAUNCHER=${2:-""}  # accepted for backward compat; upstream auto-detects ccache via PATH
 CC=${3:-"gcc"}
 CXX=${4:-"g++"}
 
-# Set CUDA suffix to, for example, "cu12" or "cu13", based on the cuquantum
-# package name.
-CUDA_SUFFIX=$(pip list | grep cuquantum-cu | head -1 | cut -d' ' -f1 | cut -d'-' -f2)
+export CC
+export CXX
 
-LLVM_INSTALL_PREFIX=/usr/local/llvm
-CUQUANTUM_INSTALL_PREFIX="$(pip show cuquantum-${CUDA_SUFFIX} | grep "Location:" | cut -d " " -f 2)/cuquantum"
-CUTENSOR_INSTALL_PREFIX="$(pip show cutensor-${CUDA_SUFFIX} | grep "Location:" | cut -d " " -f 2)/cutensor"
+# Keep cudaqx CI's previous defaults (these differ from upstream defaults).
+export LLVM_INSTALL_PREFIX=${LLVM_INSTALL_PREFIX:-/usr/local/llvm}
+export CUDAQ_REQUIRE_OPENMP=${CUDAQ_REQUIRE_OPENMP:-TRUE}
+export CUDAQ_BUILD_TESTS=${CUDAQ_BUILD_TESTS:-FALSE}
+export CUDAQ_WERROR=${CUDAQ_WERROR:-OFF}
+# CUDAQ_INSTALL_PREFIX / CUQUANTUM_INSTALL_PREFIX / CUTENSOR_INSTALL_PREFIX /
+# CCACHE_DIR are expected to be set by the calling action (see action.yaml).
 
-cd cudaq
-
-# Determine linker and linker flags
-if [ -x "$(command -v "$LLVM_INSTALL_PREFIX/bin/ld.lld")" ]; then
-  echo "Configuring nvq++ to use the lld linker by default."
-  NVQPP_LD_PATH="$LLVM_INSTALL_PREFIX/bin/ld.lld"
-fi
-
-
-# Determine CUDA flags
-cuda_driver=${CUDACXX:-${CUDA_HOME:-/usr/local/cuda}/bin/nvcc}
-
-if [ -z "$CUDAHOSTCXX" ] && [ -z "$CUDAFLAGS" ]; then
-  CUDAFLAGS='-allow-unsupported-compiler'
-  if [ -x "$CXX" ] && [ -n "$("$CXX" --version | grep -i clang)" ]; then
-    CUDAFLAGS+=" --compiler-options --stdlib=libstdc++"
-  fi
-  if [ -d "$GCC_TOOLCHAIN" ]; then 
-    # e.g. GCC_TOOLCHAIN=/opt/rh/gcc-toolset-11/root/usr/
-    CUDAFLAGS+=" --compiler-options --gcc-toolchain=\"$GCC_TOOLCHAIN\""
-  fi
-fi
-
-# Determine OpenMP flags
-if [ -n "$(find "$LLVM_INSTALL_PREFIX" -name 'libomp.so')" ]; then
-  OMP_LIBRARY=${OMP_LIBRARY:-libomp}
-  OpenMP_libomp_LIBRARY=${OMP_LIBRARY#lib}
-  OpenMP_FLAGS="${OpenMP_FLAGS:-'-fopenmp'}"
-fi
-
-echo "Preparing CUDA-Q build with LLVM installation in $LLVM_INSTALL_PREFIX..."
-cmake_args="-G Ninja \
-  -DCMAKE_INSTALL_PREFIX='"$CUDAQ_INSTALL_PREFIX"' \
-  -DCMAKE_BUILD_TYPE=$BUILD_TYPE \
-  -DCMAKE_C_COMPILER=$CC \
-  -DCMAKE_CXX_COMPILER=$CXX \
-  -DCMAKE_C_COMPILER_LAUNCHER=$LAUNCHER \
-  -DCMAKE_CXX_COMPILER_LAUNCHER=$LAUNCHER \
-  -DNVQPP_LD_PATH='"$NVQPP_LD_PATH"' \
-  -DCMAKE_CUDA_COMPILER='"$cuda_driver"' \
-  -DCMAKE_CUDA_FLAGS='"$CUDAFLAGS"' \
-  -DCMAKE_CUDA_HOST_COMPILER='"${CUDAHOSTCXX:-$CXX}"' \
-  ${OpenMP_libomp_LIBRARY:+-DOpenMP_C_LIB_NAMES=lib$OpenMP_libomp_LIBRARY} \
-  ${OpenMP_libomp_LIBRARY:+-DOpenMP_CXX_LIB_NAMES=lib$OpenMP_libomp_LIBRARY} \
-  ${OpenMP_libomp_LIBRARY:+-DOpenMP_libomp_LIBRARY=$OpenMP_libomp_LIBRARY} \
-  ${OpenMP_FLAGS:+"-DOpenMP_C_FLAGS='"$OpenMP_FLAGS"'"} \
-  ${OpenMP_FLAGS:+"-DOpenMP_CXX_FLAGS='"$OpenMP_FLAGS"'"} \
-  -DCUDAQ_REQUIRE_OPENMP=TRUE \
-  -DCUDAQ_ENABLE_PYTHON=TRUE \
-  -DCUDAQ_BUILD_TESTS=FALSE \
-  -DCUDAQ_TEST_MOCK_SERVERS=FALSE \
-  -DCMAKE_COMPILE_WARNING_AS_ERROR=OFF"
-
-echo $cmake_args | xargs cmake -S . -B "build"
-
-cmake --build "build" --target install
-
+cd cudaq && bash scripts/build_cudaq.sh -v -c "$BUILD_TYPE"

--- a/.github/actions/get-cudaq-wheels/action.yaml
+++ b/.github/actions/get-cudaq-wheels/action.yaml
@@ -119,7 +119,7 @@ runs:
         context: cudaq
         file: ./cudaq/docker/release/cudaq.wheel.Dockerfile
         build-args: |
-          base_image=ghcr.io/nvidia/cuda-quantum-devdeps:manylinux-${{ inputs.platform }}-cu${{ inputs.cuda_version }}-gcc11-main
+          base_image=ghcr.io/nvidia/cuda-quantum-devdeps:manylinux-${{ inputs.platform }}-cu${{ inputs.cuda_version }}-gcc12-main
           release_version=0.14.99
           python_version=3.11
         outputs: /cudaq-wheels
@@ -130,7 +130,7 @@ runs:
         context: cudaq
         file: ./cudaq/docker/release/cudaq.wheel.Dockerfile
         build-args: |
-          base_image=ghcr.io/nvidia/cuda-quantum-devdeps:manylinux-${{ inputs.platform }}-cu${{ inputs.cuda_version }}-gcc11-main
+          base_image=ghcr.io/nvidia/cuda-quantum-devdeps:manylinux-${{ inputs.platform }}-cu${{ inputs.cuda_version }}-gcc12-main
           release_version=0.14.99
           python_version=3.12
         outputs: /cudaq-wheels
@@ -141,7 +141,7 @@ runs:
         context: cudaq
         file: ./cudaq/docker/release/cudaq.wheel.Dockerfile
         build-args: |
-          base_image=ghcr.io/nvidia/cuda-quantum-devdeps:manylinux-${{ inputs.platform }}-cu${{ inputs.cuda_version }}-gcc11-main
+          base_image=ghcr.io/nvidia/cuda-quantum-devdeps:manylinux-${{ inputs.platform }}-cu${{ inputs.cuda_version }}-gcc12-main
           release_version=0.14.99
           python_version=3.13
         outputs: /cudaq-wheels

--- a/.github/workflows/all_libs.yaml
+++ b/.github/workflows/all_libs.yaml
@@ -13,7 +13,7 @@ jobs:
         platform: ['amd64', 'arm64']
         cuda_version: ['12.6', '13.0']
     runs-on: ${{ startsWith(github.repository, 'NVIDIA/cudaqx') && format('linux-{0}-cpu8', matrix.platform) || 'ubuntu-latest' }}
-    container: ghcr.io/nvidia/cuda-quantum-devcontainer:${{ matrix.platform }}-cu${{ matrix.cuda_version }}-gcc11-main
+    container: ghcr.io/nvidia/cuda-quantum-devcontainer:${{ matrix.platform }}-cu${{ matrix.cuda_version }}-gcc12-main
     permissions:
       actions: write
       pull-requests: read

--- a/.github/workflows/build_dev.yaml
+++ b/.github/workflows/build_dev.yaml
@@ -87,7 +87,7 @@ jobs:
           TAGS+=" -t ghcr.io/nvidia/cudaqx-dev:${other_tag}-${{ matrix.platform }}-cu${{ matrix.cuda_version }}"
         fi
         docker build $TAGS -f docker/build_env/cudaqx.dev.Dockerfile . \
-          --build-arg base_image=ghcr.io/nvidia/cuda-quantum-devcontainer:${{ matrix.platform }}-cu${{ matrix.cuda_version }}-gcc11-main \
+          --build-arg base_image=ghcr.io/nvidia/cuda-quantum-devcontainer:${{ matrix.platform }}-cu${{ matrix.cuda_version }}-gcc12-main \
           --build-arg cuda_version=${{ matrix.cuda_version }}
         docker push -a ghcr.io/nvidia/cudaqx-dev
       shell: bash --noprofile --norc -euo pipefail {0}
@@ -159,7 +159,7 @@ jobs:
         context: cudaq
         file: cudaq/docker/release/cudaq.wheel.Dockerfile
         build-args: |
-          base_image=ghcr.io/nvidia/cuda-quantum-devdeps:manylinux-${{ matrix.platform }}-cu${{ matrix.cuda_version }}-gcc11-main
+          base_image=ghcr.io/nvidia/cuda-quantum-devdeps:manylinux-${{ matrix.platform }}-cu${{ matrix.cuda_version }}-gcc12-main
           release_version=0.14.99
           python_version=${{ matrix.python }}
           cuda_version=${{ matrix.cuda_version }}
@@ -190,7 +190,7 @@ jobs:
         if [ -n "$other_tag" ]; then
           TAGS+=" -t ghcr.io/nvidia/cudaqx-dev:${other_tag}-py${{ matrix.python }}-${{ matrix.platform }}-cu${{ matrix.cuda_version }}"
         fi
-        BUILDARGS="--build-arg base_image=ghcr.io/nvidia/cuda-quantum-devdeps:manylinux-${{ matrix.platform }}-cu${{ matrix.cuda_version }}-gcc11-main"
+        BUILDARGS="--build-arg base_image=ghcr.io/nvidia/cuda-quantum-devdeps:manylinux-${{ matrix.platform }}-cu${{ matrix.cuda_version }}-gcc12-main"
         BUILDARGS+=" --build-arg python_version=${{ matrix.python }}"
         BUILDARGS+=" --build-arg cuda_version=${{ matrix.cuda_version }}"
         BUILDARGS+=" --ulimit nofile=1048576:1048576"

--- a/.github/workflows/build_wheels.yaml
+++ b/.github/workflows/build_wheels.yaml
@@ -51,7 +51,7 @@ jobs:
     # FIXME: there is no guarantee that this CUDA-Q image aligns with the CUDA-Q
     # commit that we are trying to align with.
     container:
-      image: ghcr.io/nvidia/cuda-quantum-devdeps:manylinux-${{ matrix.platform }}-cu${{ matrix.cuda_version }}-gcc11-main
+      image: ghcr.io/nvidia/cuda-quantum-devdeps:manylinux-${{ matrix.platform }}-cu${{ matrix.cuda_version }}-gcc12-main
       options: --ulimit nofile=1048576:1048576
     permissions: write-all
     strategy:

--- a/.github/workflows/build_wheels.yaml
+++ b/.github/workflows/build_wheels.yaml
@@ -61,8 +61,8 @@ jobs:
         platform: ['amd64', 'arm64']
         cuda_version: ['12.6', '13.0']
         toolchain:
-          - cc: gcc-11
-            cxx: g++-11
+          - cc: gcc-12
+            cxx: g++-12
             build-type: Release
 
     steps:

--- a/.github/workflows/cudaq_cache.yaml
+++ b/.github/workflows/cudaq_cache.yaml
@@ -26,7 +26,7 @@ jobs:
         platform: ['amd64', 'arm64']
         cuda_version: ['12.6', '13.0']
     runs-on: ${{ startsWith(github.repository, 'NVIDIA/cudaqx') && format('linux-{0}-cpu32', matrix.platform) || 'ubuntu-latest' }}
-    container: ghcr.io/nvidia/cuda-quantum-devcontainer:${{ matrix.platform }}-cu${{ matrix.cuda_version }}-gcc11-main
+    container: ghcr.io/nvidia/cuda-quantum-devcontainer:${{ matrix.platform }}-cu${{ matrix.cuda_version }}-gcc12-main
     permissions:
       actions: write
       contents: read

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -72,8 +72,8 @@ jobs:
           # documentation).
           cmake -S . -B "build" \
             -DCMAKE_BUILD_TYPE=Release \
-            -DCMAKE_C_COMPILER=gcc-11 \
-            -DCMAKE_CXX_COMPILER=g++-11 \
+            -DCMAKE_C_COMPILER=gcc-12 \
+            -DCMAKE_CXX_COMPILER=g++-12 \
             -DCUDAQ_DIR=/cudaq-install/lib/cmake/cudaq/ \
             -DCUDAQX_ENABLE_LIBS="all" \
             -DCUDAQX_INCLUDE_DOCS=ON \

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -25,7 +25,7 @@ jobs:
   build:
     name: Build
     runs-on: ${{ startsWith(github.repository, 'NVIDIA/cudaqx') && 'linux-amd64-cpu8' || 'ubuntu-latest' }}
-    container: ghcr.io/nvidia/cuda-quantum-devcontainer:amd64-cu12.6-gcc11-main
+    container: ghcr.io/nvidia/cuda-quantum-devcontainer:amd64-cu12.6-gcc12-main
     permissions:
       actions: write
       contents: read

--- a/.github/workflows/lib_qec.yaml
+++ b/.github/workflows/lib_qec.yaml
@@ -13,7 +13,7 @@ jobs:
         platform: ['amd64', 'arm64']
         cuda_version: ['12.6', '13.0']
     runs-on: ${{ startsWith(github.repository, 'NVIDIA/cudaqx') && format('linux-{0}-cpu8', matrix.platform) || 'ubuntu-latest' }}
-    container: ghcr.io/nvidia/cuda-quantum-devcontainer:${{ matrix.platform }}-cu${{ matrix.cuda_version }}-gcc11-main
+    container: ghcr.io/nvidia/cuda-quantum-devcontainer:${{ matrix.platform }}-cu${{ matrix.cuda_version }}-gcc12-main
     permissions:
       actions: write
       pull-requests: read
@@ -154,7 +154,7 @@ jobs:
         cuda_version: ['12.6', '13.0']
     runs-on: ${{ startsWith(github.repository, 'NVIDIA/cudaqx') && format('linux-{0}-gpu-a100-latest-1', matrix.platform) || 'ubuntu-latest' }}
     container:
-      image: ghcr.io/nvidia/cuda-quantum-devcontainer:${{ matrix.platform }}-cu${{ matrix.cuda_version }}-gcc11-main
+      image: ghcr.io/nvidia/cuda-quantum-devcontainer:${{ matrix.platform }}-cu${{ matrix.cuda_version }}-gcc12-main
       env:
         NVIDIA_VISIBLE_DEVICES: ${{ env.NVIDIA_VISIBLE_DEVICES }}
     permissions:

--- a/.github/workflows/lib_solvers.yaml
+++ b/.github/workflows/lib_solvers.yaml
@@ -13,7 +13,7 @@ jobs:
         platform: ['amd64', 'arm64']
         cuda_version: ['12.6', '13.0']
     runs-on: ${{ startsWith(github.repository, 'NVIDIA/cudaqx') && format('linux-{0}-cpu8', matrix.platform) || 'ubuntu-latest' }}
-    container: ghcr.io/nvidia/cuda-quantum-devcontainer:${{ matrix.platform }}-cu${{ matrix.cuda_version }}-gcc11-main
+    container: ghcr.io/nvidia/cuda-quantum-devcontainer:${{ matrix.platform }}-cu${{ matrix.cuda_version }}-gcc12-main
     permissions:
       actions: write
       contents: read

--- a/.github/workflows/pr_workflow.yaml
+++ b/.github/workflows/pr_workflow.yaml
@@ -100,7 +100,7 @@ jobs:
         platform: ['amd64', 'arm64']
         cuda_version: ['12.6', '13.0']
     runs-on: ${{ startsWith(github.repository, 'NVIDIA/cudaqx') && format('linux-{0}-cpu32', matrix.platform) || 'ubuntu-latest' }}
-    container: ghcr.io/nvidia/cuda-quantum-devcontainer:${{ matrix.platform }}-cu${{ matrix.cuda_version }}-gcc11-main
+    container: ghcr.io/nvidia/cuda-quantum-devcontainer:${{ matrix.platform }}-cu${{ matrix.cuda_version }}-gcc12-main
     permissions:
       actions: write
       contents: read

--- a/.github/workflows/scripts/build_cudaq.sh
+++ b/.github/workflows/scripts/build_cudaq.sh
@@ -79,7 +79,7 @@ export CUDA_VERSION=${cuda_version}
 export CUDAQ_INSTALL_PREFIX=/usr/local/cudaq
 
 # We need to use a newer toolchain because CUDA-QX libraries rely on c++20
-source /opt/rh/gcc-toolset-11/enable
+source /opt/rh/gcc-toolset-12/enable
 
 export CC=gcc
 export CXX=g++

--- a/.github/workflows/scripts/build_wheels.sh
+++ b/.github/workflows/scripts/build_wheels.sh
@@ -132,7 +132,7 @@ if $devdeps; then
   PLAT_STR="--plat manylinux_2_34_x86_64"
 else
   # We need to use a newer toolchain because CUDA-QX libraries rely on c++20
-  source /opt/rh/gcc-toolset-11/enable
+  source /opt/rh/gcc-toolset-12/enable
 fi
 
 export CC=gcc
@@ -173,7 +173,7 @@ cp pyproject.toml.cu${cuda_version} pyproject.toml
 
 SKBUILD_CMAKE_ARGS="-DCUDAQ_DIR=$cudaq_prefix/lib/cmake/cudaq;-DTENSORRT_ROOT=$tensorrt_path"
 if ! $devdeps; then
-  SKBUILD_CMAKE_ARGS+=";-DCMAKE_CXX_COMPILER_EXTERNAL_TOOLCHAIN=/opt/rh/gcc-toolset-11/root/usr/lib/gcc/${ARCH}-redhat-linux/11/"
+  SKBUILD_CMAKE_ARGS+=";-DCMAKE_CXX_COMPILER_EXTERNAL_TOOLCHAIN=/opt/rh/gcc-toolset-12/root/usr/lib/gcc/${ARCH}-redhat-linux/12/"
 fi
 SKBUILD_CMAKE_ARGS+=";-DCMAKE_BUILD_TYPE=$build_type"
 export SKBUILD_CMAKE_ARGS
@@ -202,7 +202,7 @@ cp pyproject.toml.cu${cuda_version} pyproject.toml
 
 SKBUILD_CMAKE_ARGS="-DCUDAQ_DIR=$cudaq_prefix/lib/cmake/cudaq"
 if ! $devdeps; then
-  SKBUILD_CMAKE_ARGS+=";-DCMAKE_CXX_COMPILER_EXTERNAL_TOOLCHAIN=/opt/rh/gcc-toolset-11/root/usr/lib/gcc/${ARCH}-redhat-linux/11/;"
+  SKBUILD_CMAKE_ARGS+=";-DCMAKE_CXX_COMPILER_EXTERNAL_TOOLCHAIN=/opt/rh/gcc-toolset-12/root/usr/lib/gcc/${ARCH}-redhat-linux/12/;"
 fi
 SKBUILD_CMAKE_ARGS+=";-DCMAKE_BUILD_TYPE=$build_type" \
 export SKBUILD_CMAKE_ARGS

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,7 +69,7 @@ option(CUDAQX_BINDINGS_PYTHON "Generate build targets for python bindings." ON)
 # using `LLVM_VERSION_MAJOR`, e.g. "-LLVM_VERSION_MAJOR=16".  Note that this
 # version variable is set to the latest LLVM version by default, and setting it
 # to an older version might break the project.
-find_package(LLVM ${LLVM_VERSION_MAJOR} CONFIG QUIET)
+find_package(LLVM ${LLVM_VERSION_MAJOR}.${LLVM_VERSION_MINOR} CONFIG QUIET)
 
 if(NOT LLVM_DIR)
   message(STATUS "LLVM_DIR not found, will try with llvm-config executable.")
@@ -130,7 +130,7 @@ if(NOT LLVM_DIR)
       "Could not find suitable llvm-config(-${LLVM_VERSION_MAJOR}).\
       \nTry providing valid -DLLVM_DIR=/path/to/llvm/lib/cmake/llvm.")
   else()
-    find_package(LLVM ${LLVM_VERSION_MAJOR} REQUIRED CONFIG
+    find_package(LLVM ${LLVM_VERSION_MAJOR}.${LLVM_VERSION_MINOR} REQUIRED CONFIG
       HINTS ${LLVM_CONFIG_CMAKE_DIR} NO_DEFAULT_PATH)
   endif()
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,6 +69,12 @@ option(CUDAQX_BINDINGS_PYTHON "Generate build targets for python bindings." ON)
 # using `LLVM_VERSION_MAJOR`, e.g. "-LLVM_VERSION_MAJOR=16".  Note that this
 # version variable is set to the latest LLVM version by default, and setting it
 # to an older version might break the project.
+if(NOT LLVM_VERSION_MAJOR)
+  set(LLVM_VERSION_MAJOR 22)
+endif()
+if(NOT LLVM_VERSION_MINOR)
+  set(LLVM_VERSION_MINOR 1)
+endif()
 find_package(LLVM ${LLVM_VERSION_MAJOR}.${LLVM_VERSION_MINOR} CONFIG QUIET)
 
 if(NOT LLVM_DIR)

--- a/cmake/Modules/CUDA-QX.cmake
+++ b/cmake/Modules/CUDA-QX.cmake
@@ -296,6 +296,6 @@ cudaqx_add_pymodule
 
 #]=======================================================================]
 function(cudaqx_add_pymodule module)
-  nanobind_add_module(${module} ${ARGN})
+  nanobind_add_module(${module} NB_DOMAIN cudaq ${ARGN})
   add_dependencies(cudaqx-pymodules ${module})
 endfunction()

--- a/cmake/Modules/CUDA-QX.cmake
+++ b/cmake/Modules/CUDA-QX.cmake
@@ -194,27 +194,6 @@ function(cudaqx_import_cudaq_targets)
     include("${CUDAQ_CMAKE_DIR}/CUDAQTargets.cmake")
   endif()
 
-  # CUDA-Q built with GCC 12 baked `--param=evrp-mode=legacy` into the
-  # PUBLIC compile options of `cudaq-common` (see runtime/common/CMakeLists.txt
-  # in CUDA-Q). That flag was removed in GCC 13, so it leaks into consumers
-  # like cudaqx and breaks the build. Scrub it from the imported targets'
-  # INTERFACE_COMPILE_OPTIONS so we don't propagate it to our own targets.
-  foreach(_cudaq_target IN ITEMS
-      cudaq::cudaq
-      cudaq::cudaq-common
-      cudaq::cudaq-operator
-      cudaq::cudaq-em-default
-      cudaq::cudaq-platform-default)
-    if(TARGET ${_cudaq_target})
-      get_target_property(_iface_opts ${_cudaq_target} INTERFACE_COMPILE_OPTIONS)
-      if(_iface_opts)
-        list(REMOVE_ITEM _iface_opts "--param=evrp-mode=legacy")
-        set_target_properties(${_cudaq_target} PROPERTIES
-          INTERFACE_COMPILE_OPTIONS "${_iface_opts}")
-      endif()
-    endif()
-  endforeach()
-
   set(__base_nvtarget_name "custatevec")
   find_library(CUDAQ_CUSVSIM_PATH NAMES cusvsim-fp32 HINTS ${CUDAQ_LIBRARY_DIR})
   if (CUDAQ_CUSVSIM_PATH)

--- a/cmake/Modules/CUDA-QX.cmake
+++ b/cmake/Modules/CUDA-QX.cmake
@@ -194,6 +194,27 @@ function(cudaqx_import_cudaq_targets)
     include("${CUDAQ_CMAKE_DIR}/CUDAQTargets.cmake")
   endif()
 
+  # CUDA-Q built with GCC 12 baked `--param=evrp-mode=legacy` into the
+  # PUBLIC compile options of `cudaq-common` (see runtime/common/CMakeLists.txt
+  # in CUDA-Q). That flag was removed in GCC 13, so it leaks into consumers
+  # like cudaqx and breaks the build. Scrub it from the imported targets'
+  # INTERFACE_COMPILE_OPTIONS so we don't propagate it to our own targets.
+  foreach(_cudaq_target IN ITEMS
+      cudaq::cudaq
+      cudaq::cudaq-common
+      cudaq::cudaq-operator
+      cudaq::cudaq-em-default
+      cudaq::cudaq-platform-default)
+    if(TARGET ${_cudaq_target})
+      get_target_property(_iface_opts ${_cudaq_target} INTERFACE_COMPILE_OPTIONS)
+      if(_iface_opts)
+        list(REMOVE_ITEM _iface_opts "--param=evrp-mode=legacy")
+        set_target_properties(${_cudaq_target} PROPERTIES
+          INTERFACE_COMPILE_OPTIONS "${_iface_opts}")
+      endif()
+    endif()
+  endforeach()
+
   set(__base_nvtarget_name "custatevec")
   find_library(CUDAQ_CUSVSIM_PATH NAMES cusvsim-fp32 HINTS ${CUDAQ_LIBRARY_DIR})
   if (CUDAQ_CUSVSIM_PATH)

--- a/docker/build_env/cudaqx.dev.Dockerfile
+++ b/docker/build_env/cudaqx.dev.Dockerfile
@@ -6,7 +6,7 @@
 # the terms of the Apache License 2.0 which accompanies this distribution.     #
 # ============================================================================ #
 
-ARG base_image=ghcr.io/nvidia/cuda-quantum-devcontainer:amd64-cu12.6-gcc11-main
+ARG base_image=ghcr.io/nvidia/cuda-quantum-devcontainer:amd64-cu12.6-gcc12-main
 FROM $base_image
 
 ARG cuda_version=12.6

--- a/docker/build_env/cudaqx.wheel.Dockerfile
+++ b/docker/build_env/cudaqx.wheel.Dockerfile
@@ -6,7 +6,7 @@
 # the terms of the Apache License 2.0 which accompanies this distribution.     #
 # ============================================================================ #
 
-ARG base_image=ghcr.io/nvidia/cuda-quantum-devdeps:manylinux-amd64-cu12.6-gcc11-main
+ARG base_image=ghcr.io/nvidia/cuda-quantum-devdeps:manylinux-amd64-cu12.6-gcc12-main
 FROM ${base_image}
 
 ARG python_version=3.12

--- a/libs/core/unittests/CMakeLists.txt
+++ b/libs/core/unittests/CMakeLists.txt
@@ -21,10 +21,11 @@ set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
 
 # Bug in GCC 12 leads to spurious warnings (-Wrestrict)
 # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=105329
-if (CMAKE_COMPILER_IS_GNUCXX 
-  AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 12.0.0 
+if (CMAKE_COMPILER_IS_GNUCXX
+  AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 12.0.0
   AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 13.0.0)
-  target_compile_options(gtest PUBLIC --param=evrp-mode=legacy)
+  target_compile_options(gtest PUBLIC
+    $<$<COMPILE_LANGUAGE:CXX>:--param=evrp-mode=legacy>)
 endif()
 include(GoogleTest)
 

--- a/libs/qec/CMakeLists.txt
+++ b/libs/qec/CMakeLists.txt
@@ -79,7 +79,7 @@ set_property(CACHE CUDAQ_QEC_BUILD_TRT_DECODER
 # using `LLVM_VERSION_MAJOR`, e.g. "-LLVM_VERSION_MAJOR=16".  Note that this
 # version variable is set to the latest LLVM version by default, and setting it
 # to an older version might break the project.
-find_package(LLVM ${LLVM_VERSION_MAJOR} CONFIG QUIET)
+find_package(LLVM ${LLVM_VERSION_MAJOR}.${LLVM_VERSION_MINOR} CONFIG QUIET)
 
 if(NOT LLVM_DIR)
   message(STATUS "LLVM_DIR not found, will try with llvm-config executable.")
@@ -140,7 +140,7 @@ if(NOT LLVM_DIR)
       "Could not find suitable llvm-config(-${LLVM_VERSION_MAJOR}).\
       \nTry providing valid -DLLVM_DIR=/path/to/llvm/lib/cmake/llvm.")
   else()
-    find_package(LLVM ${LLVM_VERSION_MAJOR} REQUIRED CONFIG
+    find_package(LLVM ${LLVM_VERSION_MAJOR}.${LLVM_VERSION_MINOR} REQUIRED CONFIG
       HINTS ${LLVM_CONFIG_CMAKE_DIR} NO_DEFAULT_PATH)
   endif()
 endif()

--- a/libs/qec/CMakeLists.txt
+++ b/libs/qec/CMakeLists.txt
@@ -79,6 +79,12 @@ set_property(CACHE CUDAQ_QEC_BUILD_TRT_DECODER
 # using `LLVM_VERSION_MAJOR`, e.g. "-LLVM_VERSION_MAJOR=16".  Note that this
 # version variable is set to the latest LLVM version by default, and setting it
 # to an older version might break the project.
+if(NOT LLVM_VERSION_MAJOR)
+  set(LLVM_VERSION_MAJOR 22)
+endif()
+if(NOT LLVM_VERSION_MINOR)
+  set(LLVM_VERSION_MINOR 1)
+endif()
 find_package(LLVM ${LLVM_VERSION_MAJOR}.${LLVM_VERSION_MINOR} CONFIG QUIET)
 
 if(NOT LLVM_DIR)

--- a/libs/qec/lib/realtime/CMakeLists.txt
+++ b/libs/qec/lib/realtime/CMakeLists.txt
@@ -6,7 +6,7 @@
 # the terms of the Apache License 2.0 which accompanies this distribution.     #
 # ============================================================================ #
 
-find_package(LLVM 16.0.6 EXACT REQUIRED CONFIG)
+find_package(LLVM 22.1.4 EXACT REQUIRED CONFIG)
 
 # Enable CUDA for device code
 if(CMAKE_CUDA_COMPILER)

--- a/libs/qec/python/CMakeLists.txt
+++ b/libs/qec/python/CMakeLists.txt
@@ -17,7 +17,7 @@ if(NOT COMMAND nanobind_add_module)
   FetchContent_Declare(
     nanobind
     GIT_REPOSITORY https://github.com/wjakob/nanobind
-    GIT_TAG v2.12.0
+    GIT_TAG v2.9.2
     EXCLUDE_FROM_ALL
   )
   FetchContent_MakeAvailable(nanobind)

--- a/libs/qec/python/bindings/py_decoder.cpp
+++ b/libs/qec/python/bindings/py_decoder.cpp
@@ -105,6 +105,13 @@ void bindDecoder(nb::module_ &mod) {
                     ? nb::cast<nb::module_>(mod.attr("qecrt"))
                     : mod.def_submodule("qecrt");
 
+  // Workaround for nanobind v2.9.2: `def_rw` on a `std::optional<T>` field
+  // does not implicitly allow Python `None` for the setter (that behavior was
+  // added in v2.12.0 via PR #1262). Passing this annotation makes the setter
+  // accept None and store `std::nullopt`. Remove once nanobind is bumped to
+  // >=2.12.0.
+  const auto setter_accepts_none = nb::for_setter(nb::arg("value").none());
+
   nb::class_<decoder_result>(qecmod, "DecoderResult", R"pbdoc(
     A class representing the results of a quantum error correction decoding operation.
 
@@ -128,7 +135,8 @@ void bindDecoder(nb::module_ &mod) {
         the original quantum state. The format depends on the specific decoder
         implementation.
     )pbdoc")
-      .def_rw("opt_results", &decoder_result::opt_results, R"pbdoc(
+      .def_rw("opt_results", &decoder_result::opt_results, setter_accepts_none,
+              R"pbdoc(
         Optional additional results from the decoder stored in a heterogeneous map.
 
         This field may be empty if no additional results are available.

--- a/libs/qec/python/bindings/py_decoding_config.cpp
+++ b/libs/qec/python/bindings/py_decoding_config.cpp
@@ -29,6 +29,13 @@ void bindDecodingConfig(nb::module_ &mod) {
   auto mod_cfg =
       qecmod.def_submodule("config", "Realtime decoding configuration");
 
+  // Workaround for nanobind v2.9.2: `def_rw` on a `std::optional<T>` field
+  // does not implicitly allow Python `None` for the setter (that behavior was
+  // added in v2.12.0 via PR #1262). Passing this annotation makes the setter
+  // accept None and store `std::nullopt`. Remove once nanobind is bumped to
+  // >=2.12.0.
+  const auto setter_accepts_none = nb::for_setter(nb::arg("value").none());
+
   // srelay_bp_config
   nb::class_<config::srelay_bp_config>(mod_cfg, "srelay_bp_config",
                                        "Relay-BP decoder configuration.")
@@ -41,10 +48,11 @@ void bindDecodingConfig(nb::module_ &mod) {
                 srelay_bp_config(srelay_bp_config::from_heterogeneous_map(map));
           },
           nb::arg("map"))
-      .def_rw("pre_iter", &srelay_bp_config::pre_iter)
-      .def_rw("num_sets", &srelay_bp_config::num_sets)
-      .def_rw("stopping_criterion", &srelay_bp_config::stopping_criterion)
-      .def_rw("stop_nconv", &srelay_bp_config::stop_nconv)
+      .def_rw("pre_iter", &srelay_bp_config::pre_iter, setter_accepts_none)
+      .def_rw("num_sets", &srelay_bp_config::num_sets, setter_accepts_none)
+      .def_rw("stopping_criterion", &srelay_bp_config::stopping_criterion,
+              setter_accepts_none)
+      .def_rw("stop_nconv", &srelay_bp_config::stop_nconv, setter_accepts_none)
       .def("to_heterogeneous_map", &srelay_bp_config::to_heterogeneous_map,
            nb::rv_policy::move)
       .def_static("from_heterogeneous_map",
@@ -62,27 +70,45 @@ void bindDecodingConfig(nb::module_ &mod) {
                 nv_qldpc_decoder_config::from_heterogeneous_map(map));
           },
           nb::arg("map"))
-      .def_rw("use_sparsity", &nv_qldpc_decoder_config::use_sparsity)
-      .def_rw("error_rate", &nv_qldpc_decoder_config::error_rate)
-      .def_rw("error_rate_vec", &nv_qldpc_decoder_config::error_rate_vec)
-      .def_rw("max_iterations", &nv_qldpc_decoder_config::max_iterations)
-      .def_rw("n_threads", &nv_qldpc_decoder_config::n_threads)
-      .def_rw("use_osd", &nv_qldpc_decoder_config::use_osd)
-      .def_rw("osd_method", &nv_qldpc_decoder_config::osd_method)
-      .def_rw("osd_order", &nv_qldpc_decoder_config::osd_order)
-      .def_rw("bp_batch_size", &nv_qldpc_decoder_config::bp_batch_size)
-      .def_rw("osd_batch_size", &nv_qldpc_decoder_config::osd_batch_size)
-      .def_rw("iter_per_check", &nv_qldpc_decoder_config::iter_per_check)
-      .def_rw("clip_value", &nv_qldpc_decoder_config::clip_value)
-      .def_rw("bp_method", &nv_qldpc_decoder_config::bp_method)
-      .def_rw("scale_factor", &nv_qldpc_decoder_config::scale_factor)
-      .def_rw("proc_float", &nv_qldpc_decoder_config::proc_float)
-      .def_rw("gamma0", &nv_qldpc_decoder_config::gamma0)
-      .def_rw("gamma_dist", &nv_qldpc_decoder_config::gamma_dist)
-      .def_rw("explicit_gammas", &nv_qldpc_decoder_config::explicit_gammas)
-      .def_rw("srelay_config", &nv_qldpc_decoder_config::srelay_config)
-      .def_rw("bp_seed", &nv_qldpc_decoder_config::bp_seed)
-      .def_rw("composition", &nv_qldpc_decoder_config::composition)
+      .def_rw("use_sparsity", &nv_qldpc_decoder_config::use_sparsity,
+              setter_accepts_none)
+      .def_rw("error_rate", &nv_qldpc_decoder_config::error_rate,
+              setter_accepts_none)
+      .def_rw("error_rate_vec", &nv_qldpc_decoder_config::error_rate_vec,
+              setter_accepts_none)
+      .def_rw("max_iterations", &nv_qldpc_decoder_config::max_iterations,
+              setter_accepts_none)
+      .def_rw("n_threads", &nv_qldpc_decoder_config::n_threads,
+              setter_accepts_none)
+      .def_rw("use_osd", &nv_qldpc_decoder_config::use_osd, setter_accepts_none)
+      .def_rw("osd_method", &nv_qldpc_decoder_config::osd_method,
+              setter_accepts_none)
+      .def_rw("osd_order", &nv_qldpc_decoder_config::osd_order,
+              setter_accepts_none)
+      .def_rw("bp_batch_size", &nv_qldpc_decoder_config::bp_batch_size,
+              setter_accepts_none)
+      .def_rw("osd_batch_size", &nv_qldpc_decoder_config::osd_batch_size,
+              setter_accepts_none)
+      .def_rw("iter_per_check", &nv_qldpc_decoder_config::iter_per_check,
+              setter_accepts_none)
+      .def_rw("clip_value", &nv_qldpc_decoder_config::clip_value,
+              setter_accepts_none)
+      .def_rw("bp_method", &nv_qldpc_decoder_config::bp_method,
+              setter_accepts_none)
+      .def_rw("scale_factor", &nv_qldpc_decoder_config::scale_factor,
+              setter_accepts_none)
+      .def_rw("proc_float", &nv_qldpc_decoder_config::proc_float,
+              setter_accepts_none)
+      .def_rw("gamma0", &nv_qldpc_decoder_config::gamma0, setter_accepts_none)
+      .def_rw("gamma_dist", &nv_qldpc_decoder_config::gamma_dist,
+              setter_accepts_none)
+      .def_rw("explicit_gammas", &nv_qldpc_decoder_config::explicit_gammas,
+              setter_accepts_none)
+      .def_rw("srelay_config", &nv_qldpc_decoder_config::srelay_config,
+              setter_accepts_none)
+      .def_rw("bp_seed", &nv_qldpc_decoder_config::bp_seed, setter_accepts_none)
+      .def_rw("composition", &nv_qldpc_decoder_config::composition,
+              setter_accepts_none)
       .def("to_heterogeneous_map",
            &nv_qldpc_decoder_config::to_heterogeneous_map, nb::rv_policy::move)
       .def_static("from_heterogeneous_map",
@@ -101,7 +127,8 @@ void bindDecodingConfig(nb::module_ &mod) {
                 multi_error_lut_config::from_heterogeneous_map(map));
           },
           nb::arg("map"))
-      .def_rw("lut_error_depth", &multi_error_lut_config::lut_error_depth)
+      .def_rw("lut_error_depth", &multi_error_lut_config::lut_error_depth,
+              setter_accepts_none)
       .def("to_heterogeneous_map",
            &multi_error_lut_config::to_heterogeneous_map, nb::rv_policy::move)
       .def_static("from_heterogeneous_map",
@@ -120,11 +147,15 @@ void bindDecodingConfig(nb::module_ &mod) {
                 trt_decoder_config::from_heterogeneous_map(map));
           },
           nb::arg("map"))
-      .def_rw("onnx_load_path", &trt_decoder_config::onnx_load_path)
-      .def_rw("engine_load_path", &trt_decoder_config::engine_load_path)
-      .def_rw("engine_save_path", &trt_decoder_config::engine_save_path)
-      .def_rw("precision", &trt_decoder_config::precision)
-      .def_rw("memory_workspace", &trt_decoder_config::memory_workspace)
+      .def_rw("onnx_load_path", &trt_decoder_config::onnx_load_path,
+              setter_accepts_none)
+      .def_rw("engine_load_path", &trt_decoder_config::engine_load_path,
+              setter_accepts_none)
+      .def_rw("engine_save_path", &trt_decoder_config::engine_save_path,
+              setter_accepts_none)
+      .def_rw("precision", &trt_decoder_config::precision, setter_accepts_none)
+      .def_rw("memory_workspace", &trt_decoder_config::memory_workspace,
+              setter_accepts_none)
       .def("to_heterogeneous_map", &trt_decoder_config::to_heterogeneous_map,
            nb::rv_policy::move)
       .def_static("from_heterogeneous_map",
@@ -161,21 +192,28 @@ void bindDecodingConfig(nb::module_ &mod) {
                 sliding_window_config::from_heterogeneous_map(map));
           },
           nb::arg("map"))
-      .def_rw("window_size", &sliding_window_config::window_size)
-      .def_rw("step_size", &sliding_window_config::step_size)
+      .def_rw("window_size", &sliding_window_config::window_size,
+              setter_accepts_none)
+      .def_rw("step_size", &sliding_window_config::step_size,
+              setter_accepts_none)
       .def_rw("num_syndromes_per_round",
-              &sliding_window_config::num_syndromes_per_round)
+              &sliding_window_config::num_syndromes_per_round,
+              setter_accepts_none)
       .def_rw("straddle_start_round",
-              &sliding_window_config::straddle_start_round)
-      .def_rw("straddle_end_round", &sliding_window_config::straddle_end_round)
+              &sliding_window_config::straddle_start_round, setter_accepts_none)
+      .def_rw("straddle_end_round", &sliding_window_config::straddle_end_round,
+              setter_accepts_none)
       .def_rw("error_rate_vec", &sliding_window_config::error_rate_vec)
       .def_rw("inner_decoder_name", &sliding_window_config::inner_decoder_name)
       .def_rw("single_error_lut_params",
-              &sliding_window_config::single_error_lut_params)
+              &sliding_window_config::single_error_lut_params,
+              setter_accepts_none)
       .def_rw("multi_error_lut_params",
-              &sliding_window_config::multi_error_lut_params)
+              &sliding_window_config::multi_error_lut_params,
+              setter_accepts_none)
       .def_rw("nv_qldpc_decoder_params",
-              &sliding_window_config::nv_qldpc_decoder_params)
+              &sliding_window_config::nv_qldpc_decoder_params,
+              setter_accepts_none)
       .def("to_heterogeneous_map", &sliding_window_config::to_heterogeneous_map,
            nb::rv_policy::move)
       .def_static("from_heterogeneous_map",

--- a/libs/qec/unittests/CMakeLists.txt
+++ b/libs/qec/unittests/CMakeLists.txt
@@ -21,10 +21,11 @@ set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
 
 # Bug in GCC 12 leads to spurious warnings (-Wrestrict)
 # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=105329
-if (CMAKE_COMPILER_IS_GNUCXX 
-  AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 12.0.0 
+if (CMAKE_COMPILER_IS_GNUCXX
+  AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 12.0.0
   AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 13.0.0)
-  target_compile_options(gtest PUBLIC --param=evrp-mode=legacy)
+  target_compile_options(gtest PUBLIC
+    $<$<COMPILE_LANGUAGE:CXX>:--param=evrp-mode=legacy>)
 endif()
 include(GoogleTest)
 

--- a/libs/qec/unittests/decoders/pymatching/CMakeLists.txt
+++ b/libs/qec/unittests/decoders/pymatching/CMakeLists.txt
@@ -13,10 +13,11 @@ set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
 
 # Bug in GCC 12 leads to spurious warnings (-Wrestrict)
 # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=105329
-if (CMAKE_COMPILER_IS_GNUCXX 
-  AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 12.0.0 
+if (CMAKE_COMPILER_IS_GNUCXX
+  AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 12.0.0
   AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 13.0.0)
-  target_compile_options(gtest PUBLIC --param=evrp-mode=legacy)
+  target_compile_options(gtest PUBLIC
+    $<$<COMPILE_LANGUAGE:CXX>:--param=evrp-mode=legacy>)
 endif()
 include(GoogleTest)
 

--- a/libs/qec/unittests/realtime/CMakeLists.txt
+++ b/libs/qec/unittests/realtime/CMakeLists.txt
@@ -6,7 +6,8 @@
 # the terms of the Apache License 2.0 which accompanies this distribution.     #
 # ============================================================================ #
 
-add_subdirectory(app_examples)
+# FIXME - these fail to compile with CUDA-Q w/ LLVM
+#add_subdirectory(app_examples)
 
 # =========================================================================== #
 # test_realtime_predecoder_w_pymatching

--- a/libs/qec/unittests/realtime/CMakeLists.txt
+++ b/libs/qec/unittests/realtime/CMakeLists.txt
@@ -7,7 +7,7 @@
 # ============================================================================ #
 
 # FIXME - these fail to compile with CUDA-Q w/ LLVM
-add_subdirectory(app_examples)
+#add_subdirectory(app_examples)
 
 # =========================================================================== #
 # test_realtime_predecoder_w_pymatching

--- a/libs/qec/unittests/realtime/CMakeLists.txt
+++ b/libs/qec/unittests/realtime/CMakeLists.txt
@@ -6,7 +6,6 @@
 # the terms of the Apache License 2.0 which accompanies this distribution.     #
 # ============================================================================ #
 
-# FIXME - these fail to compile with CUDA-Q w/ LLVM
 add_subdirectory(app_examples)
 
 # =========================================================================== #

--- a/libs/qec/unittests/realtime/CMakeLists.txt
+++ b/libs/qec/unittests/realtime/CMakeLists.txt
@@ -7,7 +7,7 @@
 # ============================================================================ #
 
 # FIXME - these fail to compile with CUDA-Q w/ LLVM
-#add_subdirectory(app_examples)
+add_subdirectory(app_examples)
 
 # =========================================================================== #
 # test_realtime_predecoder_w_pymatching

--- a/libs/solvers/CMakeLists.txt
+++ b/libs/solvers/CMakeLists.txt
@@ -28,7 +28,7 @@ endif()
 # Project setup
 # ==============================================================================
 
-add_compile_options(-Wno-attributes) 
+add_compile_options($<$<COMPILE_LANGUAGE:C,CXX>:-Wno-attributes>)
 
 # Check if core is built as a standalone project.
 if (CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)

--- a/libs/solvers/CMakeLists.txt
+++ b/libs/solvers/CMakeLists.txt
@@ -80,7 +80,7 @@ option(CUDAQX_SOLVERS_INSTALL_PYTHON
 # using `LLVM_VERSION_MAJOR`, e.g. "-LLVM_VERSION_MAJOR=16".  Note that this
 # version variable is set to the latest LLVM version by default, and setting it
 # to an older version might break the project.
-find_package(LLVM ${LLVM_VERSION_MAJOR} CONFIG QUIET)
+find_package(LLVM ${LLVM_VERSION_MAJOR}.${LLVM_VERSION_MINOR} CONFIG QUIET)
 
 if(NOT LLVM_DIR)
   message(STATUS "LLVM_DIR not found, will try with llvm-config executable.")
@@ -141,7 +141,7 @@ if(NOT LLVM_DIR)
       "Could not find suitable llvm-config(-${LLVM_VERSION_MAJOR}).\
       \nTry providing valid -DLLVM_DIR=/path/to/llvm/lib/cmake/llvm.")
   else()
-    find_package(LLVM ${LLVM_VERSION_MAJOR} REQUIRED CONFIG
+    find_package(LLVM ${LLVM_VERSION_MAJOR}.${LLVM_VERSION_MINOR} REQUIRED CONFIG
       HINTS ${LLVM_CONFIG_CMAKE_DIR} NO_DEFAULT_PATH)
   endif()
 endif()

--- a/libs/solvers/CMakeLists.txt
+++ b/libs/solvers/CMakeLists.txt
@@ -80,6 +80,12 @@ option(CUDAQX_SOLVERS_INSTALL_PYTHON
 # using `LLVM_VERSION_MAJOR`, e.g. "-LLVM_VERSION_MAJOR=16".  Note that this
 # version variable is set to the latest LLVM version by default, and setting it
 # to an older version might break the project.
+if(NOT LLVM_VERSION_MAJOR)
+  set(LLVM_VERSION_MAJOR 22)
+endif()
+if(NOT LLVM_VERSION_MINOR)
+  set(LLVM_VERSION_MINOR 1)
+endif()
 find_package(LLVM ${LLVM_VERSION_MAJOR}.${LLVM_VERSION_MINOR} CONFIG QUIET)
 
 if(NOT LLVM_DIR)

--- a/libs/solvers/python/CMakeLists.txt
+++ b/libs/solvers/python/CMakeLists.txt
@@ -17,7 +17,7 @@ if(NOT COMMAND nanobind_add_module)
   FetchContent_Declare(
     nanobind
     GIT_REPOSITORY https://github.com/wjakob/nanobind
-    GIT_TAG v2.12.0
+    GIT_TAG v2.9.2
     EXCLUDE_FROM_ALL
   )
   FetchContent_MakeAvailable(nanobind)

--- a/libs/solvers/python/bindings/utils/type_casters.h
+++ b/libs/solvers/python/bindings/utils/type_casters.h
@@ -19,6 +19,33 @@ namespace nanobind {
 namespace detail {
 
 template <>
+struct type_caster<cudaq::spin_op> {
+  NB_TYPE_CASTER(cudaq::spin_op, const_name("SpinOperator"))
+
+  bool from_python(handle src, uint8_t, cleanup_list *) noexcept {
+    if (!src)
+      return false;
+    try {
+      auto data = nb::cast<std::vector<double>>(src.attr("serialize")());
+      value = cudaq::spin_op(data);
+      return true;
+    } catch (...) {
+      return false;
+    }
+  }
+
+  static handle from_cpp(cudaq::spin_op v, rv_policy, cleanup_list *) noexcept {
+    try {
+      nb::object tv_py = nb::module_::import_("cudaq").attr("SpinOperator")(
+          v.get_data_representation());
+      return tv_py.release();
+    } catch (...) {
+      return handle();
+    }
+  }
+};
+
+template <>
 struct type_caster<cudaq::pauli_word> {
   NB_TYPE_CASTER(cudaq::pauli_word, const_name("pauli_word"))
 

--- a/libs/solvers/python/bindings/utils/type_casters.h
+++ b/libs/solvers/python/bindings/utils/type_casters.h
@@ -19,33 +19,6 @@ namespace nanobind {
 namespace detail {
 
 template <>
-struct type_caster<cudaq::spin_op> {
-  NB_TYPE_CASTER(cudaq::spin_op, const_name("SpinOperator"))
-
-  bool from_python(handle src, uint8_t, cleanup_list *) noexcept {
-    if (!src)
-      return false;
-    try {
-      auto data = nb::cast<std::vector<double>>(src.attr("serialize")());
-      value = cudaq::spin_op(data);
-      return true;
-    } catch (...) {
-      return false;
-    }
-  }
-
-  static handle from_cpp(cudaq::spin_op v, rv_policy, cleanup_list *) noexcept {
-    try {
-      nb::object tv_py = nb::module_::import_("cudaq").attr("SpinOperator")(
-          v.get_data_representation());
-      return tv_py.release();
-    } catch (...) {
-      return handle();
-    }
-  }
-};
-
-template <>
 struct type_caster<cudaq::pauli_word> {
   NB_TYPE_CASTER(cudaq::pauli_word, const_name("pauli_word"))
 

--- a/libs/solvers/unittests/CMakeLists.txt
+++ b/libs/solvers/unittests/CMakeLists.txt
@@ -21,10 +21,11 @@ set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
 
 # Bug in GCC 12 leads to spurious warnings (-Wrestrict)
 # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=105329
-if (CMAKE_COMPILER_IS_GNUCXX 
-  AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 12.0.0 
+if (CMAKE_COMPILER_IS_GNUCXX
+  AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 12.0.0
   AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 13.0.0)
-  target_compile_options(gtest PUBLIC --param=evrp-mode=legacy)
+  target_compile_options(gtest PUBLIC
+    $<$<COMPILE_LANGUAGE:CXX>:--param=evrp-mode=legacy>)
 endif()
 include(GoogleTest)
 

--- a/scripts/build_wheels.sh
+++ b/scripts/build_wheels.sh
@@ -8,7 +8,7 @@
 # the terms of the Apache License 2.0 which accompanies this distribution.     #
 # ============================================================================ #
 
-IMAGE_NAME=ghcr.io/nvidia/cuda-quantum-devdeps:manylinux-amd64-cu12.6-gcc11-main
+IMAGE_NAME=ghcr.io/nvidia/cuda-quantum-devdeps:manylinux-amd64-cu12.6-gcc12-main
 
 CONTAINER_NAME=cudaqx_wheel_builder
 CONTAINER_STATUS=$(docker container inspect -f '{{.State.Status}}' $CONTAINER_NAME 2>/dev/null)

--- a/scripts/ci/build_cudaq_wheel.sh
+++ b/scripts/ci/build_cudaq_wheel.sh
@@ -18,7 +18,7 @@ cd /cuda-quantum
 export CUDA_VERSION=12.6
 
 # We need to use a newer toolchain because CUDA-QX libraries rely on c++20
-source /opt/rh/gcc-toolset-11/enable
+source /opt/rh/gcc-toolset-12/enable
 
 export CC=gcc
 export CXX=g++

--- a/scripts/ci/build_qec_wheel.sh
+++ b/scripts/ci/build_qec_wheel.sh
@@ -24,12 +24,12 @@ git config --global --add safe.directory /cuda-qx
 cd /cuda-qx/libs/qec
 
 # We need to use a newer toolchain because CUDA-QX libraries rely on c++20
-source /opt/rh/gcc-toolset-11/enable
+source /opt/rh/gcc-toolset-12/enable
 
 export CC=gcc
 export CXX=g++
 
-SKBUILD_CMAKE_ARGS="-DCUDAQ_DIR=$HOME/.cudaq/lib/cmake/cudaq;-DCMAKE_CXX_COMPILER_EXTERNAL_TOOLCHAIN=/opt/rh/gcc-toolset-11/root/usr/lib/gcc/x86_64-redhat-linux/11/" \
+SKBUILD_CMAKE_ARGS="-DCUDAQ_DIR=$HOME/.cudaq/lib/cmake/cudaq;-DCMAKE_CXX_COMPILER_EXTERNAL_TOOLCHAIN=/opt/rh/gcc-toolset-12/root/usr/lib/gcc/x86_64-redhat-linux/12/" \
 $python -m build --wheel
 
 LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$(pwd)/_skbuild/lib" \

--- a/scripts/ci/build_solvers_wheel.sh
+++ b/scripts/ci/build_solvers_wheel.sh
@@ -24,12 +24,12 @@ git config --global --add safe.directory /cuda-qx
 cd /cuda-qx/libs/solvers
 
 # We need to use a newer toolchain because CUDA-QX libraries rely on c++20
-source /opt/rh/gcc-toolset-11/enable
+source /opt/rh/gcc-toolset-12/enable
 
 export CC=gcc
 export CXX=g++
 
-SKBUILD_CMAKE_ARGS="-DCUDAQ_DIR=$HOME/.cudaq/lib/cmake/cudaq;-DCMAKE_CXX_COMPILER_EXTERNAL_TOOLCHAIN=/opt/rh/gcc-toolset-11/root/usr/lib/gcc/x86_64-redhat-linux/11/" \
+SKBUILD_CMAKE_ARGS="-DCUDAQ_DIR=$HOME/.cudaq/lib/cmake/cudaq;-DCMAKE_CXX_COMPILER_EXTERNAL_TOOLCHAIN=/opt/rh/gcc-toolset-12/root/usr/lib/gcc/x86_64-redhat-linux/12/" \
 $python -m build --wheel
 
 LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$(pwd)/_skbuild/lib" \


### PR DESCRIPTION
## Summary

This PR updates the CUDA-Q Libraries to build cleanly with the LLVM 22 toolchain and aligns the CI, container, and wheel build paths with the GCC 12-based CUDA-Q environment. It also reduces drift from upstream CUDA-Q build logic.

## What changed

- Updated CMake configuration to default to LLVM `22.1` and use the full major/minor version when locating LLVM.
- Switched CI jobs, wheel builds, helper scripts, docker images, cache keys, and workflow toolchain settings from `gcc-11` to `gcc-12`.
- Scoped GCC12-specific flags such as `--param=evrp-mode=legacy` and `-Wno-attributes` so they only apply to the relevant C/C++ compilation paths.
- Bumped the pinned CUDA-Q / CUDA-Q Realtime refs and updated the `get-cudaq-build` action to delegate to upstream `cudaq/scripts/build_cudaq.sh`, while preserving CUDA-QX-specific defaults.
- Added parallel `cmake --build -j` usage in CI helper scripts and pinned `cmake<4` where needed for compatibility.
- Matched CUDA-Q's nanobind configuration by using the CUDA-Q nanobind domain and pinning the version expected by the current upstream integration. Note: CUDA-Q rolledback nanobind from 2.12.0 to 2.9.2 as part of the LLVM update. It's not clear if this was intentional or not, but if they decide to roll back to 2.12.0, we can revert a0724f6, which was only added to account for this change.

**Note: wheel builds do not work yet. Those will be handled with a follow-up PR.**