### PR TITLE
Remove pinned cudaq_realtime_version

### DIFF
--- a/.cudaq_realtime_version
+++ b/.cudaq_realtime_version
@@ -1,6 +1,0 @@
-{
-  "cudaq_realtime": {
-    "repository": "NVIDIA/cuda-quantum",
-    "ref": "053480dda0413c219c224d42313aa14d7a17a7fe"
-  }
-}

--- a/.github/actions/build-lib/build_qec.sh
+++ b/.github/actions/build-lib/build_qec.sh
@@ -6,17 +6,17 @@ set -e
 # Build cuda-quantum realtime library + hololink tools (if CUDAQ_REALTIME_ROOT not set)
 if [ -z "$CUDAQ_REALTIME_ROOT" ]; then
   CUDAQ_REALTIME_ROOT=/tmp/cudaq-realtime
-  CUDAQ_REALTIME_REPO=https://github.com/NVIDIA/cuda-quantum.git
-  CUDAQ_REALTIME_REF=$(jq -r '.cudaq_realtime.ref' .cudaq_realtime_version)
+  CUDAQ_REPO=$(jq -r '.cudaq.repository' .cudaq_version)
+  CUDAQ_REF=$(jq -r '.cudaq.ref' .cudaq_version)
   _build_cwd=$(pwd)
 
   cd /tmp
   rm -rf cudaq-realtime-src $CUDAQ_REALTIME_ROOT
-  git clone --filter=blob:none --no-checkout $CUDAQ_REALTIME_REPO cudaq-realtime-src
+  git clone --filter=blob:none --no-checkout https://github.com/${CUDAQ_REPO}.git cudaq-realtime-src
   cd cudaq-realtime-src
   git sparse-checkout init --cone
   git sparse-checkout set realtime
-  git checkout $CUDAQ_REALTIME_REF
+  git checkout $CUDAQ_REF
 
   # Install build tools and DOCA/Holoscan SDK for HSB.
   # The cudaqx CI container has Mellanox OFED pre-installed, so we cannot use

--- a/.github/actions/get-cudaq-version/action.yaml
+++ b/.github/actions/get-cudaq-version/action.yaml
@@ -1,4 +1,5 @@
 name: Get CUDAQ version
+description: Read the pinned CUDA-Q repository and ref from .cudaq_version
 
 outputs:
   repo:
@@ -30,8 +31,8 @@ runs:
       run: |
         repo=$(jq -r '.cudaq.repository' .cudaq_version)
         ref=$(jq -r '.cudaq.ref' .cudaq_version)
+        echo "Using CUDA-Q version: ${repo}@${ref}"
         echo "repo=$repo" >> $GITHUB_OUTPUT
         echo "ref=$ref" >> $GITHUB_OUTPUT
       shell: bash
-
 

--- a/.github/workflows/all_libs_release.yaml
+++ b/.github/workflows/all_libs_release.yaml
@@ -99,18 +99,22 @@ jobs:
       # Build cuda-quantum realtime (base library, no Hololink tools)
       # ========================================================================
 
+      - name: Get required CUDAQ version
+        id: get-cudaq-version
+        uses: ./.github/actions/get-cudaq-version
+
       - name: Build cuda-quantum realtime
         run: |
-          CUDAQ_REALTIME_REPO=https://github.com/NVIDIA/cuda-quantum.git
-          CUDAQ_REALTIME_REF=$(jq -r '.cudaq_realtime.ref' .cudaq_realtime_version)
+          CUDAQ_REPO="${{ steps.get-cudaq-version.outputs.repo }}"
+          CUDAQ_REF="${{ steps.get-cudaq-version.outputs.ref }}"
           CUDAQ_REALTIME_ROOT=/tmp/cudaq-realtime
           cd /tmp
           rm -rf cudaq-realtime-src $CUDAQ_REALTIME_ROOT
-          git clone --filter=blob:none --no-checkout $CUDAQ_REALTIME_REPO cudaq-realtime-src
+          git clone --filter=blob:none --no-checkout "https://github.com/${CUDAQ_REPO}.git" cudaq-realtime-src
           cd cudaq-realtime-src
           git sparse-checkout init --cone
           git sparse-checkout set realtime
-          git checkout $CUDAQ_REALTIME_REF
+          git checkout "$CUDAQ_REF"
           cd realtime && mkdir -p build && cd build
           cmake -G Ninja -DCMAKE_INSTALL_PREFIX=$CUDAQ_REALTIME_ROOT ..
           ninja && ninja install
@@ -193,4 +197,3 @@ jobs:
         run: |
           ln -s /usr/local/cudaq /cudaq-install
           bash scripts/ci/test_examples.sh all 
-


### PR DESCRIPTION
<!--
Thanks for contributing to CUDA-Q Libraries!

Please read the full Pull Request Guidelines in Contributing.md:
https://github.com/NVIDIA/cudaqx/blob/main/Contributing.md#pull-request-guidelines
-->

## Description

- Remove `.cudaq_realtime_version` in favor of `.cudaq_version`
- Add logging to indicate the chosen CUDA-Q version in the `get-cudaq-version` action

Test run of `All libs (Release)` workflow: https://github.com/NVIDIA/cudaqx/actions/runs/26310275121

<!-- What does this PR change, and why? Link related issues. -->

## Runtime / performance impact

<!--
If this change affects performance, paste benchmark numbers here.
Otherwise write "N/A".
-->

## Self-review checklist

Please confirm each item before requesting review. Check `[x]` or strike
through and explain.

### Before requesting review
- [x] I reviewed my own full diff in GitHub or my editor.
- [x] PR is in Draft if it is not yet ready for review.
- [x] Temporary / debugging changes have been removed.
- [x] Local test logs reviewed; no unexplained warnings or errors.
- [x] CI logs reviewed; no unexplained warnings or errors.
- [x] Full CI has been run.

### Scope and size
- [x] PR is under ~1000 lines, or an exception is justified in the description.
- [x] Refactoring-only changes are isolated in their own PR(s).
- [x] No existing tests were disabled or modified just to make this PR pass
      (if so, an issue has been raised).

### Tests
- [x] New functionality has new tests.
- [x] Tests fail if the new functionality is broken (including crashes), not
      just when it is missing.
- [x] Negative tests added where exceptions are expected.
- [x] Truth data added where simple `EXPECT_*` / `assert` checks are
      insufficient for algorithmic correctness.
- [x] CI runtime impact considered; team notified if significant.

### Documentation
- [x] Public-facing APIs have Doxygen docs.
- [x] User-visible behavior changes have public docs, or a follow-up is
      tracked.
- [x] User-facing docs for new features are in a **separate PR** held until
      release (the docs site publishes immediately on merge to the default
      branch, so feature docs must not land before the feature ships).

### Code style
- [x] Naming follows the existing convention (`snake_case` vs `camelCase`) for
      the area being modified.

### Dependencies
- [x] No new third-party dependencies, **or** the team has been notified and
      OSRB tickets filed.
