### PR TITLE
Fix failing test in Python wheels

### DIFF
--- a/.github/workflows/lib_qec.yaml
+++ b/.github/workflows/lib_qec.yaml
@@ -193,19 +193,24 @@ jobs:
         run: |
           pip install --upgrade "cuquantum-python-cu${{ steps.config.outputs.cuda_major }}>=26.3.0"
 
-      - name: Install TensorRT (amd64)
+      - name: Install TensorRT (C++, amd64)
         if: matrix.platform == 'amd64'
         run: |
           apt-cache search tensorrt | awk '{print "Package: "$1"\nPin: version *+cuda${{ matrix.cuda_version }}\nPin-Priority: 1001\n"}' | tee /etc/apt/preferences.d/tensorrt-cuda${{ matrix.cuda_version }}.pref > /dev/null
           apt update
           apt install -y tensorrt-dev
 
-      - name: Install TensorRT (arm64)
+      - name: Install TensorRT (C++, arm64)
         if: matrix.platform == 'arm64' && !startsWith(matrix.cuda_version, '12')
         run: |
           apt-cache search tensorrt | awk '{print "Package: "$1"\nPin: version *+cuda13.0\nPin-Priority: 1001\n"}' | tee /etc/apt/preferences.d/tensorrt-cuda13.0.pref > /dev/null
           apt update
           apt install -y tensorrt-dev
+
+      - name: Install TensorRT (Python)
+        if: matrix.platform != 'arm64' || !startsWith(matrix.cuda_version, '12')
+        run: |
+          pip install "tensorrt-cu${{ steps.config.outputs.cuda_major }}==10.13.*" "cuda_toolkit[cudart]==${{ matrix.cuda_version }}.*"
 
       - name: Install Python GPU test requirements
         run: |
@@ -222,4 +227,3 @@ jobs:
         run: |
           PYTHONPATH="/cudaq-install:$GITHUB_WORKSPACE/build_qec/python" \
             pytest -v libs/qec/python/tests/
-

--- a/libs/qec/python/tests/test_trt_decoder.py
+++ b/libs/qec/python/tests/test_trt_decoder.py
@@ -922,21 +922,26 @@ class TestTRTDecoderBatchValidation:
                 except Exception:
                     pass  # tmp_path cleanup will handle it
 
-    def test_decode_batch_non_integral_multiple_should_fail(
+    def test_decode_batch_accepts_non_integral_multiple(
             self, decoder_with_batch_size):
-        """Test that decode_batch fails when syndrome count is not an integral multiple of batch size."""
+        """Test that decode_batch accepts a final partial batch."""
         decoder, batch_size, syndrome_size, _ = decoder_with_batch_size
 
         if batch_size == 1:
-            pytest.skip("All counts work for batch_size=1")
+            pytest.skip("All counts are integral multiples for batch_size=1")
 
         # Create syndromes (batch_size + 1) - not a multiple
         syndromes = [[float(i + j)
                       for i in range(syndrome_size)]
                      for j in range(batch_size + 1)]
 
-        with pytest.raises(RuntimeError, match="integral multiple"):
-            decoder.decode_batch(syndromes)
+        results = decoder.decode_batch(syndromes)
+
+        assert len(results) == len(syndromes), f"Expected {len(syndromes)} results, got {len(results)}"
+        for i, result in enumerate(results):
+            assert result.converged, f"Result {i} did not converge"
+            assert len(result.result) == syndrome_size, \
+                f"Result {i} has wrong output size: {len(result.result)}"
 
     def test_decode_batch_syndrome_size_mismatch(self, decoder_with_batch_size):
         """Test that decode_batch validates individual syndrome sizes."""

--- a/libs/qec/python/tests/test_trt_decoder.py
+++ b/libs/qec/python/tests/test_trt_decoder.py
@@ -937,7 +937,8 @@ class TestTRTDecoderBatchValidation:
 
         results = decoder.decode_batch(syndromes)
 
-        assert len(results) == len(syndromes), f"Expected {len(syndromes)} results, got {len(results)}"
+        assert len(results) == len(
+            syndromes), f"Expected {len(syndromes)} results, got {len(results)}"
         for i, result in enumerate(results):
             assert result.converged, f"Result {i} did not converge"
             assert len(result.result) == syndrome_size, \


### PR DESCRIPTION
See test failure [here](https://github.com/NVIDIA/cudaqx/actions/runs/25698909898).

Python packages for TensorRT are installed in `test_wheels.sh`, but only installed for C++ in the general PR workflow. Because of this, Python tests that relied on TensorRT were skipped in PR checks, and the above test didn't fail until the Python wheels were tested. This PR adds Python TensorRT installation to the general PR workflow, meaning this test will no longer be skipped there. It also updates the failing test to match the new behavior from #524.