### PR TITLE
Return Python decode result as NumPy arrays

### DIFF
--- a/libs/qec/python/bindings/py_decoder.cpp
+++ b/libs/qec/python/bindings/py_decoder.cpp
@@ -231,11 +231,14 @@ nb::object decoderResultsToNumpy(const std::vector<decoder_result> &results) {
   // not rely on result.shape[1] when the batch is empty.
   const auto result_size = num_results == 0 ? 0 : results.front().result.size();
 
-  for (const auto &result : results) {
-    if (result.result.size() != result_size) {
-      throw std::runtime_error(
+  for (std::size_t i = 0; i < results.size(); ++i) {
+    const auto actual_size = results[i].result.size();
+    if (actual_size != result_size) {
+      throw std::runtime_error(fmt::format(
           "Cannot return decode_batch results as a NumPy array because result "
-          "vectors have inconsistent sizes.");
+          "vectors have inconsistent sizes: expected row width {}, but row {} "
+          "has width {}.",
+          result_size, i, actual_size));
     }
   }
 

--- a/libs/qec/python/bindings/py_decoder.cpp
+++ b/libs/qec/python/bindings/py_decoder.cpp
@@ -16,6 +16,7 @@
 #include <filesystem>
 #include <limits>
 #include <link.h>
+#include <memory>
 #include <nanobind/nanobind.h>
 #include <nanobind/ndarray.h>
 #include <nanobind/stl/complex.h>
@@ -32,8 +33,10 @@
 #include "cuda-qx/core/kwargs_utils.h"
 #include "cuda-qx/core/library_utils.h"
 #include "type_casters.h"
+#include <algorithm>
 
 namespace nb = nanobind;
+using namespace nanobind::literals;
 using namespace cudaqx;
 
 namespace cudaq::qec {
@@ -94,6 +97,197 @@ std::unordered_map<std::string,
                        const nb::ndarray<nb::numpy, uint8_t> &, nb::kwargs)>>
     PyDecoderRegistry::registry;
 
+namespace {
+
+struct batch_decoder_result {
+  // Python-facing constructor for decoder plugin authors. nanobind enforces
+  // ndim on the typed array arguments and rejects wrong-rank input with
+  // TypeError, but it does not enforce dtype strictly (int32 input is
+  // silently coerced to float) and does not enforce C-contiguity. We
+  // therefore re-coerce through np.ascontiguousarray below to guarantee
+  // both invariants — batch[i] reads rows by raw pointer and relies on
+  // them. Cross-array invariants (row count, opt_results length) are also
+  // checked here since nanobind cannot see them.
+  batch_decoder_result(nb::ndarray<nb::numpy, float_t, nb::ndim<2>> result_arr,
+                       nb::ndarray<nb::numpy, bool, nb::ndim<1>> converged_arr,
+                       nb::object opt_results) {
+    size = converged_arr.shape(0);
+    if (result_arr.shape(0) != size)
+      throw std::runtime_error(
+          "BatchDecoderResult result row count must match the number of "
+          "convergence flags.");
+
+    if (opt_results.is_none()) {
+      nb::list lst;
+      for (std::size_t i = 0; i < size; ++i)
+        lst.append(nb::none());
+      this->opt_results = lst;
+    } else {
+      this->opt_results = nb::cast<nb::list>(opt_results);
+      if (nb::len(this->opt_results) != size)
+        throw std::runtime_error(
+            "BatchDecoderResult opt_results length must match the number of "
+            "convergence flags.");
+    }
+
+    nb::module_ np = nb::module_::import_("numpy");
+    nb::object float_dtype = sizeof(float_t) == sizeof(float)
+                                 ? np.attr("float32")
+                                 : np.attr("float64");
+    this->result = np.attr("ascontiguousarray")(nb::cast(result_arr),
+                                                "dtype"_a = float_dtype);
+    this->converged = np.attr("ascontiguousarray")(
+        nb::cast(converged_arr), "dtype"_a = np.attr("bool_"));
+  }
+
+  // Trusted internal constructor: callers guarantee shape/dtype invariants.
+  // Used by makeBatchDecoderResult and batchSliceToBatchDecoderResult.
+  batch_decoder_result(nb::object result, nb::object converged,
+                       nb::list opt_results, std::size_t size)
+      : result(result), converged(converged), opt_results(opt_results),
+        size(size) {}
+
+  nb::object result;
+  nb::object converged;
+  nb::list opt_results;
+  std::size_t size = 0;
+};
+
+Py_ssize_t normalizeBatchIndex(Py_ssize_t index, std::size_t size) {
+  const auto signed_size = static_cast<Py_ssize_t>(size);
+  if (index < 0)
+    index += signed_size;
+  if (index < 0 || index >= signed_size)
+    throw nb::index_error();
+  return index;
+}
+
+decoder_result batchItemToDecoderResult(const batch_decoder_result &batch,
+                                        Py_ssize_t index) {
+  const auto normalized_index = normalizeBatchIndex(index, batch.size);
+  nb::object py_index = nb::int_(normalized_index);
+  auto row = nb::cast<nb::ndarray<nb::numpy, float_t>>(
+      batch.result.attr("__getitem__")(py_index));
+
+  decoder_result result;
+  nb::object converged = batch.converged.attr("__getitem__")(py_index);
+  const int is_converged = PyObject_IsTrue(converged.ptr());
+  if (is_converged < 0) {
+    PyErr_Clear();
+    throw nb::type_error(
+        "BatchDecoderResult converged entries must be bool-like.");
+  }
+  result.converged = is_converged != 0;
+  const auto result_size = row.shape(0);
+  const auto *data = static_cast<const float_t *>(row.data());
+  result.result.assign(data, data + result_size);
+
+  nb::object opt_results = batch.opt_results.attr("__getitem__")(py_index);
+  if (!opt_results.is_none())
+    result.opt_results = nb::cast<cudaqx::heterogeneous_map>(opt_results);
+  return result;
+}
+
+batch_decoder_result
+batchSliceToBatchDecoderResult(const batch_decoder_result &batch,
+                               const nb::slice &slice) {
+  nb::object result = batch.result.attr("__getitem__")(slice);
+  nb::object converged = batch.converged.attr("__getitem__")(slice);
+  nb::list opt_results =
+      nb::cast<nb::list>(batch.opt_results.attr("__getitem__")(slice));
+  return batch_decoder_result(result, converged, opt_results,
+                              nb::len(converged));
+}
+
+nb::object decoderResultToNumpy(const std::vector<float_t> &result) {
+  const auto num_elements = result.size();
+  auto data = std::make_unique<float_t[]>(num_elements);
+
+  std::copy(result.begin(), result.end(), data.get());
+
+  size_t shape[1] = {num_elements};
+  auto *raw_data = data.get();
+  nb::capsule owner(
+      raw_data, [](void *p) noexcept { delete[] static_cast<float_t *>(p); });
+  data.release();
+  return nb::cast(
+      nb::ndarray<nb::numpy, float_t>(raw_data, 1, shape, std::move(owner)));
+}
+
+nb::object decoderResultsToNumpy(const std::vector<decoder_result> &results,
+                                 std::size_t block_size) {
+  const auto num_results = results.size();
+  const auto result_size =
+      num_results == 0 ? block_size : results.front().result.size();
+
+  for (const auto &result : results) {
+    if (result.result.size() != result_size) {
+      throw std::runtime_error(
+          "Cannot return decode_batch results as a NumPy array because result "
+          "vectors have inconsistent sizes.");
+    }
+  }
+
+  const auto num_elements = num_results * result_size;
+  auto data = std::make_unique<float_t[]>(num_elements);
+
+  auto *out = data.get();
+  for (const auto &result : results) {
+    out = std::copy(result.result.begin(), result.result.end(), out);
+  }
+
+  size_t shape[2] = {num_results, result_size};
+  auto *raw_data = data.get();
+  nb::capsule owner(
+      raw_data, [](void *p) noexcept { delete[] static_cast<float_t *>(p); });
+  data.release();
+  return nb::cast(
+      nb::ndarray<nb::numpy, float_t>(raw_data, 2, shape, std::move(owner)));
+}
+
+nb::object
+decoderResultsConvergedToNumpy(const std::vector<decoder_result> &results) {
+  const auto num_results = results.size();
+  auto data = std::make_unique<bool[]>(num_results);
+
+  for (std::size_t i = 0; i < num_results; ++i)
+    data[i] = results[i].converged;
+
+  size_t shape[1] = {num_results};
+  auto *raw_data = data.get();
+  nb::capsule owner(raw_data,
+                    [](void *p) noexcept { delete[] static_cast<bool *>(p); });
+  data.release();
+  return nb::cast(
+      nb::ndarray<nb::numpy, bool>(raw_data, 1, shape, std::move(owner)));
+}
+
+nb::list
+decoderResultsOptResultsToList(const std::vector<decoder_result> &results) {
+  nb::list opt_results;
+  for (const auto &result : results) {
+    if (result.opt_results.has_value()) {
+      opt_results.append(nb::cast(result.opt_results));
+    } else {
+      opt_results.append(nb::none());
+    }
+  }
+  return opt_results;
+}
+
+batch_decoder_result
+makeBatchDecoderResult(const std::vector<decoder_result> &results,
+                       std::size_t block_size) {
+  return batch_decoder_result{
+      decoderResultsToNumpy(results, block_size),
+      decoderResultsConvergedToNumpy(results),
+      decoderResultsOptResultsToList(results),
+      results.size(),
+  };
+}
+
+} // namespace
+
 void bindDecoder(nb::module_ &mod) {
   // Store a sentinel (non-null pointer required by PyCapsule_New) and invoke
   // plugin cleanup when the module is garbage-collected.
@@ -106,9 +300,24 @@ void bindDecoder(nb::module_ &mod) {
                     : mod.def_submodule("qecrt");
 
   nb::class_<decoder_result>(qecmod, "DecoderResult", R"pbdoc(
-    A class representing the results of a quantum error correction decoding operation.
+    Single-shot decoder result.
 
-    This class encapsulates both the convergence status and the actual decoding result.
+    Returned by `decoder.decode(...)`. Carries the convergence flag, the
+    decoded correction chain, and optional decoder-specific metadata.
+
+    Like `BatchDecoderResult`, this is conceptually output-only — user code
+    should not need to construct or mutate one. Unlike `BatchDecoderResult`,
+    the no-arg constructor and writable fields are preserved here because
+    Python decoder plugins implementing a `decode` override use the
+    construct-then-mutate pattern:
+
+        res = DecoderResult()
+        res.converged = True
+        res.result = np.arange(...)
+        return res
+
+    Tightening this construction surface would break every existing Python
+    decoder plugin and is deferred to a future change.
 )pbdoc")
       .def(nb::init<>(), R"pbdoc(
         Default constructor for DecoderResult.
@@ -121,12 +330,28 @@ void bindDecoder(nb::module_ &mod) {
         True if the decoder successfully found a valid correction chain,
         False if the decoder failed to converge or exceeded iteration limits.
     )pbdoc")
-      .def_rw("result", &decoder_result::result, R"pbdoc(
+      .def_prop_rw(
+          "result",
+          [](const decoder_result &self) {
+            return decoderResultToNumpy(self.result);
+          },
+          [](decoder_result &self, const std::vector<float_t> &value) {
+            self.result = value;
+          },
+          R"pbdoc(
         The decoded correction chain or recovery operation.
 
         Contains the sequence of corrections that should be applied to recover
         the original quantum state. The format depends on the specific decoder
         implementation.
+
+        Returns a 1-D NumPy array of the configured QEC floating point dtype
+        (float64 in standard wheels). A fresh array is allocated per access —
+        the underlying storage is a `std::vector<float_t>` and the data is
+        copied out on read.
+
+        Accepts any sequence of floats on assignment; this is the path Python
+        decoder plugins use in their `decode` overrides (see class docstring).
     )pbdoc")
       .def_rw("opt_results", &decoder_result::opt_results, R"pbdoc(
         Optional additional results from the decoder stored in a heterogeneous map.
@@ -140,7 +365,7 @@ void bindDecoder(nb::module_ &mod) {
              case 0:
                return nb::cast(r.converged);
              case 1:
-               return nb::cast(r.result);
+               return decoderResultToNumpy(r.result);
              case 2:
                return nb::cast(r.opt_results);
              default:
@@ -149,9 +374,114 @@ void bindDecoder(nb::module_ &mod) {
            })
       // Enable iteration protocol
       .def("__iter__", [](const decoder_result &r) -> nb::object {
-        return nb::make_tuple(r.converged, r.result, r.opt_results)
+        return nb::make_tuple(r.converged, decoderResultToNumpy(r.result),
+                              r.opt_results)
             .attr("__iter__")();
       });
+
+  nb::class_<batch_decoder_result>(qecmod, "BatchDecoderResult", R"pbdoc(
+    Batched decoder result.
+
+    Produced by `decoder.decode_batch(...)`. This type is output-only: it
+    carries decoder output back to the caller and is not parsed by decoders.
+    User code should not need to construct one — call
+    `decoder.decode_batch(...)` and read the result.
+
+    Python decoder plugins implementing a `decode_batch` override may use the
+    constructor to produce one. `result` should be a 2-D NumPy array of the
+    configured QEC floating point dtype (float64 in standard wheels);
+    `converged` should be a 1-D NumPy bool array; `opt_results` is a list of
+    per-shot dicts or None entries. The constructor coerces `result` and
+    `converged` to C-contiguous storage of the expected dtype (via
+    `np.ascontiguousarray`), copying when the input doesn't already satisfy
+    those invariants. Wrong rank (e.g. 1-D `result`) is rejected with
+    TypeError.
+
+    Access patterns, fastest to slowest:
+
+      1. Vectorized: read `result`, `converged`, or `opt_results` directly.
+         The properties return the underlying NumPy arrays and Python list
+         with no copy. This is the recommended path for batch processing.
+
+      2. Slicing: `batch[a:b]` returns another BatchDecoderResult that shares
+         data with the parent. NumPy basic slicing — including stepped slices
+         like `batch[::2]` — returns views, so no data is copied. The opt
+         results list slice creates a new Python list, but its entries are
+         shared references.
+
+      3. Integer indexing / iteration: `batch[i]` or `for r in batch:` yields
+         a DecoderResult copy of one shot. This compatibility surface exists
+         for code written against the previous `list[DecoderResult]` return
+         type. Each access copies the row out into a fresh per-shot buffer
+         because DecoderResult's underlying storage (`std::vector<float_t>`)
+         cannot alias into the batch's packed NumPy array — the layouts are
+         incompatible. Avoid in hot loops; prefer pattern 1.
+)pbdoc")
+      .def(nb::init<nb::ndarray<nb::numpy, float_t, nb::ndim<2>>,
+                    nb::ndarray<nb::numpy, bool, nb::ndim<1>>, nb::object>(),
+           nb::arg("result"), nb::arg("converged"),
+           nb::arg("opt_results") = nb::none())
+      .def_prop_ro(
+          "result",
+          [](const batch_decoder_result &self) { return self.result; },
+          R"pbdoc(
+        A two-dimensional NumPy array of decoder outputs, with one row per shot.
+
+        This is the fast path for batch consumers. Its dtype is the configured
+        QEC floating point type.
+    )pbdoc")
+      .def_prop_ro(
+          "converged",
+          [](const batch_decoder_result &self) { return self.converged; },
+          R"pbdoc(
+        A one-dimensional NumPy bool array indicating convergence per shot.
+    )pbdoc")
+      .def_prop_ro(
+          "opt_results",
+          [](const batch_decoder_result &self) { return self.opt_results; },
+          R"pbdoc(
+        A list of per-shot optional result dictionaries, or None entries.
+    )pbdoc")
+      .def(
+          "__getitem__",
+          [](const batch_decoder_result &self, nb::handle key) -> nb::object {
+            if (PyIndex_Check(key.ptr())) {
+              Py_ssize_t index =
+                  PyNumber_AsSsize_t(key.ptr(), PyExc_IndexError);
+              if (index == -1 && PyErr_Occurred()) {
+                PyErr_Clear();
+                throw nb::index_error();
+              }
+              return nb::cast(batchItemToDecoderResult(self, index));
+            }
+            if (nb::isinstance<nb::slice>(key)) {
+              return nb::cast(batchSliceToBatchDecoderResult(
+                  self, nb::borrow<nb::slice>(key)));
+            }
+            throw nb::type_error(
+                "BatchDecoderResult indices must be integers or slices.");
+          },
+          R"pbdoc(
+        Return one or more batch entries.
+
+        Integer indexing materializes a DecoderResult copy of one shot. This
+        path exists for compatibility with code written against the previous
+        `list[DecoderResult]` return type. Each access copies the row out
+        per shot because DecoderResult's storage (`std::vector<float_t>`)
+        cannot alias into the batch's packed NumPy array. Prefer reading
+        `result`, `converged`, and `opt_results` directly for batch
+        workflows.
+
+        Slicing returns another BatchDecoderResult whose `result` and
+        `converged` arrays are NumPy views into the parent (basic slicing,
+        including stepped slices, does not copy). `opt_results` is a new list
+        with shared element references. No per-shot work.
+    )pbdoc")
+      .def(
+          "__len__", [](const batch_decoder_result &self) { return self.size; },
+          R"pbdoc(
+        Return the number of shots in the batch.
+    )pbdoc");
 
   nb::class_<async_decoder_result>(qecmod, "AsyncDecoderResult",
                                    R"pbdoc(
@@ -189,7 +519,8 @@ void bindDecoder(nb::module_ &mod) {
           "decode_batch",
           [](decoder &decoder,
              const std::vector<std::vector<float_t>> &syndrome) {
-            return decoder.decode_batch(syndrome);
+            auto results = decoder.decode_batch(syndrome);
+            return makeBatchDecoderResult(results, decoder.get_block_size());
           },
           "Decode multiple syndromes and return the results",
           nb::arg("syndrome"))

--- a/libs/qec/python/bindings/py_decoder.cpp
+++ b/libs/qec/python/bindings/py_decoder.cpp
@@ -214,11 +214,13 @@ nb::object decoderResultToNumpy(const std::vector<float_t> &result) {
       nb::ndarray<nb::numpy, float_t>(raw_data, 1, shape, std::move(owner)));
 }
 
-nb::object decoderResultsToNumpy(const std::vector<decoder_result> &results,
-                                 std::size_t block_size) {
+nb::object decoderResultsToNumpy(const std::vector<decoder_result> &results) {
   const auto num_results = results.size();
-  const auto result_size =
-      num_results == 0 ? block_size : results.front().result.size();
+  // Empty batch yields shape (0, 0). The per-shot width is unknown without
+  // running a decode (and depends on decoder mode — e.g. decode_to_observables
+  // produces num_observables-wide rows, not block_size-wide). Callers should
+  // not rely on result.shape[1] when the batch is empty.
+  const auto result_size = num_results == 0 ? 0 : results.front().result.size();
 
   for (const auto &result : results) {
     if (result.result.size() != result_size) {
@@ -276,10 +278,9 @@ decoderResultsOptResultsToList(const std::vector<decoder_result> &results) {
 }
 
 batch_decoder_result
-makeBatchDecoderResult(const std::vector<decoder_result> &results,
-                       std::size_t block_size) {
+makeBatchDecoderResult(const std::vector<decoder_result> &results) {
   return batch_decoder_result{
-      decoderResultsToNumpy(results, block_size),
+      decoderResultsToNumpy(results),
       decoderResultsConvergedToNumpy(results),
       decoderResultsOptResultsToList(results),
       results.size(),
@@ -396,6 +397,11 @@ void bindDecoder(nb::module_ &mod) {
     `np.ascontiguousarray`), copying when the input doesn't already satisfy
     those invariants. Wrong rank (e.g. 1-D `result`) is rejected with
     TypeError.
+
+    An empty batch (zero syndromes) yields `result.shape == (0, 0)` and
+    `converged.shape == (0,)`. The per-shot width is unknown without running
+    a decode and depends on decoder mode, so `result.shape[1]` is only
+    meaningful when the batch is non-empty.
 
     Access patterns, fastest to slowest:
 
@@ -520,7 +526,7 @@ void bindDecoder(nb::module_ &mod) {
           [](decoder &decoder,
              const std::vector<std::vector<float_t>> &syndrome) {
             auto results = decoder.decode_batch(syndrome);
-            return makeBatchDecoderResult(results, decoder.get_block_size());
+            return makeBatchDecoderResult(results);
           },
           "Decode multiple syndromes and return the results",
           nb::arg("syndrome"))

--- a/libs/qec/python/bindings/py_decoder.cpp
+++ b/libs/qec/python/bindings/py_decoder.cpp
@@ -36,7 +36,6 @@
 #include <algorithm>
 
 namespace nb = nanobind;
-using namespace nanobind::literals;
 using namespace cudaqx;
 
 namespace cudaq::qec {
@@ -135,9 +134,9 @@ struct batch_decoder_result {
                                  ? np.attr("float32")
                                  : np.attr("float64");
     this->result = np.attr("ascontiguousarray")(nb::cast(result_arr),
-                                                "dtype"_a = float_dtype);
+                                                nb::arg("dtype") = float_dtype);
     this->converged = np.attr("ascontiguousarray")(
-        nb::cast(converged_arr), "dtype"_a = np.attr("bool_"));
+        nb::cast(converged_arr), nb::arg("dtype") = np.attr("bool_"));
   }
 
   // Trusted internal constructor: callers guarantee shape/dtype invariants.

--- a/libs/qec/python/bindings/py_decoder.cpp
+++ b/libs/qec/python/bindings/py_decoder.cpp
@@ -198,19 +198,29 @@ batchSliceToBatchDecoderResult(const batch_decoder_result &batch,
                               nb::len(converged));
 }
 
+// Wrap a heap-allocated buffer (owned via unique_ptr) in a NumPy ndarray that
+// will free the buffer when garbage-collected. The unique_ptr argument keeps
+// the buffer alive until ownership is transferred to the capsule; if any step
+// inside this function throws, the buffer is freed by the unique_ptr
+// destructor on unwind.
+template <typename T, std::size_t Rank>
+nb::object makeOwnedNdarray(std::unique_ptr<T[]> data,
+                            const std::size_t (&shape)[Rank]) {
+  auto *raw_data = data.get();
+  nb::capsule owner(raw_data,
+                    [](void *p) noexcept { delete[] static_cast<T *>(p); });
+  data.release();
+  return nb::cast(
+      nb::ndarray<nb::numpy, T>(raw_data, Rank, shape, std::move(owner)));
+}
+
 nb::object decoderResultToNumpy(const std::vector<float_t> &result) {
   const auto num_elements = result.size();
   auto data = std::make_unique<float_t[]>(num_elements);
-
   std::copy(result.begin(), result.end(), data.get());
 
   size_t shape[1] = {num_elements};
-  auto *raw_data = data.get();
-  nb::capsule owner(
-      raw_data, [](void *p) noexcept { delete[] static_cast<float_t *>(p); });
-  data.release();
-  return nb::cast(
-      nb::ndarray<nb::numpy, float_t>(raw_data, 1, shape, std::move(owner)));
+  return makeOwnedNdarray<float_t>(std::move(data), shape);
 }
 
 nb::object decoderResultsToNumpy(const std::vector<decoder_result> &results) {
@@ -238,29 +248,18 @@ nb::object decoderResultsToNumpy(const std::vector<decoder_result> &results) {
   }
 
   size_t shape[2] = {num_results, result_size};
-  auto *raw_data = data.get();
-  nb::capsule owner(
-      raw_data, [](void *p) noexcept { delete[] static_cast<float_t *>(p); });
-  data.release();
-  return nb::cast(
-      nb::ndarray<nb::numpy, float_t>(raw_data, 2, shape, std::move(owner)));
+  return makeOwnedNdarray<float_t>(std::move(data), shape);
 }
 
 nb::object
 decoderResultsConvergedToNumpy(const std::vector<decoder_result> &results) {
   const auto num_results = results.size();
   auto data = std::make_unique<bool[]>(num_results);
-
   for (std::size_t i = 0; i < num_results; ++i)
     data[i] = results[i].converged;
 
   size_t shape[1] = {num_results};
-  auto *raw_data = data.get();
-  nb::capsule owner(raw_data,
-                    [](void *p) noexcept { delete[] static_cast<bool *>(p); });
-  data.release();
-  return nb::cast(
-      nb::ndarray<nb::numpy, bool>(raw_data, 1, shape, std::move(owner)));
+  return makeOwnedNdarray<bool>(std::move(data), shape);
 }
 
 nb::list

--- a/libs/qec/python/cudaq_qec/__init__.py
+++ b/libs/qec/python/cudaq_qec/__init__.py
@@ -18,6 +18,8 @@ def _ensure_cuda_runtime_loaded():
 _ensure_cuda_runtime_loaded()
 del _ensure_cuda_runtime_loaded
 
+import functools
+
 from .patch import patch
 try:
     from ._pycudaqx_qec_the_suffix_matters_cudaq_qec import *
@@ -58,6 +60,7 @@ def decoder(name):
             original = cls.decode_batch
             cls_name = cls.__name__
 
+            @functools.wraps(original)
             def checked_decode_batch(self, *args, **kwargs):
                 result = original(self, *args, **kwargs)
                 if not isinstance(result, qecrt.BatchDecoderResult):

--- a/libs/qec/python/cudaq_qec/__init__.py
+++ b/libs/qec/python/cudaq_qec/__init__.py
@@ -48,6 +48,7 @@ get_code = qecrt.get_code
 get_available_codes = qecrt.get_available_codes
 get_decoder = qecrt.get_decoder
 DecoderResult = qecrt.DecoderResult
+BatchDecoderResult = qecrt.BatchDecoderResult
 DetectorErrorModel = qecrt.DetectorErrorModel
 generate_random_bit_flips = qecrt.generate_random_bit_flips
 sample_memory_circuit = qecrt.sample_memory_circuit

--- a/libs/qec/python/cudaq_qec/__init__.py
+++ b/libs/qec/python/cudaq_qec/__init__.py
@@ -39,8 +39,42 @@ except ImportError as exc:
 __version__ = qecrt.__version__
 code = qecrt.code
 Code = qecrt.Code
-decoder = qecrt.decoder
+_native_decoder = qecrt.decoder
 Decoder = qecrt.Decoder
+
+
+def decoder(name):
+    """Register a Python class as a decoder plugin under `name`.
+
+    Wraps the native registration decorator so that any user-defined
+    `decode_batch` override is checked at runtime to return a
+    BatchDecoderResult. Returning a list[DecoderResult] (the pre-batch API)
+    is no longer supported.
+    """
+    native = _native_decoder(name)
+
+    def wrap(cls):
+        if "decode_batch" in cls.__dict__:
+            original = cls.decode_batch
+            cls_name = cls.__name__
+
+            def checked_decode_batch(self, *args, **kwargs):
+                result = original(self, *args, **kwargs)
+                if not isinstance(result, qecrt.BatchDecoderResult):
+                    raise TypeError(
+                        f"{cls_name}.decode_batch must return a "
+                        f"BatchDecoderResult; got "
+                        f"{type(result).__name__}. See BatchDecoderResult "
+                        f"in the cudaq_qec docs for the supported "
+                        f"construction surface.")
+                return result
+
+            cls.decode_batch = checked_decode_batch
+        return native(cls)
+
+    return wrap
+
+
 TwoQubitDepolarization = qecrt.TwoQubitDepolarization
 TwoQubitBitFlip = qecrt.TwoQubitBitFlip
 operation = qecrt.operation

--- a/libs/qec/python/cudaq_qec/plugins/decoders/tensor_network_decoder.py
+++ b/libs/qec/python/cudaq_qec/plugins/decoders/tensor_network_decoder.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 from typing import Any
 import cudaq_qec as qec
+import numpy as np
 
 import numpy.typing as npt
 from quimb.tensor import TensorNetwork
@@ -416,15 +417,17 @@ class TensorNetworkDecoder:
     def decode_batch(
         self,
         syndrome_batch: npt.NDArray[Any],
-    ) -> list["qec.DecoderResult"]:
+    ) -> "qec.BatchDecoderResult":
         """Decode a batch of detection events.
 
         Args:
             syndrome_batch (np.ndarray): A numpy array of shape (batch_size, syndrome_length) where each row is a detection event.
 
         Returns:
-            list[qec.DecoderResult]: list of results for each detection event in the batch.
-                The probabilities that the logical observable flipped for each syndrome.
+            qec.BatchDecoderResult: batched results for each detection event in
+                the batch. The `result` field has shape (batch_size, 1) and
+                contains the probabilities that the logical observable flipped
+                for each syndrome.
         """
 
         assert hasattr(self, "noise_model")
@@ -459,16 +462,20 @@ class TensorNetworkDecoder:
             device_id=self.contractor_config.device_id,
         )
 
-        res = []
+        probabilities = []
         for r in range(syndrome_batch.shape[0]):
-            res.append(qec.DecoderResult())
-            res[r].converged = True
-            res[r].result = [
+            probabilities.append(
                 float(contraction_value[r, 1] /
-                      (contraction_value[r, 1] + contraction_value[r, 0]))
-            ]
+                      (contraction_value[r, 1] + contraction_value[r, 0])))
 
-        return res
+        # Python `decode_batch` override: construct a BatchDecoderResult
+        # directly, bypassing the native decoder aggregation path. This is
+        # the only sanctioned caller of the BatchDecoderResult constructor;
+        # see its docstring for the supported construction surface.
+        return qec.BatchDecoderResult(
+            np.asarray(probabilities, dtype=np.float64).reshape((-1, 1)),
+            np.ones(syndrome_batch.shape[0], dtype=bool),
+        )
 
     def optimize_path(
         self,

--- a/libs/qec/python/tests/test_decoder.py
+++ b/libs/qec/python/tests/test_decoder.py
@@ -41,13 +41,33 @@ def test_decoder_api():
     decoder = qec.get_decoder('example_byod', H)
     result = decoder.decode_batch(
         [create_test_syndrome(), create_test_syndrome()])
+    assert isinstance(result, qec.BatchDecoderResult)
     assert len(result) == 2
-    for r in result:
-        assert hasattr(r, 'converged')
-        assert hasattr(r, 'result')
-        assert isinstance(r.converged, bool)
-        assert isinstance(r.result, list)
-        assert len(r.result) == 10
+    assert hasattr(result, 'converged')
+    assert hasattr(result, 'result')
+    assert hasattr(result, 'opt_results')
+    assert isinstance(result.converged, np.ndarray)
+    assert result.converged.shape == (2,)
+    assert isinstance(result.result, np.ndarray)
+    assert result.result.shape == (2, 10)
+    assert len(result.opt_results) == 2
+    assert all(opt is None for opt in result.opt_results)
+    first = result[0]
+    assert isinstance(first, qec.DecoderResult)
+    assert first.converged == result.converged[0]
+    np.testing.assert_array_equal(first.result, result.result[0])
+    assert first.opt_results is None
+    last = result[-1]
+    np.testing.assert_array_equal(last.result, result.result[-1])
+    sliced = result[:1]
+    assert isinstance(sliced, qec.BatchDecoderResult)
+    assert sliced.result.shape == (1, 10)
+    assert sliced.converged.shape == (1,)
+    assert len(sliced.opt_results) == 1
+    iterated = list(result)
+    assert len(iterated) == 2
+    assert all(isinstance(r, qec.DecoderResult) for r in iterated)
+    np.testing.assert_array_equal(iterated[1].result, result.result[1])
 
     # Test decode_async
     decoder = qec.get_decoder('example_byod', H)
@@ -59,8 +79,8 @@ def test_decoder_api():
     assert hasattr(result, 'converged')
     assert hasattr(result, 'result')
     assert isinstance(result.converged, bool)
-    assert isinstance(result.result, list)
-    assert len(result.result) == 10
+    assert isinstance(result.result, np.ndarray)
+    assert result.result.shape == (10,)
 
 
 def test_decoder_result_structure():
@@ -72,8 +92,8 @@ def test_decoder_result_structure():
     assert hasattr(result, 'result')
     assert hasattr(result, 'opt_results')
     assert isinstance(result.converged, bool)
-    assert isinstance(result.result, list)
-    assert len(result.result) == 10
+    assert isinstance(result.result, np.ndarray)
+    assert result.result.shape == (10,)
 
     # Test opt_results functionality
     assert result.opt_results is None  # Default should be None
@@ -83,6 +103,83 @@ def test_decoder_result_structure():
     result = async_result.get()
     assert hasattr(result, 'opt_results')
     assert result.opt_results is None
+
+
+def test_batch_decoder_result_constructor():
+    result = np.zeros((2, 3), dtype=np.float64)
+    converged = np.array([True, False], dtype=np.bool_)
+    batch_result = qec.BatchDecoderResult(result, converged)
+
+    assert isinstance(batch_result.result, np.ndarray)
+    assert batch_result.result.shape == (2, 3)
+    assert batch_result.converged.tolist() == [True, False]
+    assert batch_result.opt_results == [None, None]
+    assert batch_result[np.int64(0)].converged is True
+    assert batch_result[::2].result.shape == (1, 3)
+    assert np.shares_memory(batch_result[::2].result, batch_result.result)
+
+    empty_result = qec.BatchDecoderResult(np.empty((0, 3), dtype=np.float64),
+                                          np.array([], dtype=np.bool_))
+    assert len(empty_result) == 0
+    assert empty_result.result.shape == (0, 3)
+    assert empty_result.converged.shape == (0,)
+    assert list(empty_result) == []
+    with pytest.raises(IndexError):
+        empty_result[0]
+
+    # Cross-array invariants we still enforce.
+    with pytest.raises(RuntimeError, match="row count must match"):
+        qec.BatchDecoderResult(result,
+                               np.array([True, False, True], dtype=np.bool_))
+
+    with pytest.raises(RuntimeError, match="opt_results length must match"):
+        qec.BatchDecoderResult(result, converged, [None])
+
+    # Rank is enforced by nanobind, surfaced as TypeError.
+    with pytest.raises(TypeError):
+        qec.BatchDecoderResult(np.zeros(3, dtype=np.float64), converged)
+
+    # dtype and contiguity are coerced silently, not rejected.
+    int_result = qec.BatchDecoderResult(np.zeros((2, 3), dtype=np.int32),
+                                        converged)
+    assert int_result.result.dtype == batch_result.result.dtype
+    assert int_result.result.flags.c_contiguous
+
+    f_order = np.asfortranarray(np.zeros((2, 3), dtype=np.float64))
+    assert not f_order.flags.c_contiguous
+    f_result = qec.BatchDecoderResult(f_order, converged)
+    assert f_result.result.flags.c_contiguous
+
+
+def test_python_decoder_batch_preserves_opt_results():
+
+    @qec.decoder("python_opt_results_byod")
+    class PythonOptResultsDecoder:
+
+        def __init__(self, H, **kwargs):
+            qec.Decoder.__init__(self, H)
+            self.H = H
+
+        def decode(self, syndrome):
+            res = qec.DecoderResult()
+            res.converged = True
+            res.result = np.arange(self.H.shape[1], dtype=np.float64)
+            res.opt_results = {
+                "syndrome_weight": int(np.count_nonzero(syndrome)),
+                "tag": "python"
+            }
+            return res
+
+    decoder = qec.get_decoder("python_opt_results_byod", H)
+    batch_result = decoder.decode_batch(
+        [np.zeros(H.shape[0]), np.ones(H.shape[0])])
+
+    assert isinstance(batch_result, qec.BatchDecoderResult)
+    assert batch_result.result.shape == (2, H.shape[1])
+    assert batch_result.converged.tolist() == [True, True]
+    assert batch_result.opt_results[0]["syndrome_weight"] == 0
+    assert batch_result.opt_results[1]["syndrome_weight"] == H.shape[0]
+    assert batch_result[1].opt_results["tag"] == "python"
 
 
 def test_decoder_plugin_initialization():
@@ -133,7 +230,7 @@ def test_decoder_plugin_result_structure():
     assert hasattr(result, 'converged')
     assert hasattr(result, 'result')
     assert isinstance(result.converged, bool)
-    assert isinstance(result.result, list)
+    assert isinstance(result.result, np.ndarray)
 
 
 def test_decoder_result_values():
@@ -141,8 +238,8 @@ def test_decoder_result_values():
     result = decoder.decode(create_test_syndrome())
 
     assert result.converged is True
-    assert all(isinstance(x, float) for x in result.result)
-    assert all(0 <= x <= 1 for x in result.result)
+    assert isinstance(result.result, np.ndarray)
+    assert np.all((0 <= result.result) & (result.result <= 1))
 
 
 @pytest.mark.parametrize("matrix_shape,syndrome_size", [((5, 10), 5),
@@ -158,8 +255,8 @@ def test_decoder_different_matrix_sizes(matrix_shape, syndrome_size):
 
     assert len(result) == syndrome_size
     assert convergence is True
-    assert all(isinstance(x, float) for x in result)
-    assert all(0 <= x <= 1 for x in result)
+    assert isinstance(result, np.ndarray)
+    assert np.all((0 <= result) & (result <= 1))
 
 
 # FIXME add this back
@@ -187,7 +284,7 @@ def test_decoder_reproducibility():
     np.random.seed(42)
     convergence2, result2, opt2 = decoder.decode(create_test_syndrome())
 
-    assert result1 == result2
+    np.testing.assert_array_equal(result1, result2)
     assert convergence1 == convergence2
 
 
@@ -338,6 +435,19 @@ def test_single_error_lut_opt_results():
     assert "syndrome_weight" in result.opt_results
     assert "decoding_time" not in result.opt_results  # Was set to False
 
+    batch_result = decoder.decode_batch(
+        [create_test_syndrome(), create_test_syndrome()])
+    assert isinstance(batch_result.result, np.ndarray)
+    assert batch_result.result.shape == (2, H.shape[1])
+    assert isinstance(batch_result.converged, np.ndarray)
+    assert batch_result.converged.shape == (2,)
+    assert len(batch_result.opt_results) == 2
+    for opt_results in batch_result.opt_results:
+        assert opt_results is not None
+        assert "error_probability" in opt_results
+        assert "syndrome_weight" in opt_results
+        assert "decoding_time" not in opt_results
+
 
 def test_decoder_pymatching_results():
     pcm = qec.generate_random_pcm(n_rounds=2,
@@ -353,8 +463,8 @@ def test_decoder_pymatching_results():
     decoder = qec.get_decoder('pymatching', pcm)
     result = decoder.decode(syndrome)
     assert result.converged is True
-    assert all(isinstance(x, float) for x in result.result)
-    assert all(0 <= x <= 1 for x in result.result)
+    assert isinstance(result.result, np.ndarray)
+    assert np.all((0 <= result.result) & (result.result <= 1))
     actual_errors = np.zeros(pcm.shape[1], dtype=np.uint8)
     actual_errors[columns] = 1
     assert np.array_equal(result.result, actual_errors)

--- a/libs/qec/python/tests/test_decoder.py
+++ b/libs/qec/python/tests/test_decoder.py
@@ -69,6 +69,14 @@ def test_decoder_api():
     assert all(isinstance(r, qec.DecoderResult) for r in iterated)
     np.testing.assert_array_equal(iterated[1].result, result.result[1])
 
+    # Empty batch: shape (0, 0); per-shot width is undefined without input.
+    empty_result = decoder.decode_batch([])
+    assert isinstance(empty_result, qec.BatchDecoderResult)
+    assert empty_result.result.shape == (0, 0)
+    assert empty_result.converged.shape == (0,)
+    assert len(empty_result) == 0
+    assert len(empty_result.opt_results) == 0
+
     # Test decode_async
     decoder = qec.get_decoder('example_byod', H)
     result_async = decoder.decode_async(create_test_syndrome())
@@ -180,6 +188,30 @@ def test_python_decoder_batch_preserves_opt_results():
     assert batch_result.opt_results[0]["syndrome_weight"] == 0
     assert batch_result.opt_results[1]["syndrome_weight"] == H.shape[0]
     assert batch_result[1].opt_results["tag"] == "python"
+
+
+def test_python_decoder_batch_override_must_return_batch_decoder_result():
+
+    @qec.decoder("python_bad_batch_byod")
+    class PythonBadBatchDecoder:
+
+        def __init__(self, H, **kwargs):
+            qec.Decoder.__init__(self, H)
+            self.H = H
+
+        def decode(self, syndrome):
+            res = qec.DecoderResult()
+            res.converged = True
+            res.result = np.zeros(self.H.shape[1], dtype=np.float64)
+            return res
+
+        def decode_batch(self, syndromes):
+            # Pre-batch return shape; the decorator should reject this.
+            return [self.decode(s) for s in syndromes]
+
+    decoder = qec.get_decoder("python_bad_batch_byod", H)
+    with pytest.raises(TypeError, match="must return a BatchDecoderResult"):
+        decoder.decode_batch([np.zeros(H.shape[0]), np.ones(H.shape[0])])
 
 
 def test_decoder_plugin_initialization():

--- a/libs/qec/python/tests/test_dem.py
+++ b/libs/qec/python/tests/test_dem.py
@@ -160,8 +160,8 @@ def test_decoding_from_dem_from_memory_circuit():
     syndromes = syndromes.reshape((nShots, -1))
     decoder = qec.get_decoder('single_error_lut', dem.detector_error_matrix)
     dr = decoder.decode_batch(syndromes)
-    error_predictions = np.array([e.result for e in dr], dtype=np.uint8)
-    dr_converged = np.array([e.converged for e in dr], dtype=np.uint8)
+    error_predictions = np.asarray(dr.result, dtype=np.uint8)
+    dr_converged = np.asarray(dr.converged, dtype=np.uint8)
 
     data_predictions = (dem.observables_flips_matrix @ error_predictions.T) % 2
     print(f'data_predictions.shape: {data_predictions.shape}')
@@ -249,12 +249,11 @@ def test_decoding_from_surface_code_dem_from_memory_circuit(
     print(f'decoder_name: {decoder_name}')
 
     dr = decoder.decode_batch(syndromes)
-    error_predictions = np.array([e.result for e in dr], dtype=np.uint8)
-    dr_converged = np.array([e.converged for e in dr], dtype=np.uint8)
+    error_predictions = np.asarray(dr.result, dtype=np.uint8)
+    dr_converged = np.asarray(dr.converged, dtype=np.uint8)
     if decoder_name == "tensor_network_decoder":
         # Tensor network decoder returns the observable flips, not the error predictions.
-        data_predictions = np.array([np.round(e.result) for e in dr],
-                                    dtype=np.uint8).T
+        data_predictions = np.round(dr.result).astype(np.uint8).T
     else:
         data_predictions = (
             dem.observables_flips_matrix @ error_predictions.T) % 2
@@ -308,9 +307,9 @@ def test_pymatching_decode_to_observable_surface_code_dem():
     )
 
     dr = decoder.decode_batch(syndromes)
-    # With decode_to_observables=True, each e.result is observable flips
+    # With decode_to_observables=True, each row is observable flips
     # (length num_observables), not error predictions.
-    obs_per_shot = np.array([e.result for e in dr], dtype=np.float64)
+    obs_per_shot = np.asarray(dr.result, dtype=np.float64)
     data_predictions = np.round(obs_per_shot).astype(np.uint8).T
 
     nLogicalErrorsWithoutDecoding = np.sum(logical_measurements)

--- a/libs/qec/python/tests/test_sliding_window.py
+++ b/libs/qec/python/tests/test_sliding_window.py
@@ -70,19 +70,15 @@ def test_sliding_window_1(decoder_name, batched, num_rounds, num_windows):
     if batched:
         full_results = full_decoder.decode_batch(syndromes)
         sw_results = sw_as_full_decoder.decode_batch(syndromes)
-        num_mismatches = 0
-        for r1, r2 in zip(full_results, sw_results):
-            if r1.result != r2.result:
-                num_mismatches += 1
+        num_mismatches = np.count_nonzero(
+            np.any(full_results.result != sw_results.result, axis=1))
         assert num_mismatches == 0
 
     else:
-        full_results = []
-        sw_results = []
         num_mismatches = 0
         for syndrome in syndromes:
             r1 = full_decoder.decode(syndrome)
             r2 = sw_as_full_decoder.decode(syndrome)
-            if r1.result != r2.result:
+            if not np.array_equal(r1.result, r2.result):
                 num_mismatches += 1
         assert num_mismatches == 0

--- a/libs/qec/python/tests/test_tensor_network_decoder.py
+++ b/libs/qec/python/tests/test_tensor_network_decoder.py
@@ -140,7 +140,7 @@ def test_decoder_decode_single():
     res = decoder.decode(syndrome)
     assert hasattr(res, "converged")
     assert hasattr(res, "result")
-    assert isinstance(res.result, list)
+    assert isinstance(res.result, np.ndarray)
     assert 0.0 <= res.result[0] <= 1.0
 
 
@@ -152,12 +152,14 @@ def test_decoder_decode_batch():
                               noise_model=noise)
     batch = np.array([[1.0, 0.0], [0.0, 1.0], [1.0, 1.0]])
     res = decoder.decode_batch(batch)
-    print([r.result for r in res])
-    assert isinstance(res, list)
-    assert all(hasattr(r, "converged") and hasattr(r, "result") for r in res)
-    assert all(
-        isinstance(r.result, list) and 0.0 <= np.round(r.result[0]) <= 1.0
-        for r in res)
+    print(res.result)
+    assert isinstance(res, qec.BatchDecoderResult)
+    assert isinstance(res.result, np.ndarray)
+    assert res.result.shape == (3, 1)
+    assert res.converged.shape == (3,)
+    assert np.all(res.converged)
+    assert np.all((0.0 <= np.round(res.result[:, 0])) &
+                  (np.round(res.result[:, 0]) <= 1.0))
 
 
 def test_decoder_set_contractor_invalid():
@@ -291,20 +293,19 @@ def test_decoder_batch_vs_single_and_expected_results_with_contractors():
         # Decode the batch
         try:
             res_batch = decoder.decode_batch(batch)
-            assert isinstance(res_batch, list)
-            assert all(isinstance(r, qec.DecoderResult) for r in res_batch)
-            assert all(r.converged for r in res_batch)
+            assert isinstance(res_batch, qec.BatchDecoderResult)
+            assert np.all(res_batch.converged)
         except Exception as e:
             logging.error(f"Test failed due to: {e}")
             pytest.fail(f"Operation failed: {e}")
 
         if dtype == "float32":
-            batch_results = [np.float32(r.result[0]) for r in res_batch]
+            batch_results = res_batch.result[:, 0].astype(np.float32)
             expected_cast = np.array(expected, dtype=np.float32)
             rtol = 1e-5
             atol = 1e-5
         else:
-            batch_results = [np.float64(r.result[0]) for r in res_batch]
+            batch_results = res_batch.result[:, 0].astype(np.float64)
             expected_cast = np.array(expected, dtype=np.float64)
             rtol = 1e-5
             atol = 1e-5

--- a/libs/qec/python/tests/test_trt_decoder.py
+++ b/libs/qec/python/tests/test_trt_decoder.py
@@ -544,7 +544,7 @@ class TestTRTDecoderInference(TestTRTDecoderSetup):
         assert hasattr(result, 'converged')
         assert hasattr(result, 'result')
         assert isinstance(result.converged, bool)
-        assert isinstance(result.result, list)
+        assert isinstance(result.result, np.ndarray)
         assert len(result.result) > 0
 
     def test_decoder_batch_processing(self):
@@ -557,15 +557,17 @@ class TestTRTDecoderInference(TestTRTDecoderSetup):
         results = self.decoder.decode_batch(syndromes)
 
         assert len(results) == len(syndromes)
+        assert isinstance(results, qec.BatchDecoderResult)
+        assert results.result.shape[0] == len(syndromes)
+        assert results.converged.shape == (len(syndromes),)
 
         # Check each result
         TOLERANCE = 1e-4
-        for i, (result, expected) in enumerate(zip(results, expected_outputs)):
-            assert hasattr(result, 'converged')
-            assert hasattr(result, 'result')
-            assert len(result.result) > 0
+        for i, expected in enumerate(expected_outputs):
+            assert results.converged[i]
+            assert results.result.shape[1] > 0
 
-            error = abs(result.result[0] - expected)
+            error = abs(results.result[i, 0] - expected)
             assert error < TOLERANCE, f"Batch test case {i} failed with error {error}"
 
 
@@ -939,10 +941,9 @@ class TestTRTDecoderBatchValidation:
 
         assert len(results) == len(
             syndromes), f"Expected {len(syndromes)} results, got {len(results)}"
-        for i, result in enumerate(results):
-            assert result.converged, f"Result {i} did not converge"
-            assert len(result.result) == syndrome_size, \
-                f"Result {i} has wrong output size: {len(result.result)}"
+        assert results.result.shape == (len(syndromes), syndrome_size)
+        for i, converged in enumerate(results.converged):
+            assert converged, f"Result {i} did not converge"
 
     def test_decode_batch_syndrome_size_mismatch(self, decoder_with_batch_size):
         """Test that decode_batch validates individual syndrome sizes."""
@@ -1000,10 +1001,9 @@ class TestTRTDecoderBatchValidation:
             ) == count, f"Expected {count} results, got {len(results)}"
 
             # Verify all results are valid
-            for i, result in enumerate(results):
-                assert result.converged, f"Result {i} did not converge"
-                assert len(result.result) == syndrome_size, \
-                    f"Result {i} has wrong output size: {len(result.result)}"
+            assert results.result.shape == (count, syndrome_size)
+            for i, converged in enumerate(results.converged):
+                assert converged, f"Result {i} did not converge"
 
     def test_decode_zero_padding_for_batch_gt_1(self, decoder_with_batch_size):
         """Test that decode() zero-pads correctly for batch_size > 1 models."""
@@ -1024,16 +1024,16 @@ class TestTRTDecoderBatchValidation:
         result_batch = decoder.decode_batch(manual_batch)
 
         # Results should be identical
-        assert result_decode.converged == result_batch[0].converged, \
+        assert result_decode.converged == result_batch.converged[0], \
             "Convergence status should match"
 
-        assert len(result_decode.result) == len(result_batch[0].result), \
+        assert len(result_decode.result) == len(result_batch.result[0]), \
             "Output sizes should match"
 
         # Compare results (should be very close)
         np.testing.assert_allclose(
             result_decode.result,
-            result_batch[0].result,
+            result_batch.result[0],
             rtol=1e-5,
             atol=1e-7,
             err_msg=


### PR DESCRIPTION
## Description

Updates Python decoder result access so decoded correction data is exposed as NumPy arrays instead of Python lists.

This is a breaking Python API change: `DecoderResult.result` now returns a 1-D NumPy array. This affects:

- `decoder.decode(...).result`
- `decoder.decode_async(...).get().result`
- tuple unpacking of `DecoderResult`
- `decoder.decode_batch(...)[i].result`
- iteration over `BatchDecoderResult`

Existing code that reads, indexes, iterates, or numerically consumes `result` should generally continue to work. Code that requires `result` to be an actual Python `list`, mutates it with list APIs, compares it with list equality, or serializes it directly should migrate to NumPy semantics or call `.tolist()`.

Also updates `decode_batch(...)` to return `BatchDecoderResult` instead of `list[DecoderResult]`.

`BatchDecoderResult` exposes vectorized batch fields:

- `result`: 2D NumPy array
- `converged`: 1D NumPy bool array
- `opt_results`: list-like per-shot optional results

Compatibility for existing batch consumers is preserved through indexing, slicing, `len(...)`, and iteration:

- `batch[i]` materializes a per-shot `DecoderResult`
- `batch[a:b]` returns another `BatchDecoderResult`
- `for r in batch` continues to yield per-shot `DecoderResult` objects

This avoids forcing user code onto the old per-shot Python list extraction path when the natural batch output is already array-shaped.

Python decoder plugin authors with custom `decode_batch(...)` overrides must now return `BatchDecoderResult`, not `list[DecoderResult]`.

User-facing Sphinx documentation will be updated in a separate docs PR, per project guidance that feature docs should not land before release.

## Runtime / performance impact

This change is intended to reduce Python-side result extraction overhead for batch decoding by allowing users to read batch results directly as NumPy arrays instead of iterating through a list of `DecoderResult` objects.

Minibench run on commit `246114b0a33e9a58ff3a96e9abb77ac72e945fd1` using the C++ `single_error_lut` decoder.

The benchmark uses a CUDA-Q/Stim Steane memory syndrome workload, then splits the fixed shot set into chunks of `batch_size`. Each timed repeat loops over all chunks and measures wall-clock time from calling `decode_batch(...)` through reading the decoded result.

Two current-branch access patterns are compared:

- `numpy_view`: `decoded = decoder.decode_batch(chunk)`, then read `decoded.result` and `decoded.converged`
- `compat_iteration`: `decoded = decoder.decode_batch(chunk)`, then iterate `for r in decoded` and read `r.result` and `r.converged` (this is the backward compatible list access pattern)

Each row reports the median of 5 measured repeats. Speedup is `compat_iteration median / numpy_view median`.

| shots | batch size | decode_batch calls | result width | NumPy view median ms | compat iteration median ms | speedup |
| ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| 1000 | 1 | 1000 | 697 | 3.892 | 7.234 | 1.86x |
| 1000 | 32 | 32 | 697 | 1.990 | 4.111 | 2.07x |
| 1000 | 256 | 4 | 697 | 2.399 | 3.936 | 1.64x |
| 3000 | 1 | 3000 | 697 | 11.748 | 21.462 | 1.83x |
| 3000 | 32 | 94 | 697 | 6.040 | 12.162 | 2.01x |
| 3000 | 256 | 12 | 697 | 5.923 | 11.818 | 1.99x |

In this minibench, direct NumPy batch access is about `1.6x-2.1x` faster than compatibility iteration for the measured `single_error_lut` cases.