### PR TITLE
Nightly ci tests

### DIFF
--- a/.github/workflows/build_wheels.yaml
+++ b/.github/workflows/build_wheels.yaml
@@ -1,8 +1,5 @@
 name: Build wheels
 
-env:
-  DEFAULT_CUDAQX_VERSION: &default_cudaqx_version '0.14.99'
-
 on:
   workflow_dispatch:
     inputs:
@@ -17,7 +14,6 @@ on:
       version:
         type: string
         description: Version number to create wheels with (e.g. 0.2.0). Defaults to 0.14.99 if unspecified
-        default: *default_cudaqx_version
         required: false
       cudaq_wheels:
         type: choice
@@ -48,7 +44,6 @@ on:
         required: false
       version:
         type: string
-        default: *default_cudaqx_version
         required: false
       cudaq_wheels:
         type: string
@@ -197,7 +192,7 @@ jobs:
               --build-type ${{ inputs.build_type }} \
               --python-version ${{ matrix.python }} \
               --tensorrt-path /trt_download/TensorRT-${{ steps.config.outputs.tensorrt_version }} \
-              --version ${{ inputs.version || env.DEFAULT_CUDAQX_VERSION }}
+              --version ${{ inputs.version || '0.14.99' }}
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
@@ -229,7 +224,7 @@ jobs:
       - name: Build CUDA-QX Meta Packages
         shell: bash
         run: |
