### PR TITLE
Update cudaq and nanobind versions

### DIFF
--- a/.cudaq_realtime_version
+++ b/.cudaq_realtime_version
@@ -1,6 +1,6 @@
 {
   "cudaq_realtime": {
     "repository": "NVIDIA/cuda-quantum",
-    "ref": "033eeeb2022400628dc662d1b0c2440ad3a7248b"
+    "ref": "053480dda0413c219c224d42313aa14d7a17a7fe"
   }
 }

--- a/.cudaq_realtime_version
+++ b/.cudaq_realtime_version
@@ -1,6 +1,6 @@
 {
   "cudaq_realtime": {
     "repository": "NVIDIA/cuda-quantum",
-    "ref": "cd88025b3d1beb02ca2703de70a583e647af10fb"
+    "ref": "b17e09ba3686fc13b101919a9276cd8fa0ddaac8"
   }
 }

--- a/.cudaq_realtime_version
+++ b/.cudaq_realtime_version
@@ -1,6 +1,6 @@
 {
   "cudaq_realtime": {
     "repository": "NVIDIA/cuda-quantum",
-    "ref": "b17e09ba3686fc13b101919a9276cd8fa0ddaac8"
+    "ref": "033eeeb2022400628dc662d1b0c2440ad3a7248b"
   }
 }

--- a/.cudaq_version
+++ b/.cudaq_version
@@ -1,6 +1,6 @@
 {
   "cudaq": {
     "repository": "NVIDIA/cuda-quantum",
-    "ref": "cd88025b3d1beb02ca2703de70a583e647af10fb"
+    "ref": "b17e09ba3686fc13b101919a9276cd8fa0ddaac8"
   }
 }

--- a/.cudaq_version
+++ b/.cudaq_version
@@ -1,6 +1,6 @@
 {
   "cudaq": {
     "repository": "NVIDIA/cuda-quantum",
-    "ref": "bb93f26df2ccb5300190318425dc08bd52b60e2e"
+    "ref": "f0aa11751cab921a3b299a16d2ecb12f309c54e8"
   }
 }

--- a/.cudaq_version
+++ b/.cudaq_version
@@ -1,6 +1,6 @@
 {
   "cudaq": {
     "repository": "NVIDIA/cuda-quantum",
-    "ref": "29143907207ff686fe19d761ef6e74c74d08eed9"
+    "ref": "12c93088eaca9164cd9885c161eb6e506dde4221"
   }
 }

--- a/.cudaq_version
+++ b/.cudaq_version
@@ -1,6 +1,6 @@
 {
   "cudaq": {
     "repository": "NVIDIA/cuda-quantum",
-    "ref": "b17e09ba3686fc13b101919a9276cd8fa0ddaac8"
+    "ref": "033eeeb2022400628dc662d1b0c2440ad3a7248b"
   }
 }

--- a/.cudaq_version
+++ b/.cudaq_version
@@ -1,6 +1,6 @@
 {
   "cudaq": {
     "repository": "NVIDIA/cuda-quantum",
-    "ref": "2914390720"
+    "ref": "29143907207ff686fe19d761ef6e74c74d08eed9"
   }
 }

--- a/.cudaq_version
+++ b/.cudaq_version
@@ -1,6 +1,6 @@
 {
   "cudaq": {
     "repository": "NVIDIA/cuda-quantum",
-    "ref": "a18a4000a23a2ed55594bd3a119548f5fabc9d1a"
+    "ref": "2914390720"
   }
 }

--- a/.cudaq_version
+++ b/.cudaq_version
@@ -1,6 +1,6 @@
 {
   "cudaq": {
     "repository": "NVIDIA/cuda-quantum",
-    "ref": "12c93088eaca9164cd9885c161eb6e506dde4221"
+    "ref": "bb93f26df2ccb5300190318425dc08bd52b60e2e"
   }
 }

--- a/.cudaq_version
+++ b/.cudaq_version
@@ -1,6 +1,6 @@
 {
   "cudaq": {
     "repository": "NVIDIA/cuda-quantum",
-    "ref": "033eeeb2022400628dc662d1b0c2440ad3a7248b"
+    "ref": "053480dda0413c219c224d42313aa14d7a17a7fe"
   }
 }

--- a/docs/sphinx/examples/qec/cpp/real_time_complete.cpp
+++ b/docs/sphinx/examples/qec/cpp/real_time_complete.cpp
@@ -122,7 +122,7 @@ __qpu__ int64_t qec_circuit() {
       cudaq::x(data[i]);
   }
 
-  return cudaq::to_integer(mz(data));
+  return cudaq::to_integer(cudaq::to_bools(mz(data)));
 }
 // [End QEC Circuit]
 

