### PR TITLE
ci: declare contents:read on PR sanity checks workflow

### DIFF
--- a/.github/workflows/pr_sanity_checks.yaml
+++ b/.github/workflows/pr_sanity_checks.yaml
@@ -13,6 +13,9 @@ concurrency:
 env:
   LLVM_VERSION: 16
 
+permissions:
+  contents: read
+
 jobs:
   check-changes:
     name: Check changes


### PR DESCRIPTION
The `pr_sanity_checks` workflow has four jobs (`check-changes`, `check-cpp`, `check-python`, `verify`) and only does read-style work: a `dorny/paths-filter` step on `pull_request`, `clang-format`/`yapf` runs against the diff, and `actions/upload-artifact` for the format patch on failure. None of the steps invoke the GitHub API beyond what `actions/checkout` needs.

Adding `permissions: contents: read` at workflow scope pins the token to that minimum. Most of the other workflows in the repo (`all_libs.yaml`, `all_libs_release.yaml`, `build_docker.yaml`, `build_qa_wheel_test.yaml`, `build_wheels.yaml`, ...) already carry per-job `permissions:` blocks, so the explicit-scope shape is already idiomatic here.

The third-party action exposure that motivates this: `dorny/paths-filter@v3` runs in the same context as the workflow token, so if it's ever compromised (cf. `tj-actions/changed-files` CVE-2025-30066), the explicit read-only scope keeps it boxed.

I deliberately left two other workflows out of this patch:

- `build_dev.yaml` pushes Docker images to `ghcr.io` and needs `packages: write`, which is a more involved permissions discussion best handled separately.
- `sync.yml` is guarded by `if: ${{ ... github.repository != 'NVIDIA/cudaqx' }}` so it never runs on the main repo; happy to tighten it if you'd like but it's not in the hot path.

No behavioural change to this workflow.