### PR TITLE
Fix for building Python wheels with LLVM 22

### DIFF
--- a/.github/actions/build-lib/build_all.sh
+++ b/.github/actions/build-lib/build_all.sh
@@ -20,4 +20,4 @@ cmake -S . -B "$1" \
   -DCMAKE_INSTALL_PREFIX="$2" \
   $_rt_flag
 
-cmake --build "$1" --target install -j
+cmake --build "$1" --target install -j 4

--- a/.github/actions/build-lib/build_qec.sh
+++ b/.github/actions/build-lib/build_qec.sh
@@ -128,4 +128,4 @@ cmake -S libs/qec -B "$1" \
   -DHOLOSCAN_SENSOR_BRIDGE_SOURCE_DIR=$HSB_ROOT \
   -DHOLOSCAN_SENSOR_BRIDGE_BUILD_DIR=$HSB_BUILD
 
-cmake --build "$1" --target install -j
+cmake --build "$1" --target install -j 4

--- a/.github/actions/build-lib/build_solvers.sh
+++ b/.github/actions/build-lib/build_solvers.sh
@@ -11,5 +11,4 @@ cmake -S libs/solvers -B "$1" \
   -DCUDAQX_BINDINGS_PYTHON=ON \
   -DCMAKE_INSTALL_PREFIX="$2"
 
-cmake --build "$1" --target install -j
-
+cmake --build "$1" --target install -j 4

--- a/.github/workflows/lib_qec.yaml
+++ b/.github/workflows/lib_qec.yaml
@@ -193,19 +193,24 @@ jobs:
         run: |
           pip install --upgrade "cuquantum-python-cu${{ steps.config.outputs.cuda_major }}>=26.3.0"
 
-      - name: Install TensorRT (amd64)
+      - name: Install TensorRT (C++, amd64)
         if: matrix.platform == 'amd64'
         run: |
           apt-cache search tensorrt | awk '{print "Package: "$1"\nPin: version *+cuda${{ matrix.cuda_version }}\nPin-Priority: 1001\n"}' | tee /etc/apt/preferences.d/tensorrt-cuda${{ matrix.cuda_version }}.pref > /dev/null
           apt update
           apt install -y tensorrt-dev
 
-      - name: Install TensorRT (arm64)
+      - name: Install TensorRT (C++, arm64)
         if: matrix.platform == 'arm64' && !startsWith(matrix.cuda_version, '12')
         run: |
           apt-cache search tensorrt | awk '{print "Package: "$1"\nPin: version *+cuda13.0\nPin-Priority: 1001\n"}' | tee /etc/apt/preferences.d/tensorrt-cuda13.0.pref > /dev/null
           apt update
           apt install -y tensorrt-dev
+
+      - name: Install TensorRT (Python)
+        if: matrix.platform != 'arm64' || !startsWith(matrix.cuda_version, '12')
+        run: |
+          pip install "tensorrt-cu${{ steps.config.outputs.cuda_major }}==10.13.*" "cuda_toolkit[cudart]==${{ matrix.cuda_version }}.*"
 
       - name: Install Python GPU test requirements
         run: |
@@ -222,4 +227,3 @@ jobs:
         run: |
           PYTHONPATH="/cudaq-install:$GITHUB_WORKSPACE/build_qec/python" \
             pytest -v libs/qec/python/tests/
-

--- a/.github/workflows/lib_qec.yaml
+++ b/.github/workflows/lib_qec.yaml
@@ -193,24 +193,19 @@ jobs:
         run: |
           pip install --upgrade "cuquantum-python-cu${{ steps.config.outputs.cuda_major }}>=26.3.0"
 
-      - name: Install TensorRT (C++, amd64)
+      - name: Install TensorRT (amd64)
         if: matrix.platform == 'amd64'
         run: |
           apt-cache search tensorrt | awk '{print "Package: "$1"\nPin: version *+cuda${{ matrix.cuda_version }}\nPin-Priority: 1001\n"}' | tee /etc/apt/preferences.d/tensorrt-cuda${{ matrix.cuda_version }}.pref > /dev/null
           apt update
           apt install -y tensorrt-dev
 
-      - name: Install TensorRT (C++, arm64)
+      - name: Install TensorRT (arm64)
         if: matrix.platform == 'arm64' && !startsWith(matrix.cuda_version, '12')
         run: |
           apt-cache search tensorrt | awk '{print "Package: "$1"\nPin: version *+cuda13.0\nPin-Priority: 1001\n"}' | tee /etc/apt/preferences.d/tensorrt-cuda13.0.pref > /dev/null
           apt update
           apt install -y tensorrt-dev