--- a/docs/sphinx/examples/qec/cpp/real_time_complete.cpp
+++ b/docs/sphinx/examples/qec/cpp/real_time_complete.cpp
@@ -112,7 +112,7 @@ __qpu__ int64_t qec_circuit() {
   // 3 rounds of syndrome measurement
   for (int round = 0; round < 3; ++round) {
     auto syndromes = measure_stabilizers(logical);
-    cudaq::qec::decoding::enqueue_syndromes(0, cudaq::to_bools(syndromes));
+    cudaq::qec::decoding::enqueue_syndromes(0, syndromes);
   }
 
   // Get corrections and apply them (single logical observable)

--- a/docs/sphinx/examples/qec/cpp/real_time_complete.cpp
+++ b/docs/sphinx/examples/qec/cpp/real_time_complete.cpp
@@ -112,7 +112,7 @@ __qpu__ int64_t qec_circuit() {
   // 3 rounds of syndrome measurement
   for (int round = 0; round < 3; ++round) {
     auto syndromes = measure_stabilizers(logical);
-    cudaq::qec::decoding::enqueue_syndromes(0, syndromes);
+    cudaq::qec::decoding::enqueue_syndromes(0, cudaq::to_bools(syndromes));
   }
 
   // Get corrections and apply them (single logical observable)
@@ -122,7 +122,7 @@ __qpu__ int64_t qec_circuit() {
       cudaq::x(data[i]);
   }
 
-  return cudaq::to_integer(mz(data));
+  return cudaq::to_integer(cudaq::to_bools(mz(data)));
 }
 // [End QEC Circuit]
 

--- a/docs/sphinx/examples/qec/python/real_time_complete.py
+++ b/docs/sphinx/examples/qec/python/real_time_complete.py
@@ -31,7 +31,7 @@ def prep0(logical: qec.patch):
 
 # Measure ZZ stabilizers for 3-qubit repetition code
 @cudaq.kernel
-def measure_stabilizers(logical: qec.patch) -> list[bool]:
+def measure_stabilizers(logical: qec.patch) -> list[cudaq.measure_handle]:
     for i in range(logical.ancz.size()):
         reset(logical.ancz[i])
 

--- a/docs/sphinx/examples/qec/python/real_time_complete.py
+++ b/docs/sphinx/examples/qec/python/real_time_complete.py
@@ -70,7 +70,7 @@ def qec_circuit() -> int:
         for i in range(3):
             x(data[i])
 
-    return cudaq.to_integer(mz(data))
+    return cudaq.to_integer(cudaq.to_bools(mz(data)))
 
 
 # [End QEC Circuit]

--- a/libs/qec/include/cudaq/qec/realtime/decoding.h
+++ b/libs/qec/include/cudaq/qec/realtime/decoding.h
@@ -29,9 +29,23 @@ namespace cudaq::qec::decoding {
 /// @param syndromes The syndromes to enqueue.
 /// @param tag The tag to use for the syndrome (currently useful for logging
 /// only)
-__qpu__ void enqueue_syndromes(std::uint64_t decoder_id,
-                               const std::vector<bool> &syndromes,
-                               std::uint64_t tag = 0);
+__qpu__ void
+enqueue_syndromes(std::uint64_t decoder_id,
+                  const std::vector<cudaq::measure_result> &syndromes,
+                  std::uint64_t tag = 0);
+
+/// @brief Test-only entry point for enqueueing pre-discriminated syndrome
+/// bits (e.g., raw syndromes replayed from a saved file). Production code
+/// must use `enqueue_syndromes`. This entry point exists because raw bits
+/// read from disk have no measurement-event identity to preserve, so the
+/// `vector<measure_result>` API is the wrong shape for them.
+/// @param decoder_id The ID of the decoder to use.
+/// @param syndromes Pre-discriminated syndrome bits.
+/// @param tag The tag to use for the syndrome (currently useful for logging
+/// only)
+__qpu__ void enqueue_syndromes_test(std::uint64_t decoder_id,
+                                    const std::vector<bool> &syndromes,
+                                    std::uint64_t tag = 0);
 
 /// @brief Get the corrections for a given decoder.
 /// @param decoder_id The ID of the decoder to use.

--- a/libs/qec/include/cudaq/qec/realtime/decoding.h
+++ b/libs/qec/include/cudaq/qec/realtime/decoding.h
@@ -29,10 +29,9 @@ namespace cudaq::qec::decoding {
 /// @param syndromes The syndromes to enqueue.
 /// @param tag The tag to use for the syndrome (currently useful for logging
 /// only)
-__qpu__ void
-enqueue_syndromes(std::uint64_t decoder_id,
-                  const std::vector<cudaq::measure_result> &syndromes,
-                  std::uint64_t tag = 0);
+__qpu__ void enqueue_syndromes(std::uint64_t decoder_id,
+                               const std::vector<bool> &syndromes,
+                               std::uint64_t tag = 0);
 
 /// @brief Get the corrections for a given decoder.
 /// @param decoder_id The ID of the decoder to use.

--- a/libs/qec/lib/realtime/quantinuum/quantinuum_device.cpp
+++ b/libs/qec/lib/realtime/quantinuum/quantinuum_device.cpp
@@ -16,10 +16,9 @@
 
 namespace cudaq::qec::decoding {
 
-__qpu__ void
-enqueue_syndromes(std::uint64_t decoder_id,
-                  const std::vector<cudaq::measure_result> &syndromes,
-                  std::uint64_t tag) {
+__qpu__ void enqueue_syndromes(std::uint64_t decoder_id,
+                               const std::vector<bool> &syndromes,
+                               std::uint64_t tag) {
   uint64_t syndrome_size = syndromes.size();
   uint64_t syndrome = cudaq::to_integer(syndromes);
   cudaq::device_call(enqueue_syndromes_ui64, decoder_id, syndrome_size,

--- a/libs/qec/lib/realtime/quantinuum/quantinuum_device.cpp
+++ b/libs/qec/lib/realtime/quantinuum/quantinuum_device.cpp
@@ -21,7 +21,7 @@ enqueue_syndromes(std::uint64_t decoder_id,
                   const std::vector<cudaq::measure_result> &syndromes,
                   std::uint64_t tag) {
   uint64_t syndrome_size = syndromes.size();
-  uint64_t syndrome = cudaq::to_integer(syndromes);
+  uint64_t syndrome = cudaq::to_integer(cudaq::to_bools(syndromes));
   cudaq::device_call(enqueue_syndromes_ui64, decoder_id, syndrome_size,
                      syndrome, tag);
 }

--- a/libs/qec/lib/realtime/quantinuum/quantinuum_device.cpp
+++ b/libs/qec/lib/realtime/quantinuum/quantinuum_device.cpp
@@ -16,9 +16,20 @@
 
 namespace cudaq::qec::decoding {
 
-__qpu__ void enqueue_syndromes(std::uint64_t decoder_id,
-                               const std::vector<bool> &syndromes,
-                               std::uint64_t tag) {
+__qpu__ void
+enqueue_syndromes(std::uint64_t decoder_id,
+                  const std::vector<cudaq::measure_result> &syndromes,
+                  std::uint64_t tag) {
+  uint64_t syndrome_size = syndromes.size();
+  // Discriminate first, then bit-pack into the `uint64` wire format.
+  uint64_t syndrome = cudaq::to_integer(cudaq::to_bools(syndromes));
+  cudaq::device_call(enqueue_syndromes_ui64, decoder_id, syndrome_size,
+                     syndrome, tag);
+}
+
+__qpu__ void enqueue_syndromes_test(std::uint64_t decoder_id,
+                                    const std::vector<bool> &syndromes,
+                                    std::uint64_t tag) {
   uint64_t syndrome_size = syndromes.size();
   uint64_t syndrome = cudaq::to_integer(syndromes);
   cudaq::device_call(enqueue_syndromes_ui64, decoder_id, syndrome_size,

--- a/libs/qec/lib/realtime/simulation/simulation_device.cpp
+++ b/libs/qec/lib/realtime/simulation/simulation_device.cpp
@@ -19,9 +19,9 @@
 // exact signature (other than converting vectors to spans), there will be no
 // errors or warnings, other than bad crashes.
 extern "C" __attribute__((visibility("default"))) void
-simulation_enqueue_syndromes(
-    std::uint64_t decoder_id,
-    const std::vector<cudaq::measure_result> &syndromes, std::uint64_t tag);
+simulation_enqueue_syndromes(std::uint64_t decoder_id,
+                             const std::vector<bool> &syndromes,
+                             std::uint64_t tag);
 
 extern "C" __attribute__((visibility("default"))) void
 simulation_get_corrections(std::uint64_t decoder_id,
@@ -29,10 +29,9 @@ simulation_get_corrections(std::uint64_t decoder_id,
 
 namespace cudaq::qec::decoding {
 
-__qpu__ void
-enqueue_syndromes(std::uint64_t decoder_id,
-                  const std::vector<cudaq::measure_result> &syndromes,
-                  std::uint64_t tag) {
+__qpu__ void enqueue_syndromes(std::uint64_t decoder_id,
+                               const std::vector<bool> &syndromes,
+                               std::uint64_t tag) {
   cudaq::device_call(simulation_enqueue_syndromes, decoder_id, syndromes, tag);
 }
 

--- a/libs/qec/lib/realtime/simulation/simulation_device.cpp
+++ b/libs/qec/lib/realtime/simulation/simulation_device.cpp
@@ -29,9 +29,19 @@ simulation_get_corrections(std::uint64_t decoder_id,
 
 namespace cudaq::qec::decoding {
 
-__qpu__ void enqueue_syndromes(std::uint64_t decoder_id,
-                               const std::vector<bool> &syndromes,
-                               std::uint64_t tag) {
+__qpu__ void
+enqueue_syndromes(std::uint64_t decoder_id,
+                  const std::vector<cudaq::measure_result> &syndromes,
+                  std::uint64_t tag) {
+  // The host trampoline takes a bit-typed span (see WARNING above), so
+  // discriminate the handles before crossing the boundary.
+  cudaq::device_call(simulation_enqueue_syndromes, decoder_id,
+                     cudaq::to_bools(syndromes), tag);
+}
+
+__qpu__ void enqueue_syndromes_test(std::uint64_t decoder_id,
+                                    const std::vector<bool> &syndromes,
+                                    std::uint64_t tag) {
   cudaq::device_call(simulation_enqueue_syndromes, decoder_id, syndromes, tag);
 }
 

--- a/libs/qec/python/CMakeLists.txt
+++ b/libs/qec/python/CMakeLists.txt
@@ -17,7 +17,7 @@ if(NOT COMMAND nanobind_add_module)
   FetchContent_Declare(
     nanobind
     GIT_REPOSITORY https://github.com/wjakob/nanobind
-    GIT_TAG v2.9.2
+    GIT_TAG v2.12.0
     EXCLUDE_FROM_ALL
   )
   FetchContent_MakeAvailable(nanobind)

--- a/libs/qec/python/bindings/py_decoder.cpp
+++ b/libs/qec/python/bindings/py_decoder.cpp
@@ -742,9 +742,14 @@ void bindDecoder(nb::module_ &mod) {
     // `std::vector<cudaq::measure_handle>`. If CUDA-Q ever renames the
     // underlying handle type or changes the alias direction, this string must
     // be re-derived from `nm` on the per-target device .o.
+    //
+    // `enqueue_syndromes_test` is the bool-typed counterpart and stays bound
+    // to `INS_t6vectorIbSaIbEE`; the Python frontend hands it pre-discriminated
+    // bits via `cudaq.to_bools(...)`.
     // clang-format off
     static const std::vector<std::string> initFuncNames = {
         "function_enqueue_syndromes._ZN5cudaq3qec8decoding17enqueue_syndromesEmRKSt6vectorINS_14measure_handleESaIS3_EEm.init_func",
+        "function_enqueue_syndromes_test._ZN5cudaq3qec8decoding22enqueue_syndromes_testEmRKSt6vectorIbSaIbEEm.init_func",
         "function_get_corrections._ZN5cudaq3qec8decoding15get_correctionsEmmb.init_func",
         "function_reset_decoder._ZN5cudaq3qec8decoding13reset_decoderEm.init_func"};
     // clang-format on

--- a/libs/qec/python/bindings/py_decoder.cpp
+++ b/libs/qec/python/bindings/py_decoder.cpp
@@ -105,13 +105,6 @@ void bindDecoder(nb::module_ &mod) {
                     ? nb::cast<nb::module_>(mod.attr("qecrt"))
                     : mod.def_submodule("qecrt");
 
-  // Workaround for nanobind v2.9.2: `def_rw` on a `std::optional<T>` field
-  // does not implicitly allow Python `None` for the setter (that behavior was
-  // added in v2.12.0 via PR #1262). Passing this annotation makes the setter
-  // accept None and store `std::nullopt`. Remove once nanobind is bumped to
-  // >=2.12.0.
-  const auto setter_accepts_none = nb::for_setter(nb::arg("value").none());
-
   nb::class_<decoder_result>(qecmod, "DecoderResult", R"pbdoc(
     A class representing the results of a quantum error correction decoding operation.
 
@@ -135,8 +128,7 @@ void bindDecoder(nb::module_ &mod) {
         the original quantum state. The format depends on the specific decoder
         implementation.
     )pbdoc")
-      .def_rw("opt_results", &decoder_result::opt_results, setter_accepts_none,
-              R"pbdoc(
+      .def_rw("opt_results", &decoder_result::opt_results, R"pbdoc(
         Optional additional results from the decoder stored in a heterogeneous map.
 
         This field may be empty if no additional results are available.

--- a/libs/qec/python/bindings/py_decoder.cpp
+++ b/libs/qec/python/bindings/py_decoder.cpp
@@ -726,10 +726,18 @@ void bindDecoder(nb::module_ &mod) {
                       (error_msg ? std::string(error_msg) : "unknown error.")));
     }
 
-    // List of `init_func` names to call for decoder registration
+    // List of `init_func` names to call for decoder registration.
+    //
+    // The `enqueue_syndromes` mangled string encodes the public API's
+    // parameter type. Under CUDA-Q alias `using measure_result =
+    // measure_handle;`, C++ mangling resolves the typedef to its underlying
+    // type, so `INS_14measure_handleESaIS3_EE` is the inner-vector mangling for
+    // `std::vector<cudaq::measure_handle>`. If CUDA-Q ever renames the
+    // underlying handle type or changes the alias direction, this string must
+    // be re-derived from `nm` on the per-target device .o.
     // clang-format off
     static const std::vector<std::string> initFuncNames = {
-        "function_enqueue_syndromes._ZN5cudaq3qec8decoding17enqueue_syndromesEmRKSt6vectorIbSaIbEEm.init_func",
+        "function_enqueue_syndromes._ZN5cudaq3qec8decoding17enqueue_syndromesEmRKSt6vectorINS_14measure_handleESaIS3_EEm.init_func",
         "function_get_corrections._ZN5cudaq3qec8decoding15get_correctionsEmmb.init_func",
         "function_reset_decoder._ZN5cudaq3qec8decoding13reset_decoderEm.init_func"};
     // clang-format on

--- a/libs/qec/python/bindings/py_decoding.cpp
+++ b/libs/qec/python/bindings/py_decoding.cpp
@@ -55,6 +55,22 @@ void bindDecoding(nb::module_ &mod) {
                 - syndromes: A vector of syndrome bits (0 or 1).
                 - tag: An optional tag for the enqueue operation.
                         )pbdoc");
+  // Mirrors the C++ `enqueue_syndromes_test(uint64_t, vector<bool>, uint64_t)`
+  // entry point. The Python device kernel must pre-discriminate any
+  // `list[measure_handle]` via `cudaq.to_bools(...)` before the call. Used by
+  // app examples that already own bool-typed syndrome bits (file replay or
+  // explicit kernel-side discrimination) where the production
+  // `enqueue_syndromes(vector<measure_result>)` shape is the wrong fit.
+  qecSubMod.def(
+      "enqueue_syndromes_test",
+      [](std::uint64_t, std::vector<bool>, std::uint64_t) {},
+      R"pbdoc(Test-only entry point for enqueueing pre-discriminated syndrome
+              bits. Production code should use `enqueue_syndromes` instead.
+                Parameters
+                - decoder_id: The ID of the decoder.
+                - syndromes: A vector of syndrome bits (0 or 1).
+                - tag: An optional tag for the enqueue operation.
+                        )pbdoc");
   qecSubMod.def(
       "get_corrections", [](std::uint64_t, std::uint64_t, bool) {},
       R"pbdoc(Get the corrections from the decoder.
@@ -70,6 +86,10 @@ void bindDecoding(nb::module_ &mod) {
         cudaq::python::getMangledArgsString<std::uint64_t>());
     cudaq::python::registerDeviceKernel(
         qecModName, "enqueue_syndromes",
+        cudaq::python::getMangledArgsString<std::uint64_t, std::vector<bool>,
+                                            std::uint64_t>());
+    cudaq::python::registerDeviceKernel(
+        qecModName, "enqueue_syndromes_test",
         cudaq::python::getMangledArgsString<std::uint64_t, std::vector<bool>,
                                             std::uint64_t>());
     cudaq::python::registerDeviceKernel(

--- a/libs/qec/python/bindings/py_decoding_config.cpp
+++ b/libs/qec/python/bindings/py_decoding_config.cpp
@@ -29,13 +29,6 @@ void bindDecodingConfig(nb::module_ &mod) {
   auto mod_cfg =
       qecmod.def_submodule("config", "Realtime decoding configuration");
 
-  // Workaround for nanobind v2.9.2: `def_rw` on a `std::optional<T>` field
-  // does not implicitly allow Python `None` for the setter (that behavior was
-  // added in v2.12.0 via PR #1262). Passing this annotation makes the setter
-  // accept None and store `std::nullopt`. Remove once nanobind is bumped to
-  // >=2.12.0.
-  const auto setter_accepts_none = nb::for_setter(nb::arg("value").none());
-
   // srelay_bp_config
   nb::class_<config::srelay_bp_config>(mod_cfg, "srelay_bp_config",
                                        "Relay-BP decoder configuration.")
@@ -48,11 +41,10 @@ void bindDecodingConfig(nb::module_ &mod) {
                 srelay_bp_config(srelay_bp_config::from_heterogeneous_map(map));
           },
           nb::arg("map"))
-      .def_rw("pre_iter", &srelay_bp_config::pre_iter, setter_accepts_none)
-      .def_rw("num_sets", &srelay_bp_config::num_sets, setter_accepts_none)
-      .def_rw("stopping_criterion", &srelay_bp_config::stopping_criterion,
-              setter_accepts_none)
-      .def_rw("stop_nconv", &srelay_bp_config::stop_nconv, setter_accepts_none)
+      .def_rw("pre_iter", &srelay_bp_config::pre_iter)
+      .def_rw("num_sets", &srelay_bp_config::num_sets)
+      .def_rw("stopping_criterion", &srelay_bp_config::stopping_criterion)
+      .def_rw("stop_nconv", &srelay_bp_config::stop_nconv)
       .def("to_heterogeneous_map", &srelay_bp_config::to_heterogeneous_map,
            nb::rv_policy::move)
       .def_static("from_heterogeneous_map",
@@ -70,45 +62,27 @@ void bindDecodingConfig(nb::module_ &mod) {
                 nv_qldpc_decoder_config::from_heterogeneous_map(map));
           },
           nb::arg("map"))
-      .def_rw("use_sparsity", &nv_qldpc_decoder_config::use_sparsity,
-              setter_accepts_none)
-      .def_rw("error_rate", &nv_qldpc_decoder_config::error_rate,
-              setter_accepts_none)
-      .def_rw("error_rate_vec", &nv_qldpc_decoder_config::error_rate_vec,
-              setter_accepts_none)
-      .def_rw("max_iterations", &nv_qldpc_decoder_config::max_iterations,
-              setter_accepts_none)
-      .def_rw("n_threads", &nv_qldpc_decoder_config::n_threads,
-              setter_accepts_none)
-      .def_rw("use_osd", &nv_qldpc_decoder_config::use_osd, setter_accepts_none)
-      .def_rw("osd_method", &nv_qldpc_decoder_config::osd_method,
-              setter_accepts_none)
-      .def_rw("osd_order", &nv_qldpc_decoder_config::osd_order,
-              setter_accepts_none)
-      .def_rw("bp_batch_size", &nv_qldpc_decoder_config::bp_batch_size,
-              setter_accepts_none)
-      .def_rw("osd_batch_size", &nv_qldpc_decoder_config::osd_batch_size,
-              setter_accepts_none)
-      .def_rw("iter_per_check", &nv_qldpc_decoder_config::iter_per_check,
-              setter_accepts_none)
-      .def_rw("clip_value", &nv_qldpc_decoder_config::clip_value,
-              setter_accepts_none)
-      .def_rw("bp_method", &nv_qldpc_decoder_config::bp_method,
-              setter_accepts_none)
-      .def_rw("scale_factor", &nv_qldpc_decoder_config::scale_factor,
-              setter_accepts_none)
-      .def_rw("proc_float", &nv_qldpc_decoder_config::proc_float,
-              setter_accepts_none)
-      .def_rw("gamma0", &nv_qldpc_decoder_config::gamma0, setter_accepts_none)
-      .def_rw("gamma_dist", &nv_qldpc_decoder_config::gamma_dist,
-              setter_accepts_none)
-      .def_rw("explicit_gammas", &nv_qldpc_decoder_config::explicit_gammas,
-              setter_accepts_none)
-      .def_rw("srelay_config", &nv_qldpc_decoder_config::srelay_config,
-              setter_accepts_none)
-      .def_rw("bp_seed", &nv_qldpc_decoder_config::bp_seed, setter_accepts_none)
-      .def_rw("composition", &nv_qldpc_decoder_config::composition,
-              setter_accepts_none)
+      .def_rw("use_sparsity", &nv_qldpc_decoder_config::use_sparsity)
+      .def_rw("error_rate", &nv_qldpc_decoder_config::error_rate)
+      .def_rw("error_rate_vec", &nv_qldpc_decoder_config::error_rate_vec)
+      .def_rw("max_iterations", &nv_qldpc_decoder_config::max_iterations)
+      .def_rw("n_threads", &nv_qldpc_decoder_config::n_threads)
+      .def_rw("use_osd", &nv_qldpc_decoder_config::use_osd)
+      .def_rw("osd_method", &nv_qldpc_decoder_config::osd_method)
+      .def_rw("osd_order", &nv_qldpc_decoder_config::osd_order)
+      .def_rw("bp_batch_size", &nv_qldpc_decoder_config::bp_batch_size)
+      .def_rw("osd_batch_size", &nv_qldpc_decoder_config::osd_batch_size)
+      .def_rw("iter_per_check", &nv_qldpc_decoder_config::iter_per_check)
+      .def_rw("clip_value", &nv_qldpc_decoder_config::clip_value)
+      .def_rw("bp_method", &nv_qldpc_decoder_config::bp_method)
+      .def_rw("scale_factor", &nv_qldpc_decoder_config::scale_factor)
+      .def_rw("proc_float", &nv_qldpc_decoder_config::proc_float)
+      .def_rw("gamma0", &nv_qldpc_decoder_config::gamma0)
+      .def_rw("gamma_dist", &nv_qldpc_decoder_config::gamma_dist)
+      .def_rw("explicit_gammas", &nv_qldpc_decoder_config::explicit_gammas)
+      .def_rw("srelay_config", &nv_qldpc_decoder_config::srelay_config)
+      .def_rw("bp_seed", &nv_qldpc_decoder_config::bp_seed)
+      .def_rw("composition", &nv_qldpc_decoder_config::composition)
       .def("to_heterogeneous_map",
            &nv_qldpc_decoder_config::to_heterogeneous_map, nb::rv_policy::move)
       .def_static("from_heterogeneous_map",
@@ -127,8 +101,7 @@ void bindDecodingConfig(nb::module_ &mod) {
                 multi_error_lut_config::from_heterogeneous_map(map));
           },
           nb::arg("map"))
-      .def_rw("lut_error_depth", &multi_error_lut_config::lut_error_depth,
-              setter_accepts_none)
+      .def_rw("lut_error_depth", &multi_error_lut_config::lut_error_depth)
       .def("to_heterogeneous_map",
            &multi_error_lut_config::to_heterogeneous_map, nb::rv_policy::move)
       .def_static("from_heterogeneous_map",
@@ -147,15 +120,11 @@ void bindDecodingConfig(nb::module_ &mod) {
                 trt_decoder_config::from_heterogeneous_map(map));
           },
           nb::arg("map"))
-      .def_rw("onnx_load_path", &trt_decoder_config::onnx_load_path,
-              setter_accepts_none)
-      .def_rw("engine_load_path", &trt_decoder_config::engine_load_path,
-              setter_accepts_none)
-      .def_rw("engine_save_path", &trt_decoder_config::engine_save_path,
-              setter_accepts_none)
-      .def_rw("precision", &trt_decoder_config::precision, setter_accepts_none)
-      .def_rw("memory_workspace", &trt_decoder_config::memory_workspace,
-              setter_accepts_none)
+      .def_rw("onnx_load_path", &trt_decoder_config::onnx_load_path)
+      .def_rw("engine_load_path", &trt_decoder_config::engine_load_path)
+      .def_rw("engine_save_path", &trt_decoder_config::engine_save_path)
+      .def_rw("precision", &trt_decoder_config::precision)
+      .def_rw("memory_workspace", &trt_decoder_config::memory_workspace)
       .def("to_heterogeneous_map", &trt_decoder_config::to_heterogeneous_map,
            nb::rv_policy::move)
       .def_static("from_heterogeneous_map",
@@ -192,28 +161,21 @@ void bindDecodingConfig(nb::module_ &mod) {
                 sliding_window_config::from_heterogeneous_map(map));
           },
           nb::arg("map"))
-      .def_rw("window_size", &sliding_window_config::window_size,
-              setter_accepts_none)
-      .def_rw("step_size", &sliding_window_config::step_size,
-              setter_accepts_none)
+      .def_rw("window_size", &sliding_window_config::window_size)
+      .def_rw("step_size", &sliding_window_config::step_size)
       .def_rw("num_syndromes_per_round",
-              &sliding_window_config::num_syndromes_per_round,
-              setter_accepts_none)
+              &sliding_window_config::num_syndromes_per_round)
       .def_rw("straddle_start_round",
-              &sliding_window_config::straddle_start_round, setter_accepts_none)
-      .def_rw("straddle_end_round", &sliding_window_config::straddle_end_round,
-              setter_accepts_none)
+              &sliding_window_config::straddle_start_round)
+      .def_rw("straddle_end_round", &sliding_window_config::straddle_end_round)
       .def_rw("error_rate_vec", &sliding_window_config::error_rate_vec)
       .def_rw("inner_decoder_name", &sliding_window_config::inner_decoder_name)
       .def_rw("single_error_lut_params",
-              &sliding_window_config::single_error_lut_params,
-              setter_accepts_none)
+              &sliding_window_config::single_error_lut_params)
       .def_rw("multi_error_lut_params",
-              &sliding_window_config::multi_error_lut_params,
-              setter_accepts_none)
+              &sliding_window_config::multi_error_lut_params)
       .def_rw("nv_qldpc_decoder_params",
-              &sliding_window_config::nv_qldpc_decoder_params,
-              setter_accepts_none)
+              &sliding_window_config::nv_qldpc_decoder_params)
       .def("to_heterogeneous_map", &sliding_window_config::to_heterogeneous_map,
            nb::rv_policy::move)
       .def_static("from_heterogeneous_map",

--- a/libs/qec/unittests/realtime/app_examples/surface_code-1.cpp
+++ b/libs/qec/unittests/realtime/app_examples/surface_code-1.cpp
@@ -285,8 +285,7 @@ __qpu__ void custom_memory_circuit_stabs(
       combined_syndrome[i++] = s;
     if (enqueue_syndromes) {
       cudaq::qec::decoding::enqueue_syndromes(
-          /*decoder_id=*/logical_qubit_idx,
-          cudaq::to_bools(combined_syndrome));
+          /*decoder_id=*/logical_qubit_idx, combined_syndrome);
     }
     return;
   }
@@ -299,8 +298,7 @@ __qpu__ void custom_memory_circuit_stabs(
     // For window_idx > 0, enqueue the last syndrome from previous window first
     if (window_idx > 0 && enqueue_syndromes) {
       cudaq::qec::decoding::enqueue_syndromes(
-          /*decoder_id=*/logical_qubit_idx,
-          cudaq::to_bools(combined_syndrome));
+          /*decoder_id=*/logical_qubit_idx, combined_syndrome);
     }
 
     // Process the current window rounds
@@ -315,8 +313,7 @@ __qpu__ void custom_memory_circuit_stabs(
         combined_syndrome[i++] = s;
       if (enqueue_syndromes) {
         cudaq::qec::decoding::enqueue_syndromes(
-            /*decoder_id=*/logical_qubit_idx,
-            cudaq::to_bools(combined_syndrome));
+            /*decoder_id=*/logical_qubit_idx, combined_syndrome);
       }
 #if PER_SHOT_DEBUG
       debug_print_syndromes(syndrome_x_int, syndrome_z_int);
@@ -784,9 +781,10 @@ void demo_circuit_host(const cudaq::qec::code &code, int distance,
         size_t end_idx =
             std::min(start_idx + syndrome_bits_per_round, all_syndromes.size());
 
-        // Replay path: raw syndrome bits read from a saved file. Pass them
-        // straight through to enqueue_syndromes (which now takes
-        // vector<bool>); there is no measurement-event identity to preserve.
+        // Replay path: raw syndrome bits read from a saved file. Use the
+        // test-only `enqueue_syndromes_test` API since these bits have no
+        // measurement-event identity to preserve and the production
+        // `enqueue_syndromes(vector<measure_result>&)` is the wrong shape.
         std::vector<bool> syndrome_round;
         for (size_t i = start_idx; i < end_idx; i++) {
           syndrome_round.push_back(static_cast<bool>(all_syndromes[i]));
@@ -794,7 +792,8 @@ void demo_circuit_host(const cudaq::qec::code &code, int distance,
 
         // Enqueue this round for all logical qubits
         for (size_t logical_idx = 0; logical_idx < numLogical; logical_idx++) {
-          cudaq::qec::decoding::enqueue_syndromes(logical_idx, syndrome_round);
+          cudaq::qec::decoding::enqueue_syndromes_test(logical_idx,
+                                                       syndrome_round);
         }
       }
 

--- a/libs/qec/unittests/realtime/app_examples/surface_code-1.cpp
+++ b/libs/qec/unittests/realtime/app_examples/surface_code-1.cpp
@@ -432,7 +432,7 @@ demo_circuit_qpu(bool allow_device_calls,
       ret <<= numData;
     auto subData = data.slice(i * numData, numData);
     auto subMeas = mz(subData);
-    ret |= cudaq::to_integer(subMeas);
+    ret |= cudaq::to_integer(cudaq::to_bools(subMeas));
   }
   // The remaining bits are allocated to the number of corrections.
   ret |= num_corrections << (numData * numLogical);

--- a/libs/qec/unittests/realtime/app_examples/surface_code-1.cpp
+++ b/libs/qec/unittests/realtime/app_examples/surface_code-1.cpp
@@ -285,7 +285,8 @@ __qpu__ void custom_memory_circuit_stabs(
       combined_syndrome[i++] = s;
     if (enqueue_syndromes) {
       cudaq::qec::decoding::enqueue_syndromes(
-          /*decoder_id=*/logical_qubit_idx, combined_syndrome);
+          /*decoder_id=*/logical_qubit_idx,
+          cudaq::to_bools(combined_syndrome));
     }
     return;
   }
@@ -298,7 +299,8 @@ __qpu__ void custom_memory_circuit_stabs(
     // For window_idx > 0, enqueue the last syndrome from previous window first
     if (window_idx > 0 && enqueue_syndromes) {
       cudaq::qec::decoding::enqueue_syndromes(
-          /*decoder_id=*/logical_qubit_idx, combined_syndrome);
+          /*decoder_id=*/logical_qubit_idx,
+          cudaq::to_bools(combined_syndrome));
     }
 
     // Process the current window rounds
@@ -313,7 +315,8 @@ __qpu__ void custom_memory_circuit_stabs(
         combined_syndrome[i++] = s;
       if (enqueue_syndromes) {
         cudaq::qec::decoding::enqueue_syndromes(
-            /*decoder_id=*/logical_qubit_idx, combined_syndrome);
+            /*decoder_id=*/logical_qubit_idx,
+            cudaq::to_bools(combined_syndrome));
       }
 #if PER_SHOT_DEBUG
       debug_print_syndromes(syndrome_x_int, syndrome_z_int);
@@ -432,7 +435,7 @@ demo_circuit_qpu(bool allow_device_calls,
       ret <<= numData;
     auto subData = data.slice(i * numData, numData);
     auto subMeas = mz(subData);
-    ret |= cudaq::to_integer(subMeas);
+    ret |= cudaq::to_integer(cudaq::to_bools(subMeas));
   }
   // The remaining bits are allocated to the number of corrections.
   ret |= num_corrections << (numData * numLogical);
@@ -781,10 +784,12 @@ void demo_circuit_host(const cudaq::qec::code &code, int distance,
         size_t end_idx =
             std::min(start_idx + syndrome_bits_per_round, all_syndromes.size());
 
-        // Convert this round's syndromes to measure_result vector
-        std::vector<cudaq::measure_result> syndrome_round;
+        // Replay path: raw syndrome bits read from a saved file. Pass them
+        // straight through to enqueue_syndromes (which now takes
+        // vector<bool>); there is no measurement-event identity to preserve.
+        std::vector<bool> syndrome_round;
         for (size_t i = start_idx; i < end_idx; i++) {
-          syndrome_round.push_back(cudaq::measure_result(all_syndromes[i]));
+          syndrome_round.push_back(static_cast<bool>(all_syndromes[i]));
         }
 
         // Enqueue this round for all logical qubits

--- a/libs/qec/unittests/realtime/app_examples/surface_code-2.cpp
+++ b/libs/qec/unittests/realtime/app_examples/surface_code-2.cpp
@@ -321,7 +321,7 @@ demo_circuit_qpu(bool allow_device_calls,
       ret <<= numData;
     auto subData = data.slice(i * numData, numData);
     auto subMeas = mz(subData);
-    ret |= cudaq::to_integer(subMeas);
+    ret |= cudaq::to_integer(cudaq::to_bools(subMeas));
   }
   // The remaining bits are allocated to the number of corrections.
   ret |= num_corrections << (numData * numLogical);

--- a/libs/qec/unittests/realtime/app_examples/surface_code-2.cpp
+++ b/libs/qec/unittests/realtime/app_examples/surface_code-2.cpp
@@ -205,8 +205,7 @@ __qpu__ void custom_memory_circuit_stabs(
       combined_syndrome[i++] = s;
     if (enqueue_syndromes) {
       cudaq::qec::decoding::enqueue_syndromes(
-          /*decoder_id=*/logical_qubit_idx,
-          cudaq::to_bools(combined_syndrome));
+          /*decoder_id=*/logical_qubit_idx, combined_syndrome);
     }
 #if PER_SHOT_DEBUG
     debug_print_syndromes(syndrome_x_int, syndrome_z_int);

--- a/libs/qec/unittests/realtime/app_examples/surface_code-2.cpp
+++ b/libs/qec/unittests/realtime/app_examples/surface_code-2.cpp
@@ -205,7 +205,8 @@ __qpu__ void custom_memory_circuit_stabs(
       combined_syndrome[i++] = s;
     if (enqueue_syndromes) {
       cudaq::qec::decoding::enqueue_syndromes(
-          /*decoder_id=*/logical_qubit_idx, combined_syndrome);
+          /*decoder_id=*/logical_qubit_idx,
+          cudaq::to_bools(combined_syndrome));
     }
 #if PER_SHOT_DEBUG
     debug_print_syndromes(syndrome_x_int, syndrome_z_int);
@@ -321,7 +322,7 @@ demo_circuit_qpu(bool allow_device_calls,
       ret <<= numData;
     auto subData = data.slice(i * numData, numData);
     auto subMeas = mz(subData);
-    ret |= cudaq::to_integer(subMeas);
+    ret |= cudaq::to_integer(cudaq::to_bools(subMeas));
   }
   // The remaining bits are allocated to the number of corrections.
   ret |= num_corrections << (numData * numLogical);

--- a/libs/qec/unittests/realtime/app_examples/surface_code-3.cpp
+++ b/libs/qec/unittests/realtime/app_examples/surface_code-3.cpp
@@ -246,12 +246,11 @@ __qpu__ void custom_memory_circuit_stabs(
     if (enqueue_syndromes) {
       // Enqueue Z-stabilizer results to the X-error decoder
       cudaq::qec::decoding::enqueue_syndromes(
-          /*decoder_id=*/2 * logical_qubit_idx, cudaq::to_bools(syndrome_z));
+          /*decoder_id=*/2 * logical_qubit_idx, syndrome_z);
 
       // Enqueue X-stabilizer results to the Z-error decoder
       cudaq::qec::decoding::enqueue_syndromes(
-          /*decoder_id=*/2 * logical_qubit_idx + 1,
-          cudaq::to_bools(syndrome_x));
+          /*decoder_id=*/2 * logical_qubit_idx + 1, syndrome_x);
     }
 
     if (do_errors_after_non_last_rounds && round < numRounds - 1) {

--- a/libs/qec/unittests/realtime/app_examples/surface_code-3.cpp
+++ b/libs/qec/unittests/realtime/app_examples/surface_code-3.cpp
@@ -246,11 +246,12 @@ __qpu__ void custom_memory_circuit_stabs(
     if (enqueue_syndromes) {
       // Enqueue Z-stabilizer results to the X-error decoder
       cudaq::qec::decoding::enqueue_syndromes(
-          /*decoder_id=*/2 * logical_qubit_idx, syndrome_z);
+          /*decoder_id=*/2 * logical_qubit_idx, cudaq::to_bools(syndrome_z));
 
       // Enqueue X-stabilizer results to the Z-error decoder
       cudaq::qec::decoding::enqueue_syndromes(
-          /*decoder_id=*/2 * logical_qubit_idx + 1, syndrome_x);
+          /*decoder_id=*/2 * logical_qubit_idx + 1,
+          cudaq::to_bools(syndrome_x));
     }
 
     if (do_errors_after_non_last_rounds && round < numRounds - 1) {

--- a/libs/qec/unittests/realtime/app_examples/surface_code_1.py
+++ b/libs/qec/unittests/realtime/app_examples/surface_code_1.py
@@ -395,7 +395,7 @@ def demo_circuit_qpu(
             ret = ret << num_data
         sub_data = data[i * num_data:(i + 1) * num_data]
         sub_meas = mz(sub_data)
-        ret |= cudaq.to_integer(sub_meas)
+        ret |= cudaq.to_integer(cudaq.to_bools(sub_meas))
 
     # The remaining bits are allocated to the number of corrections.
     ret = ret | (num_corrections << (num_data * num_logical))

--- a/libs/qec/unittests/realtime/app_examples/surface_code_1.py
+++ b/libs/qec/unittests/realtime/app_examples/surface_code_1.py
@@ -1,5 +1,5 @@
 # ============================================================================ #
-# Copyright (c) 2025 NVIDIA Corporation & Affiliates.                          #
+# Copyright (c) 2025 - 2026 NVIDIA Corporation & Affiliates.                   #
 # All rights reserved.                                                         #
 #                                                                              #
 # This source code and the accompanying materials are made available under     #
@@ -230,22 +230,21 @@ def custom_memory_circuit_stabs(
     # Mirror the C++ idiom `std::vector<measure_result>(N)`: pre-allocate a
     # list of unbound `measure_handle`s, each slot is overwritten with a real
     # handle from `se_z_ft`/`se_x_ft` before any discrimination occurs.
-    combined_syndrome = [
-        cudaq.measure_handle() for i in range(len(xstab_anc) + len(zstab_anc))
-    ]
+    # Can't use `measure_handle`: https://github.com/NVIDIA/cuda-quantum/issues/4527
+    combined_syndrome = [False for i in range(len(xstab_anc) + len(zstab_anc))]
     # Handle the stabilizer lock-in round (numRounds == 1)
     if num_rounds == 1:
         syndrome_z = se_z_ft(logical, cnot_schedZ_flat)
         syndrome_x = se_x_ft(logical, cnot_schedX_flat)
         i = 0
         for s in syndrome_z:
-            combined_syndrome[i] = s
+            combined_syndrome[i] = bool(s)
             i += 1
         for s in syndrome_x:
-            combined_syndrome[i] = s
+            combined_syndrome[i] = bool(s)
             i += 1
         if enqueue_synd:
-            qec.enqueue_syndromes(logical_qubit_idx, combined_syndrome, 0)
+            qec.enqueue_syndromes_test(logical_qubit_idx, combined_syndrome, 0)
         return
 
     # Process rounds window by window for the main measurement rounds
@@ -254,7 +253,7 @@ def custom_memory_circuit_stabs(
     for window_idx in range(num_rounds // decoder_window):
         # For window_idx > 0, enqueue the last syndrome from previous window first
         if window_idx > 0 and enqueue_synd:
-            qec.enqueue_syndromes(logical_qubit_idx, combined_syndrome, 0)
+            qec.enqueue_syndromes_test(logical_qubit_idx, combined_syndrome, 0)
 
         # Process the current window rounds
         for round_idx in range(window_idx * decoder_window,
@@ -263,14 +262,15 @@ def custom_memory_circuit_stabs(
             syndrome_x = se_x_ft(logical, cnot_schedX_flat)
             i = 0
             for s in syndrome_z:
-                combined_syndrome[i] = s
+                combined_syndrome[i] = bool(s)
                 i += 1
             for s in syndrome_x:
-                combined_syndrome[i] = s
+                combined_syndrome[i] = bool(s)
                 i += 1
 
             if enqueue_synd:
-                qec.enqueue_syndromes(logical_qubit_idx, combined_syndrome, 0)
+                qec.enqueue_syndromes_test(logical_qubit_idx, combined_syndrome,
+                                           0)
 
             if do_errors_after_non_last_rounds and round_idx < (
                     window_idx + 1) * decoder_window - 1:

--- a/libs/qec/unittests/realtime/app_examples/surface_code_1.py
+++ b/libs/qec/unittests/realtime/app_examples/surface_code_1.py
@@ -185,7 +185,8 @@ def spam_error(logical_qubit: patch, p_spam_data: float, p_spam_ancx: float,
 
 
 @cudaq.kernel
-def se_z_ft(logical_qubit: patch, cnot_sched: List[int]) -> List[bool]:
+def se_z_ft(logical_qubit: patch,
+            cnot_sched: List[int]) -> List[cudaq.measure_handle]:
     for i in range(0, len(cnot_sched), 2):
         cx(logical_qubit.data[cnot_sched[i + 1]],
            logical_qubit.ancz[cnot_sched[i]])
@@ -196,7 +197,8 @@ def se_z_ft(logical_qubit: patch, cnot_sched: List[int]) -> List[bool]:
 
 
 @cudaq.kernel
-def se_x_ft(logical_qubit: patch, cnot_sched: List[int]) -> List[bool]:
+def se_x_ft(logical_qubit: patch,
+            cnot_sched: List[int]) -> List[cudaq.measure_handle]:
     h(logical_qubit.ancx)
     for i in range(0, len(cnot_sched), 2):
         cx(logical_qubit.ancx[cnot_sched[i]],
@@ -225,7 +227,13 @@ def custom_memory_circuit_stabs(
 ) -> None:
     # Create the logical patch
     logical = patch(data, xstab_anc, zstab_anc)
-    combined_syndrome = [False for i in range(len(xstab_anc) + len(zstab_anc))]
+    # Mirror the C++ idiom `std::vector<measure_result>(N)`: pre-allocate a
+    # list of unbound `measure_handle`s, each slot is overwritten with a real
+    # handle from `se_z_ft`/`se_x_ft` before any discrimination occurs.
+    combined_syndrome = [
+        cudaq.measure_handle()
+        for i in range(len(xstab_anc) + len(zstab_anc))
+    ]
     # Handle the stabilizer lock-in round (numRounds == 1)
     if num_rounds == 1:
         syndrome_z = se_z_ft(logical, cnot_schedZ_flat)

--- a/libs/qec/unittests/realtime/app_examples/surface_code_1.py
+++ b/libs/qec/unittests/realtime/app_examples/surface_code_1.py
@@ -231,8 +231,7 @@ def custom_memory_circuit_stabs(
     # list of unbound `measure_handle`s, each slot is overwritten with a real
     # handle from `se_z_ft`/`se_x_ft` before any discrimination occurs.
     combined_syndrome = [
-        cudaq.measure_handle()
-        for i in range(len(xstab_anc) + len(zstab_anc))
+        cudaq.measure_handle() for i in range(len(xstab_anc) + len(zstab_anc))
     ]
     # Handle the stabilizer lock-in round (numRounds == 1)
     if num_rounds == 1:

--- a/libs/solvers/python/CMakeLists.txt
+++ b/libs/solvers/python/CMakeLists.txt
@@ -17,7 +17,7 @@ if(NOT COMMAND nanobind_add_module)
   FetchContent_Declare(
     nanobind
     GIT_REPOSITORY https://github.com/wjakob/nanobind
-    GIT_TAG v2.9.2
+    GIT_TAG v2.12.0
     EXCLUDE_FROM_ALL
   )
   FetchContent_MakeAvailable(nanobind)


### PR DESCRIPTION
- Updates pinned version of cudaq.
- Updates nanobind by reverting previous commits (https://github.com/NVIDIA/cudaqx/pull/531/commits/62936b17439f9bd045c8088c79b6c21bef06c7d8 https://github.com/NVIDIA/cudaqx/pull/531/commits/7488c8cb6f940da376f8d01bdf487096d1b4282e https://github.com/NVIDIA/cudaqx/pull/531/commits/a0724f6720bc968e96954ef0e7fb39f9a8961676), except for 7488c8c change to `cmake/Modules/CUDA-QX.cmake`.

Wheel build to confirm issue is fixed: https://github.com/NVIDIA/cudaqx/actions/runs/25936612350