-          bash scripts/ci/build_metapackages.sh ${{ inputs.version || env.DEFAULT_CUDAQX_VERSION }}
+          bash scripts/ci/build_metapackages.sh ${{ inputs.version || '0.14.99' }}
           find libs -name dist | xargs ls -la
           mkdir -p /metapackages
           mv libs/{qec,solvers}/python/metapackages/dist/* /metapackages/
@@ -386,8 +381,8 @@ jobs:
              ${{ matrix.python }} \
              ${{ matrix.platform }} \
              ${{ matrix.cuda_version }} \
-             ${{ inputs.cudaq_wheels == 'Custom' && env.DEFAULT_CUDAQX_VERSION || 'SKIP' }} \
-             ${{ inputs.version || env.DEFAULT_CUDAQX_VERSION }}
+             ${{ inputs.cudaq_wheels == 'Custom' && '0.14.99' || 'SKIP' }} \
+             ${{ inputs.version || '0.14.99' }}
   
   test-wheels-gpu:
     name: Test CUDA-QX wheels (GPU)
@@ -503,8 +498,8 @@ jobs:
              ${{ matrix.python }} \
              ${{ matrix.runner.arch }} \
              ${{ matrix.cuda_version }} \
-             ${{ inputs.cudaq_wheels == 'Custom' && env.DEFAULT_CUDAQX_VERSION || 'SKIP' }} \
-             ${{ inputs.version || env.DEFAULT_CUDAQX_VERSION }}
+             ${{ inputs.cudaq_wheels == 'Custom' && '0.14.99' || 'SKIP' }} \
+             ${{ inputs.version || '0.14.99' }}
 
       # - name: Upload any core files
       #   if: success() || failure()

--- a/.github/workflows/build_wheels.yaml
+++ b/.github/workflows/build_wheels.yaml
@@ -1,5 +1,8 @@
 name: Build wheels
 
+env:
+  DEFAULT_CUDAQX_VERSION: &default_cudaqx_version '0.14.99'
+
 on:
   workflow_dispatch:
     inputs:
@@ -14,6 +17,7 @@ on:
       version:
         type: string
         description: Version number to create wheels with (e.g. 0.2.0). Defaults to 0.14.99 if unspecified
+        default: *default_cudaqx_version
         required: false
       cudaq_wheels:
         type: choice
@@ -35,6 +39,32 @@ on:
       artifacts_from_run:
         type: string
         description: Optional argument to take artifacts from a prior run of this workflow; facilitates rerunning a failed workflow without re-building the artifacts.
+        required: false
+  workflow_call:
+    inputs:
+      build_type:
+        type: string
+        default: 'Release'
+        required: false
+      version:
+        type: string
+        default: *default_cudaqx_version
+        required: false
+      cudaq_wheels:
+        type: string
+        default: 'Custom'
+        required: false
+      assets_repo:
+        type: string
+        default: ''
+        required: false
+      assets_tag:
+        type: string
+        default: ''
+        required: false
+      artifacts_from_run:
+        type: string
+        default: ''
         required: false
 
 concurrency:
@@ -129,7 +159,7 @@ jobs:
           bash .github/workflows/scripts/install_git_cli.sh
           if [[ -n "${{ inputs.assets_repo }}" ]] && [[ -n "${{ inputs.assets_tag }}" ]]; then
             # Fetch the assets into this directory
-            gh release download -R ${{ inputs.assets_repo }} ${{ inputs.assets_tag }}
+            gh release download -R "${{ inputs.assets_repo }}" "${{ inputs.assets_tag }}"
             ls
           fi
 
@@ -167,7 +197,7 @@ jobs:
               --build-type ${{ inputs.build_type }} \
               --python-version ${{ matrix.python }} \
               --tensorrt-path /trt_download/TensorRT-${{ steps.config.outputs.tensorrt_version }} \
-              --version ${{ inputs.version || '0.14.99' }}
+              --version ${{ inputs.version || env.DEFAULT_CUDAQX_VERSION }}
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
@@ -199,7 +229,7 @@ jobs:
       - name: Build CUDA-QX Meta Packages
         shell: bash
         run: |
-          bash scripts/ci/build_metapackages.sh ${{ inputs.version || '0.14.99' }}
+          bash scripts/ci/build_metapackages.sh ${{ inputs.version || env.DEFAULT_CUDAQX_VERSION }}
           find libs -name dist | xargs ls -la
           mkdir -p /metapackages
           mv libs/{qec,solvers}/python/metapackages/dist/* /metapackages/
@@ -340,6 +370,7 @@ jobs:
           github-token: ${{ inputs.artifacts_from_run && secrets.WORKFLOW_TOKEN || github.token }}
   
       - name: Test wheels
+        shell: bash
         run: |
           # If using Custom CUDA-Q wheels, then /cudaq-wheels will exist.
           # Otherwise, the directory will not exist, and that is ok.
@@ -355,8 +386,8 @@ jobs:
              ${{ matrix.python }} \
              ${{ matrix.platform }} \
              ${{ matrix.cuda_version }} \
-             ${{ inputs.cudaq_wheels == 'Custom' && '0.14.99' || 'SKIP' }} \
-             ${{ inputs.version || '0.14.99' }}
+             ${{ inputs.cudaq_wheels == 'Custom' && env.DEFAULT_CUDAQX_VERSION || 'SKIP' }} \
+             ${{ inputs.version || env.DEFAULT_CUDAQX_VERSION }}
   
   test-wheels-gpu:
     name: Test CUDA-QX wheels (GPU)
@@ -456,6 +487,7 @@ jobs:
           github-token: ${{ inputs.artifacts_from_run && secrets.WORKFLOW_TOKEN || github.token }}
   
       - name: Test wheels
+        shell: bash
         run: |
           # If using Custom CUDA-Q wheels, then /cudaq-wheels will exist.
           # Otherwise, the directory will not exist, and that is ok.
@@ -471,8 +503,8 @@ jobs:
              ${{ matrix.python }} \
              ${{ matrix.runner.arch }} \
              ${{ matrix.cuda_version }} \
-             ${{ inputs.cudaq_wheels == 'Custom' && '0.14.99' || 'SKIP' }} \
-             ${{ inputs.version || '0.14.99' }}
+             ${{ inputs.cudaq_wheels == 'Custom' && env.DEFAULT_CUDAQX_VERSION || 'SKIP' }} \
+             ${{ inputs.version || env.DEFAULT_CUDAQX_VERSION }}
 
       # - name: Upload any core files
       #   if: success() || failure()

--- a/.github/workflows/nightly_tests.yaml
+++ b/.github/workflows/nightly_tests.yaml
@@ -2,10 +2,8 @@ name: Nightly tests
 
 on:
   schedule:
-    # Nightly run. GitHub Actions schedules use UTC.
-    - cron: '30 8 * * *'
+    - cron: '30 8 * * *' # Runs at 8:30am UTC
   workflow_dispatch:
-  pull_request:
 
 jobs:
   source:

--- a/.github/workflows/nightly_tests.yaml
+++ b/.github/workflows/nightly_tests.yaml
@@ -5,6 +5,7 @@ on:
     # Nightly run. GitHub Actions schedules use UTC.
     - cron: '30 8 * * *'
   workflow_dispatch:
+  pull_request:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/nightly_tests.yaml
+++ b/.github/workflows/nightly_tests.yaml
@@ -1,0 +1,20 @@
+name: Nightly tests
+
+on:
+  schedule:
+    # Nightly run. GitHub Actions schedules use UTC.
+    - cron: '30 8 * * *'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  source:
+    name: Build from source
+    uses: ./.github/workflows/build_wheels.yaml
+    with:
+      build_type: Release
+      cudaq_wheels: Custom
+    secrets: inherit

--- a/.github/workflows/nightly_tests.yaml
+++ b/.github/workflows/nightly_tests.yaml
@@ -7,10 +7,6 @@ on:
   workflow_dispatch:
   pull_request:
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
-
 jobs:
   source:
     name: Build from source


### PR DESCRIPTION
<!--
Thanks for contributing to CUDA-Q Libraries!

Please read the full Pull Request Guidelines in Contributing.md:
https://github.com/NVIDIA/cudaqx/blob/main/Contributing.md#pull-request-guidelines
-->

## Description

<!-- What does this PR change, and why? Link related issues. -->

Adds a new scheduled workflow, which will run nightly at 8:30 am UTC (1:30am PT). 

Currently this workflow only runs the wheel build, even though we plan to add more tests. This first PR is intended to establish the workflow in the repository, since certain workflow triggers and access to self-hosted runners are only available to workflows that exist on the default branch. Once this PR is merged, it will be much easier to expand the nightly workflow in subsequent PRs.

Changes:
- Add scheduled nightly build
- Make wheel build callable from other workflows

Test wheel build: https://github.com/NVIDIA/cudaqx/actions/runs/26259206617

## Runtime / performance impact

<!--
If this change affects performance, paste benchmark numbers here.
Otherwise write "N/A".
-->

## Self-review checklist

Please confirm each item before requesting review. Check `[x]` or strike
through and explain.

### Before requesting review
- [x] I reviewed my own full diff in GitHub or my editor.
- [x] PR is in Draft if it is not yet ready for review.
- [x] Temporary / debugging changes have been removed.
- [x] Local test logs reviewed; no unexplained warnings or errors.
- [x] CI logs reviewed; no unexplained warnings or errors.
- [x] Full CI has been run.

### Scope and size
- [x] PR is under ~1000 lines, or an exception is justified in the description.
- [x] Refactoring-only changes are isolated in their own PR(s).
- [x] No existing tests were disabled or modified just to make this PR pass
      (if so, an issue has been raised).

### Tests
- [x] New functionality has new tests.
- [x] Tests fail if the new functionality is broken (including crashes), not
      just when it is missing.
- [x] Negative tests added where exceptions are expected.
- [x] Truth data added where simple `EXPECT_*` / `assert` checks are
      insufficient for algorithmic correctness.
- [x] CI runtime impact considered; team notified if significant.

### Documentation
- [x] Public-facing APIs have Doxygen docs.
- [x] User-visible behavior changes have public docs, or a follow-up is
      tracked.
- [x] User-facing docs for new features are in a **separate PR** held until
      release (the docs site publishes immediately on merge to the default
      branch, so feature docs must not land before the feature ships).

### Code style
- [x] Naming follows the existing convention (`snake_case` vs `camelCase`) for
      the area being modified.

### Dependencies
- [x] No new third-party dependencies, **or** the team has been notified and
      OSRB tickets filed.