-
-      - name: Install TensorRT (Python)
-        if: matrix.platform != 'arm64' || !startsWith(matrix.cuda_version, '12')
-        run: |
-          pip install "tensorrt-cu${{ steps.config.outputs.cuda_major }}==10.13.*" "cuda_toolkit[cudart]==${{ matrix.cuda_version }}.*"
 
       - name: Install Python GPU test requirements
         run: |
@@ -227,3 +222,4 @@ jobs:
         run: |
           PYTHONPATH="/cudaq-install:$GITHUB_WORKSPACE/build_qec/python" \
             pytest -v libs/qec/python/tests/
+

--- a/.github/workflows/scripts/build_cudaq.sh
+++ b/.github/workflows/scripts/build_cudaq.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # ============================================================================ #
 # Copyright (c) 2022 - 2026 NVIDIA Corporation & Affiliates.                   #
@@ -11,6 +11,8 @@
 # ==============================================================================
 # Handling options
 # ==============================================================================
+
+set -eo pipefail
 
 show_help() {
     echo "Usage: $0 [options]"
@@ -99,7 +101,7 @@ echo "Building MLIR bindings for ${python}" && \
     Python3_EXECUTABLE="$(which ${python})" \
     LLVM_PROJECTS='clang;mlir;python-bindings' \
     LLVM_CMAKE_CACHE=/cmake/caches/LLVM.cmake LLVM_SOURCE=/llvm-project \
-    bash /scripts/build_llvm.sh -c Release -v 
+    bash scripts/build_llvm.sh -c Release -v
 
 # ==============================================================================
 # Building CUDA-Q

--- a/.github/workflows/scripts/build_cudaq.sh
+++ b/.github/workflows/scripts/build_cudaq.sh
@@ -108,42 +108,30 @@ echo "Building MLIR bindings for ${python}" && \
 # ==============================================================================
 
 CUDAQ_PATCH='diff --git a/CMakeLists.txt b/CMakeLists.txt
-index dc906f615..5d591ea06 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -682,7 +682,7 @@ if(CUDAQ_BUILD_TESTS)
+@@ -709,8 +709,8 @@ if(CUDAQ_BUILD_TESTS)
  endif()
 
  if (CUDAQ_ENABLE_PYTHON)
 -  find_package(Python 3 COMPONENTS Interpreter Development)
+-  find_package(Python3 COMPONENTS Interpreter Development)
 +  find_package(Python 3 COMPONENTS Interpreter Development.Module)
++  find_package(Python3 COMPONENTS Interpreter Development.Module)
 
    # Apply specific patch to pybind11 for our documentation.
    # Only apply the patch if not already applied.
 diff --git a/python/runtime/cudaq/domains/plugins/CMakeLists.txt b/python/runtime/cudaq/domains/plugins/CMakeLists.txt
-index 3bd2e991..2603e72f 100644
 --- a/python/runtime/cudaq/domains/plugins/CMakeLists.txt
 +++ b/python/runtime/cudaq/domains/plugins/CMakeLists.txt
-@@ -33,6 +33,6 @@ else()
-   endif()
+@@ -33,7 +33,7 @@ if (SKBUILD)
+ else()
    target_link_libraries(cudaq-pyscf
      PRIVATE
--      nanobind-static Python::Python
-+      nanobind-static Python::Module
+-      nanobind-static Python3::Python
++      nanobind-static Python3::Module
        cudaq-chemistry cudaq-operator cudaq cudaq-py-utils cudaq-platform-default)
  endif()
-diff --git a/python/runtime/interop/CMakeLists.txt b/python/runtime/interop/CMakeLists.txt
-index c20b2d83..dcc7bfdf 100644
---- a/python/runtime/interop/CMakeLists.txt
-+++ b/python/runtime/interop/CMakeLists.txt
-@@ -14,6 +14,6 @@ target_include_directories(cudaq-python-interop PRIVATE
- if (SKBUILD)
-   target_link_libraries(cudaq-python-interop PRIVATE nanobind-static Python::Module cudaq)
- else()
--  target_link_libraries(cudaq-python-interop PRIVATE nanobind-static Python::Python cudaq)
-+  target_link_libraries(cudaq-python-interop PRIVATE nanobind-static Python::Module cudaq)
- endif()
- install (FILES PythonCppInterop.h PythonCppInteropDecls.h DESTINATION include/cudaq/python/)
 '
 
 echo "$CUDAQ_PATCH" | git apply --verbose


### PR DESCRIPTION
Fix wheel build for LLVM 22. For most recent run of the wheel build, see [here](https://github.com/NVIDIA/cudaqx/actions/runs/25698909898).

- Update path for script call in `build_cudaq.sh`, so that correct script version is run
- Refresh git diff patch
- Limit max cmake build parallelism, to prevent out-of-memory CI failures