### PR TITLE
Rename CUDAQ_REGISTER_TYPE --> CUDAQ_EXT_PT_REGISTER_TYPE

### DIFF
--- a/.cudaq_realtime_version
+++ b/.cudaq_realtime_version
@@ -1,6 +1,6 @@
 {
   "cudaq_realtime": {
     "repository": "NVIDIA/cuda-quantum",
-    "ref": "e47b30b4d50385b97284fb124f33d3e370107fb2"
+    "ref": "cd88025b3d1beb02ca2703de70a583e647af10fb"
   }
 }

--- a/.cudaq_version
+++ b/.cudaq_version
@@ -1,6 +1,6 @@
 {
   "cudaq": {
     "repository": "NVIDIA/cuda-quantum",
-    "ref": "e47b30b4d50385b97284fb124f33d3e370107fb2"
+    "ref": "cd88025b3d1beb02ca2703de70a583e647af10fb"
   }
 }

--- a/docs/sphinx/components/qec/introduction.rst
+++ b/docs/sphinx/components/qec/introduction.rst
@@ -182,7 +182,7 @@ To implement a new quantum error correcting code:
            }
        )
 
-       CUDAQ_REGISTER_TYPE(my_code)
+       CUDAQ_EXT_PT_REGISTER_TYPE(my_code)
 
 Example: Steane Code
 ^^^^^^^^^^^^^^^^^^^^^
@@ -581,7 +581,7 @@ To implement a new decoder:
         }
     )
 
