### PR TITLE
Use canonical soft-to-hard decoder conversion

### DIFF
--- a/libs/qec/include/cudaq/qec/decoder.h
+++ b/libs/qec/include/cudaq/qec/decoder.h
@@ -282,6 +282,16 @@ protected:
   std::vector<std::vector<uint32_t>> D_sparse;
 };
 
+/// @brief Convert a single soft probability to a hard 0/1 decision.
+/// @param in Soft probability input in range [0.0, 1.0]
+/// @param thresh Values >= thresh return true; all others return false.
+template <typename t_soft,
+          typename std::enable_if<std::is_floating_point<t_soft>::value,
+                                  int>::type = 0>
+constexpr inline bool convert_soft_to_hard(t_soft in, t_soft thresh = 0.5) {
+  return in >= thresh;
+}
+
 /// @brief Convert a vector of soft probabilities to a vector of hard
 /// probabilities.
 /// @param in Soft probability input vector in range [0.0, 1.0]
@@ -298,7 +308,7 @@ inline void convert_vec_soft_to_hard(const std::vector<t_soft> &in,
                                      t_soft thresh = 0.5) {
   out.resize(in.size());
   for (std::size_t i = 0; i < in.size(); i++)
-    out[i] = static_cast<t_hard>(in[i] >= thresh ? 1 : 0);
+    out[i] = static_cast<t_hard>(convert_soft_to_hard(in[i], thresh));
 }
 
 /// @brief Convert a vector of soft probabilities to a tensor<uint8_t> of hard
@@ -326,7 +336,7 @@ inline void convert_vec_soft_to_tensor_hard(const std::vector<t_soft> &in,
         "Vector to tensor conversion requires tensor dim == vector length");
   auto raw_ptr = out.data();
   for (size_t i = 0; i < in.size(); ++i)
-    raw_ptr[i] = static_cast<t_hard>(in[i] >= thresh ? 1 : 0);
+    raw_ptr[i] = static_cast<t_hard>(convert_soft_to_hard(in[i], thresh));
 }
 
 /// @brief Convert a vector of hard probabilities to a vector of soft
@@ -392,7 +402,7 @@ inline void convert_vec_soft_to_hard(const std::vector<std::vector<t_soft>> &in,
     auto &out_row = out[row_index++];
     out_row.resize(r.size());
     for (std::size_t c = 0; c < r.size(); c++)
-      out_row[c] = static_cast<t_hard>(r[c] >= thresh ? 1 : 0);
+      out_row[c] = static_cast<t_hard>(convert_soft_to_hard(r[c], thresh));
   }
 }
 

--- a/libs/qec/lib/decoders/lut.cpp
+++ b/libs/qec/lib/decoders/lut.cpp
@@ -172,14 +172,12 @@ public:
     decoder_result result{false, std::vector<float_t>(block_size, 0.0)};
 
     // Convert syndrome to a string
-    std::vector<uint8_t> hard_syndrome;
-    cudaq::qec::convert_vec_soft_to_hard(syndrome, hard_syndrome);
-    std::string syndrome_str(hard_syndrome.size(), '0');
+    std::string syndrome_str(syndrome.size(), '0');
     int syndrome_weight = 0;
     assert(syndrome_str.length() == syndrome_size);
     bool anyErrors = false;
     for (std::size_t i = 0; i < syndrome_size; i++) {
-      if (hard_syndrome[i]) {
+      if (cudaq::qec::convert_soft_to_hard(syndrome[i])) {
         syndrome_str[i] = '1';
         anyErrors = true;
         syndrome_weight++;

--- a/libs/qec/lib/decoders/lut.cpp
+++ b/libs/qec/lib/decoders/lut.cpp
@@ -172,12 +172,14 @@ public:
     decoder_result result{false, std::vector<float_t>(block_size, 0.0)};
 
     // Convert syndrome to a string
-    std::string syndrome_str(syndrome.size(), '0');
+    std::vector<uint8_t> hard_syndrome;
+    cudaq::qec::convert_vec_soft_to_hard(syndrome, hard_syndrome);
+    std::string syndrome_str(hard_syndrome.size(), '0');
     int syndrome_weight = 0;
     assert(syndrome_str.length() == syndrome_size);
     bool anyErrors = false;
     for (std::size_t i = 0; i < syndrome_size; i++) {
-      if (syndrome[i] >= 0.5) {
+      if (hard_syndrome[i]) {
         syndrome_str[i] = '1';
         anyErrors = true;
         syndrome_weight++;

--- a/libs/qec/lib/decoders/plugins/example/single_error_lut_example.cpp
+++ b/libs/qec/lib/decoders/plugins/example/single_error_lut_example.cpp
@@ -49,11 +49,13 @@ public:
     decoder_result result{false, std::vector<float_t>(block_size, 0.0)};
 
     // Convert syndrome to a string
-    std::string syndrome_str(syndrome.size(), '0');
+    std::vector<uint8_t> hard_syndrome;
+    cudaq::qec::convert_vec_soft_to_hard(syndrome, hard_syndrome);
+    std::string syndrome_str(hard_syndrome.size(), '0');
     assert(syndrome_str.length() == syndrome_size);
     bool anyErrors = false;
     for (std::size_t i = 0; i < syndrome_size; i++) {
-      if (syndrome[i] >= 0.5) {
+      if (hard_syndrome[i]) {
         syndrome_str[i] = '1';
         anyErrors = true;
       }

--- a/libs/qec/lib/decoders/plugins/example/single_error_lut_example.cpp
+++ b/libs/qec/lib/decoders/plugins/example/single_error_lut_example.cpp
@@ -49,13 +49,11 @@ public:
     decoder_result result{false, std::vector<float_t>(block_size, 0.0)};
 
     // Convert syndrome to a string
-    std::vector<uint8_t> hard_syndrome;
-    cudaq::qec::convert_vec_soft_to_hard(syndrome, hard_syndrome);
-    std::string syndrome_str(hard_syndrome.size(), '0');
+    std::string syndrome_str(syndrome.size(), '0');
     assert(syndrome_str.length() == syndrome_size);
     bool anyErrors = false;
     for (std::size_t i = 0; i < syndrome_size; i++) {
-      if (hard_syndrome[i]) {
+      if (cudaq::qec::convert_soft_to_hard(syndrome[i])) {
         syndrome_str[i] = '1';
         anyErrors = true;
       }

--- a/libs/qec/lib/decoders/plugins/pymatching/pymatching.cpp
+++ b/libs/qec/lib/decoders/plugins/pymatching/pymatching.cpp
@@ -167,12 +167,10 @@ public:
     auto t1 = std::chrono::high_resolution_clock::now();
 #endif
 
-    std::vector<uint8_t> hard_syndrome;
-    cudaq::qec::convert_vec_soft_to_hard(syndrome, hard_syndrome);
     std::vector<uint64_t> detection_events;
-    detection_events.reserve(hard_syndrome.size());
-    for (size_t i = 0; i < hard_syndrome.size(); i++)
-      if (hard_syndrome[i])
+    detection_events.reserve(syndrome.size());
+    for (size_t i = 0; i < syndrome.size(); i++)
+      if (cudaq::qec::convert_soft_to_hard(syndrome[i]))
         detection_events.push_back(i);
 #if PERFORM_TIMING
     auto t2 = std::chrono::high_resolution_clock::now();

--- a/libs/qec/lib/decoders/plugins/pymatching/pymatching.cpp
+++ b/libs/qec/lib/decoders/plugins/pymatching/pymatching.cpp
@@ -167,10 +167,12 @@ public:
     auto t1 = std::chrono::high_resolution_clock::now();
 #endif
 
+    std::vector<uint8_t> hard_syndrome;
+    cudaq::qec::convert_vec_soft_to_hard(syndrome, hard_syndrome);
     std::vector<uint64_t> detection_events;
-    detection_events.reserve(syndrome.size());
-    for (size_t i = 0; i < syndrome.size(); i++)
-      if (syndrome[i] > 0.5)
+    detection_events.reserve(hard_syndrome.size());
+    for (size_t i = 0; i < hard_syndrome.size(); i++)
+      if (hard_syndrome[i])
         detection_events.push_back(i);
 #if PERFORM_TIMING
     auto t2 = std::chrono::high_resolution_clock::now();

--- a/libs/qec/lib/decoders/plugins/trt_decoder/trt_decoder.cpp
+++ b/libs/qec/lib/decoders/plugins/trt_decoder/trt_decoder.cpp
@@ -926,15 +926,19 @@ std::vector<decoder_result> trt_decoder::decode_batch_impl(
       // Prepare input batch. For float input we preserve soft (raw) values;
       // for uint8 we binarize to 0/1.
       std::vector<IoType> input_host(impl_->input_size);
+      std::vector<uint8_t> hard_syndrome;
       for (size_t batch_idx = 0; batch_idx < actual_batch; ++batch_idx) {
         const auto &syndrome = syndromes[batch_start + batch_idx];
-        for (size_t i = 0; i < syndrome_size_per_sample_; ++i) {
-          if constexpr (std::is_same_v<IoType, float>) {
+        if constexpr (std::is_same_v<IoType, float>) {
+          for (size_t i = 0; i < syndrome_size_per_sample_; ++i) {
             input_host[batch_idx * syndrome_size_per_sample_ + i] =
                 static_cast<IoType>(syndrome[i]);
-          } else {
+          }
+        } else {
+          cudaq::qec::convert_vec_soft_to_hard(syndrome, hard_syndrome);
+          for (size_t i = 0; i < syndrome_size_per_sample_; ++i) {
             input_host[batch_idx * syndrome_size_per_sample_ + i] =
-                static_cast<IoType>(syndrome[i] >= 0.5f ? 1 : 0);
+                static_cast<IoType>(hard_syndrome[i]);
           }
         }
       }

--- a/libs/qec/lib/decoders/plugins/trt_decoder/trt_decoder.cpp
+++ b/libs/qec/lib/decoders/plugins/trt_decoder/trt_decoder.cpp
@@ -926,7 +926,6 @@ std::vector<decoder_result> trt_decoder::decode_batch_impl(
       // Prepare input batch. For float input we preserve soft (raw) values;
       // for uint8 we binarize to 0/1.
       std::vector<IoType> input_host(impl_->input_size);
-      std::vector<uint8_t> hard_syndrome;
       for (size_t batch_idx = 0; batch_idx < actual_batch; ++batch_idx) {
         const auto &syndrome = syndromes[batch_start + batch_idx];
         if constexpr (std::is_same_v<IoType, float>) {
@@ -935,10 +934,10 @@ std::vector<decoder_result> trt_decoder::decode_batch_impl(
                 static_cast<IoType>(syndrome[i]);
           }
         } else {
-          cudaq::qec::convert_vec_soft_to_hard(syndrome, hard_syndrome);
           for (size_t i = 0; i < syndrome_size_per_sample_; ++i) {
             input_host[batch_idx * syndrome_size_per_sample_ + i] =
-                static_cast<IoType>(hard_syndrome[i]);
+                static_cast<IoType>(
+                    cudaq::qec::convert_soft_to_hard(syndrome[i]));
           }
         }
       }

--- a/libs/qec/python/tests/test_decoder.py
+++ b/libs/qec/python/tests/test_decoder.py
@@ -136,6 +136,16 @@ def test_decoder_plugin_result_structure():
     assert isinstance(result.result, list)
 
 
+def test_single_error_lut_example_uses_canonical_threshold():
+    H = np.array([[0, 1]], dtype=np.uint8)
+    decoder = qec.get_decoder('single_error_lut_example', H)
+    result = decoder.decode([0.5])
+
+    # For this H, syndrome "1" maps to a correction on qubit 0.
+    assert result.converged is True
+    assert result.result == [1.0, 0.0]
+
+
 def test_decoder_result_values():
     decoder = qec.get_decoder('example_byod', H)
     result = decoder.decode(create_test_syndrome())

--- a/libs/qec/python/tests/test_decoder.py
+++ b/libs/qec/python/tests/test_decoder.py
@@ -270,9 +270,9 @@ def test_single_error_lut_example_uses_canonical_threshold():
     decoder = qec.get_decoder('single_error_lut_example', H)
     result = decoder.decode([0.5])
 
-    # For this H, syndrome "1" maps to a correction on qubit 0.
+    # For this H, syndrome "1" maps to a correction on qubit 1.
     assert result.converged is True
-    assert np.array_equal(result.result, [1.0, 0.0])
+    assert np.array_equal(result.result, [0.0, 1.0])
 
 
 def test_decoder_result_values():

--- a/libs/qec/python/tests/test_decoder.py
+++ b/libs/qec/python/tests/test_decoder.py
@@ -272,7 +272,7 @@ def test_single_error_lut_example_uses_canonical_threshold():
 
     # For this H, syndrome "1" maps to a correction on qubit 0.
     assert result.converged is True
-    assert result.result == [1.0, 0.0]
+    assert np.array_equal(result.result, [1.0, 0.0])
 
 
 def test_decoder_result_values():

--- a/libs/qec/unittests/decoders/pymatching/test_pymatching.cpp
+++ b/libs/qec/unittests/decoders/pymatching/test_pymatching.cpp
@@ -82,4 +82,10 @@ TEST(PyMatchingDecoder, checkBoundaryEdges) {
   EXPECT_EQ(result.result[0], 0.0);
   EXPECT_EQ(result.result[1], 0.0);
   EXPECT_EQ(result.result[2], 1.0);
+
+  syndrome = {0.5, 0, 0};
+  result = d->decode(syndrome);
+  EXPECT_EQ(result.result[0], 1.0);
+  EXPECT_EQ(result.result[1], 0.0);
+  EXPECT_EQ(result.result[2], 0.0);
 }

--- a/libs/qec/unittests/test_decoders.cpp
+++ b/libs/qec/unittests/test_decoders.cpp
@@ -75,6 +75,27 @@ TEST(DecoderUtils, CovertSoftToHard) {
   }
 }
 
+TEST(DecoderUtils, ConvertSoftToHardScalar) {
+  // Default threshold (0.5): the canonical >= contract.
+  EXPECT_TRUE(cudaq::qec::convert_soft_to_hard(0.6f));
+  EXPECT_FALSE(cudaq::qec::convert_soft_to_hard(0.4f));
+  EXPECT_TRUE(cudaq::qec::convert_soft_to_hard(0.5f));
+  EXPECT_FALSE(cudaq::qec::convert_soft_to_hard(0.499f));
+  EXPECT_TRUE(cudaq::qec::convert_soft_to_hard(0.501f));
+
+  // Double-precision input.
+  EXPECT_TRUE(cudaq::qec::convert_soft_to_hard(0.5));
+  EXPECT_FALSE(cudaq::qec::convert_soft_to_hard(0.499));
+
+  // Custom threshold.
+  EXPECT_TRUE(cudaq::qec::convert_soft_to_hard(0.4f, 0.4f));
+  EXPECT_FALSE(cudaq::qec::convert_soft_to_hard(0.3f, 0.4f));
+
+  // Usable in a constant-expression context.
+  static_assert(cudaq::qec::convert_soft_to_hard(0.5f));
+  static_assert(!cudaq::qec::convert_soft_to_hard(0.49f));
+}
+
 TEST(DecoderUtils, ConvertVecSoftToTensorHard) {
   // Generate a million random floats between 0 and 1 using mt19937
   std::mt19937_64 gen(13);

--- a/libs/qec/unittests/test_decoders.cpp
+++ b/libs/qec/unittests/test_decoders.cpp
@@ -56,6 +56,14 @@ TEST(DecoderUtils, CovertSoftToHard) {
   for (int i = 0; i < out.size(); i++)
     ASSERT_EQ(out[i], expected_out[i]);
 
+  std::vector<float> boundary_in = {0.499f, 0.5f, 0.501f};
+  std::vector<uint8_t> boundary_out;
+  std::vector<uint8_t> expected_boundary_out = {0, 1, 1};
+  cudaq::qec::convert_vec_soft_to_hard(boundary_in, boundary_out);
+  ASSERT_EQ(boundary_out.size(), expected_boundary_out.size());
+  for (int i = 0; i < boundary_out.size(); i++)
+    ASSERT_EQ(boundary_out[i], expected_boundary_out[i]);
+
   std::vector<std::vector<double>> in2 = {{0.6, 0.4}, {0.7, 0.8}};
   std::vector<std::vector<int>> out2;
   std::vector<std::vector<int>> expected_out2 = {{1, 0}, {1, 1}};
@@ -182,6 +190,12 @@ TEST(SteaneLutDecoder, checkAPI) {
   }
   ASSERT_TRUE(convergeTrueFound);
   ASSERT_FALSE(convergeFalseFound);
+
+  std::vector<float_t> boundary_syndrome = {0.5, 0.0, 0.5};
+  auto boundary_result = d->decode(boundary_syndrome);
+  ASSERT_TRUE(boundary_result.converged);
+  ASSERT_EQ(boundary_result.result.size(), block_size);
+  EXPECT_EQ(boundary_result.result[4], 1.0);
 
   // Test opt_results functionality
   // Test case 1: Invalid result type


### PR DESCRIPTION
**Summary**
Use the canonical `cudaq ::qec ::convert_vec_soft_to_hard `helper for decoder syndrome binarization instead of inline threshold checks.

**Changes**

- Update LUT, example LUT, PyMatching, and TRT decoder input paths to use the shared soft-to-hard conversion helper.
- Align PyMatching’s boundary behavior with the documented helper contract: values >= 0.5 map to 1.
- Add focused boundary tests for 0.5 conversion behavior in C++ and Python.
- Keep TRT float inputs unchanged so soft-valued model inputs are still passed through as before.

**Note**
This PR intentionally leaves TRT decoder output conversion helpers unchanged. Those paths still use local threshold logic and should be revisited in a later PR to decide whether output binarization should also be centralized around the canonical conversion helper.

Resolves #552 