-    CUDAQ_REGISTER_TYPE(my_decoder)
+    CUDAQ_EXT_PT_REGISTER_TYPE(my_decoder)
 
 Example: Lookup Table Decoder
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/libs/core/include/cuda-qx/core/extension_point.h
+++ b/libs/core/include/cuda-qx/core/extension_point.h
@@ -58,10 +58,10 @@ namespace cudaqx {
 /// @endcode
 ///
 /// 3. Register your extensions:
-///    Use the CUDAQ_REGISTER_TYPE macro to register each extension.
+///    Use the CUDAQ_EXT_PT_REGISTER_TYPE macro to register each extension.
 ///
 /// @code
-/// CUDAQ_REGISTER_TYPE(RepeatBackOne)
+/// CUDAQ_EXT_PT_REGISTER_TYPE(RepeatBackOne)
 /// @endcode
 ///
 /// 4. Use your extensions:
@@ -181,7 +181,7 @@ public:
 
 /// @brief Macro for registering an extension type.
 /// @param TYPE The class to be registered as an extension.
-#define CUDAQ_REGISTER_TYPE(TYPE)                                              \
+#define CUDAQ_EXT_PT_REGISTER_TYPE(TYPE)                                       \
   const bool TYPE::registered_ = TYPE::register_type();                        \
   /* We must ALSO provide a destructor to clean up the registry so that when a \
    * dlcose happens, the parent registry no longer holds references to code    \

--- a/libs/core/unittests/test_core.cpp
+++ b/libs/core/unittests/test_core.cpp
@@ -42,7 +42,7 @@ public:
 };
 
 // Extensions must register themselves
-CUDAQ_REGISTER_TYPE(RepeatBackOne)
+CUDAQ_EXT_PT_REGISTER_TYPE(RepeatBackOne)
 
 class RepeatBackTwo : public MyExtensionPoint {
 public:
@@ -51,7 +51,7 @@ public:
   }
   CUDAQ_EXTENSION_CREATOR_FUNCTION(MyExtensionPoint, RepeatBackTwo)
 };
-CUDAQ_REGISTER_TYPE(RepeatBackTwo)
+CUDAQ_EXT_PT_REGISTER_TYPE(RepeatBackTwo)
 
 } // namespace cudaqx::testing
 
@@ -112,7 +112,7 @@ public:
       })
 };
 
-CUDAQ_REGISTER_TYPE(RepeatBackOneWithArgs)
+CUDAQ_EXT_PT_REGISTER_TYPE(RepeatBackOneWithArgs)
 
 class RepeatBackTwoWithArgs : public MyExtensionPointWithArgs {
 public:
@@ -128,7 +128,7 @@ public:
       })
 };
 
-CUDAQ_REGISTER_TYPE(RepeatBackTwoWithArgs)
+CUDAQ_EXT_PT_REGISTER_TYPE(RepeatBackTwoWithArgs)
 
 } // namespace cudaqx::testing
 

--- a/libs/qec/include/cudaq/qec/code.h
+++ b/libs/qec/include/cudaq/qec/code.h
@@ -59,7 +59,7 @@ enum class operation {
 /// the fault tolerant logical operation implementations)
 /// 4. Register the operations in your constructor using the
 /// operation_encodings map on the base class
-/// 5. Register your new code type using CUDAQ_REGISTER_TYPE
+/// 5. Register your new code type using CUDAQ_EXT_PT_REGISTER_TYPE
 ///
 /// Example implementation:
 /// @code{.cpp}
@@ -92,7 +92,7 @@ enum class operation {
 ///   )
 /// };
 ///
-/// CUDAQ_REGISTER_TYPE(my_code)
+/// CUDAQ_EXT_PT_REGISTER_TYPE(my_code)
 /// @endcode
 /// @brief Supported quantum operations for error correcting codes
 class code : public cudaqx::extension_point<code, const heterogeneous_map &> {

--- a/libs/qec/lib/codes/repetition.cpp
+++ b/libs/qec/lib/codes/repetition.cpp
@@ -55,6 +55,6 @@ repetition::repetition(const heterogeneous_map &options) : code() {
 }
 
 /// @brief Register the repetition code type
-CUDAQ_REGISTER_TYPE(repetition)
+CUDAQ_EXT_PT_REGISTER_TYPE(repetition)
 
 } // namespace cudaq::qec::repetition

--- a/libs/qec/lib/codes/steane.cpp
+++ b/libs/qec/lib/codes/steane.cpp
@@ -37,6 +37,6 @@ steane::steane(const heterogeneous_map &options) : code() {
 }
 
 /// @brief Register the Steane code type
-CUDAQ_REGISTER_TYPE(steane)
+CUDAQ_EXT_PT_REGISTER_TYPE(steane)
 
 } // namespace cudaq::qec::steane

--- a/libs/qec/lib/codes/surface_code.cpp
+++ b/libs/qec/lib/codes/surface_code.cpp
@@ -405,6 +405,6 @@ std::size_t surface_code::get_num_z_stabilizers() const {
 }
 
 /// @brief Register the surace_code type
-CUDAQ_REGISTER_TYPE(surface_code)
+CUDAQ_EXT_PT_REGISTER_TYPE(surface_code)
 
 } // namespace cudaq::qec::surface_code

--- a/libs/qec/lib/decoders/lut.cpp
+++ b/libs/qec/lib/decoders/lut.cpp
@@ -239,7 +239,7 @@ public:
       })
 };
 
-CUDAQ_REGISTER_TYPE(multi_error_lut)
+CUDAQ_EXT_PT_REGISTER_TYPE(multi_error_lut)
 
 class single_error_lut : public multi_error_lut {
 public:
@@ -257,6 +257,6 @@ public:
       })
 };
 
-CUDAQ_REGISTER_TYPE(single_error_lut)
+CUDAQ_EXT_PT_REGISTER_TYPE(single_error_lut)
 
 } // namespace cudaq::qec

--- a/libs/qec/lib/decoders/plugins/example/single_error_lut_example.cpp
+++ b/libs/qec/lib/decoders/plugins/example/single_error_lut_example.cpp
@@ -86,6 +86,6 @@ public:
       })
 };
 
-CUDAQ_REGISTER_TYPE(single_error_lut_example)
+CUDAQ_EXT_PT_REGISTER_TYPE(single_error_lut_example)
 
 } // namespace cudaq::qec

--- a/libs/qec/lib/decoders/plugins/pymatching/pymatching.cpp
+++ b/libs/qec/lib/decoders/plugins/pymatching/pymatching.cpp
@@ -247,6 +247,6 @@ public:
       })
 };
 
-CUDAQ_REGISTER_TYPE(pymatching)
+CUDAQ_EXT_PT_REGISTER_TYPE(pymatching)
 
 } // namespace cudaq::qec

--- a/libs/qec/lib/decoders/plugins/trt_decoder/trt_decoder.cpp
+++ b/libs/qec/lib/decoders/plugins/trt_decoder/trt_decoder.cpp
@@ -1070,7 +1070,7 @@ void trt_decoder::check_cuda() {
   }
 }
 
-CUDAQ_REGISTER_TYPE(trt_decoder)
+CUDAQ_EXT_PT_REGISTER_TYPE(trt_decoder)
 
 } // namespace cudaq::qec
 

--- a/libs/qec/lib/decoders/sliding_window.cpp
+++ b/libs/qec/lib/decoders/sliding_window.cpp
@@ -482,6 +482,6 @@ std::size_t sliding_window::get_num_syndromes_per_round() const {
   return num_syndromes_per_round;
 }
 
-CUDAQ_REGISTER_TYPE(sliding_window)
+CUDAQ_EXT_PT_REGISTER_TYPE(sliding_window)
 
 } // namespace cudaq::qec

--- a/libs/qec/unittests/decoders/sample_decoder.cpp
+++ b/libs/qec/unittests/decoders/sample_decoder.cpp
@@ -41,6 +41,6 @@ public:
       })
 };
 
-CUDAQ_REGISTER_TYPE(sample_decoder)
+CUDAQ_EXT_PT_REGISTER_TYPE(sample_decoder)
 
 } // namespace cudaq::qec

--- a/libs/solvers/include/cudaq/solvers/adapt/adapt_simulator.h
+++ b/libs/solvers/include/cudaq/solvers/adapt/adapt_simulator.h
@@ -44,6 +44,6 @@ public:
 };
 
 /// @brief Register the simulator type with the CUDA-Q framework
-CUDAQ_REGISTER_TYPE(simulator)
+CUDAQ_EXT_PT_REGISTER_TYPE(simulator)
 
 } // namespace cudaq::solvers::adapt

--- a/libs/solvers/include/cudaq/solvers/observe_gradients/central_difference.h
+++ b/libs/solvers/include/cudaq/solvers/observe_gradients/central_difference.h
@@ -32,6 +32,6 @@ public:
       })
 };
 
-CUDAQ_REGISTER_TYPE(central_difference)
+CUDAQ_EXT_PT_REGISTER_TYPE(central_difference)
 
 } // namespace cudaq

--- a/libs/solvers/include/cudaq/solvers/observe_gradients/forward_difference.h
+++ b/libs/solvers/include/cudaq/solvers/observe_gradients/forward_difference.h
@@ -30,5 +30,5 @@ public:
         return std::make_unique<forward_difference>(functor, op);
       })
 };
-CUDAQ_REGISTER_TYPE(forward_difference)
+CUDAQ_EXT_PT_REGISTER_TYPE(forward_difference)
 } // namespace cudaq

--- a/libs/solvers/include/cudaq/solvers/observe_gradients/parameter_shift.h
+++ b/libs/solvers/include/cudaq/solvers/observe_gradients/parameter_shift.h
@@ -30,5 +30,5 @@ public:
         return std::make_unique<parameter_shift>(functor, op);
       })
 };
-CUDAQ_REGISTER_TYPE(parameter_shift)
+CUDAQ_EXT_PT_REGISTER_TYPE(parameter_shift)
 } // namespace cudaq

--- a/libs/solvers/include/cudaq/solvers/operators/molecule/fermion_compilers/bravyi_kitaev.h
+++ b/libs/solvers/include/cudaq/solvers/operators/molecule/fermion_compilers/bravyi_kitaev.h
@@ -25,5 +25,5 @@ public:
 
   CUDAQ_EXTENSION_CREATOR_FUNCTION(fermion_compiler, bravyi_kitaev)
 };
-CUDAQ_REGISTER_TYPE(bravyi_kitaev)
+CUDAQ_EXT_PT_REGISTER_TYPE(bravyi_kitaev)
 } // namespace cudaq::solvers

--- a/libs/solvers/include/cudaq/solvers/operators/molecule/fermion_compilers/jordan_wigner.h
+++ b/libs/solvers/include/cudaq/solvers/operators/molecule/fermion_compilers/jordan_wigner.h
@@ -20,5 +20,5 @@ public:
 
   CUDAQ_EXTENSION_CREATOR_FUNCTION(fermion_compiler, jordan_wigner)
 };
-CUDAQ_REGISTER_TYPE(jordan_wigner)
+CUDAQ_EXT_PT_REGISTER_TYPE(jordan_wigner)
 } // namespace cudaq::solvers

--- a/libs/solvers/include/cudaq/solvers/operators/operator_pools/ceo_operator_pool.h
+++ b/libs/solvers/include/cudaq/solvers/operators/operator_pools/ceo_operator_pool.h
@@ -44,6 +44,6 @@ public:
   CUDAQ_EXTENSION_CREATOR_FUNCTION(operator_pool, ceo)
 };
 /// @brief Register the ceo extension type with the CUDA-Q framework
-CUDAQ_REGISTER_TYPE(ceo)
+CUDAQ_EXT_PT_REGISTER_TYPE(ceo)
 
 } // namespace cudaq::solvers

--- a/libs/solvers/include/cudaq/solvers/operators/operator_pools/qaoa_operator_pool.h
+++ b/libs/solvers/include/cudaq/solvers/operators/operator_pools/qaoa_operator_pool.h
@@ -39,6 +39,6 @@ public:
 };
 
 /// @brief Register the qaoa_pool extension type with the CUDA-Q framework
-CUDAQ_REGISTER_TYPE(qaoa_pool)
+CUDAQ_EXT_PT_REGISTER_TYPE(qaoa_pool)
 
 } // namespace cudaq::solvers

--- a/libs/solvers/include/cudaq/solvers/operators/operator_pools/spin_complement_gsd.h
+++ b/libs/solvers/include/cudaq/solvers/operators/operator_pools/spin_complement_gsd.h
@@ -41,5 +41,5 @@ public:
 };
 /// @brief Register the spin_complement_gsd extension type with the CUDA-Q
 /// framework
-CUDAQ_REGISTER_TYPE(spin_complement_gsd)
+CUDAQ_EXT_PT_REGISTER_TYPE(spin_complement_gsd)
 } // namespace cudaq::solvers

--- a/libs/solvers/include/cudaq/solvers/operators/operator_pools/uccgsd_operator_pool.h
+++ b/libs/solvers/include/cudaq/solvers/operators/operator_pools/uccgsd_operator_pool.h
@@ -38,6 +38,6 @@ public:
   CUDAQ_EXTENSION_CREATOR_FUNCTION(operator_pool, uccgsd)
 };
 /// @brief Register the uccgsd extension type with the CUDA-Q framework
-CUDAQ_REGISTER_TYPE(uccgsd)
+CUDAQ_EXT_PT_REGISTER_TYPE(uccgsd)
 
 } // namespace cudaq::solvers

--- a/libs/solvers/include/cudaq/solvers/operators/operator_pools/uccsd_operator_pool.h
+++ b/libs/solvers/include/cudaq/solvers/operators/operator_pools/uccsd_operator_pool.h
@@ -38,6 +38,6 @@ public:
   CUDAQ_EXTENSION_CREATOR_FUNCTION(operator_pool, uccsd)
 };
 /// @brief Register the uccsd extension type with the CUDA-Q framework
-CUDAQ_REGISTER_TYPE(uccsd)
+CUDAQ_EXT_PT_REGISTER_TYPE(uccsd)
 
 } // namespace cudaq::solvers

--- a/libs/solvers/include/cudaq/solvers/operators/operator_pools/upccgsd_operator_pool.h
+++ b/libs/solvers/include/cudaq/solvers/operators/operator_pools/upccgsd_operator_pool.h
@@ -42,6 +42,6 @@ public:
 };
 
 /// @brief Register the upccgsd extension type with the CUDA-Q framework
-CUDAQ_REGISTER_TYPE(upccgsd)
+CUDAQ_EXT_PT_REGISTER_TYPE(upccgsd)
 
 } // namespace cudaq::solvers

--- a/libs/solvers/include/cudaq/solvers/optimizers/cobyla.h
+++ b/libs/solvers/include/cudaq/solvers/optimizers/cobyla.h
@@ -33,6 +33,6 @@ public:
   CUDAQ_EXTENSION_CREATOR_FUNCTION(optimizer, cobyla);
 };
 
-CUDAQ_REGISTER_TYPE(cobyla)
+CUDAQ_EXT_PT_REGISTER_TYPE(cobyla)
 
 } // namespace cudaq::optim

--- a/libs/solvers/include/cudaq/solvers/optimizers/lbfgs.h
+++ b/libs/solvers/include/cudaq/solvers/optimizers/lbfgs.h
@@ -32,5 +32,5 @@ public:
 
   CUDAQ_EXTENSION_CREATOR_FUNCTION(optimizer, lbfgs)
 };
-CUDAQ_REGISTER_TYPE(lbfgs)
+CUDAQ_EXT_PT_REGISTER_TYPE(lbfgs)
 } // namespace cudaq::optim

--- a/libs/solvers/lib/operators/molecule/drivers/pyscf_driver.cpp
+++ b/libs/solvers/lib/operators/molecule/drivers/pyscf_driver.cpp
@@ -191,6 +191,6 @@ public:
                                  num_electrons,   numOrb, energies};
   }
 };
-CUDAQ_REGISTER_TYPE(RESTPySCFDriver)
+CUDAQ_EXT_PT_REGISTER_TYPE(RESTPySCFDriver)
 
 } // namespace cudaq::solvers


### PR DESCRIPTION
This is needed to be compatible with the combination of the following upstream changes. Thanks for reporting @khalatepradnya.

* https://github.com/NVIDIA/cuda-quantum/pull/4385
* https://github.com/NVIDIA/cuda-quantum/pull/4469