### PR TITLE
Fix broken 'All Libs (Release)' build

### DIFF
--- a/.github/actions/build-lib/action.yaml
+++ b/.github/actions/build-lib/action.yaml
@@ -1,4 +1,5 @@
 name: Build a CUDAQX library
+description: Configure, build, and optionally cache a CUDA-QX library
 
 inputs:
   lib:
@@ -22,6 +23,10 @@ inputs:
   install-prefix:
     description: 'Install prefix'
     default: '~/.cudaqx'
+    required: false
+  cudaq-prefix:
+    description: 'CUDA-Q install prefix'
+    default: '/cudaq-install'
     required: false
 outputs:
   build-dir:
@@ -67,7 +72,7 @@ runs:
         CCACHE_DIR: /ccache-${{ inputs.lib }}
       run: |
         build_dir=build_${{ inputs.lib }}
-        .github/actions/build-lib/build_${{ inputs.lib }}.sh $build_dir ${{ inputs.install-prefix }}
+        .github/actions/build-lib/build_${{ inputs.lib }}.sh "$build_dir" "${{ inputs.install-prefix }}" "${{ inputs.cudaq-prefix }}"
         echo "build_dir=$build_dir" >> $GITHUB_OUTPUT
       shell: bash
 
@@ -90,4 +95,3 @@ runs:
       with:
         path: /ccache-${{ inputs.lib }}
         key: ${{ steps.ccache-key.outputs.main }}${{ steps.ccache-key.outputs.pr }}
-

--- a/.github/actions/build-lib/action.yaml
+++ b/.github/actions/build-lib/action.yaml
@@ -22,7 +22,7 @@ inputs:
     required: true
   install-prefix:
     description: 'Install prefix'
-    default: '~/.cudaqx'
+    default: '$HOME/.cudaqx'
     required: false
   cudaq-prefix:
     description: 'CUDA-Q install prefix'

--- a/.github/actions/build-lib/build_all.sh
+++ b/.github/actions/build-lib/build_all.sh
@@ -2,22 +2,26 @@
 
 . "$(dirname "$0")/setup_custabilizer.sh"
 
+build_dir=$1
+install_prefix=$2
+cudaq_prefix=$3
+
 _rt_flag=""
 if [ -n "$CUDAQ_REALTIME_ROOT" ]; then
   _rt_flag="-DCUDAQ_REALTIME_ROOT=$CUDAQ_REALTIME_ROOT"
 fi
 
-cmake -S . -B "$1" \
+cmake -S . -B "$build_dir" \
   -DCMAKE_BUILD_TYPE=Release \
   -DCMAKE_C_COMPILER=gcc-12 \
   -DCMAKE_CXX_COMPILER=g++-12 \
   -DCMAKE_C_COMPILER_LAUNCHER=ccache \
   -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
-  -DCUDAQ_DIR=/cudaq-install/lib/cmake/cudaq/ \
+  -DCUDAQ_DIR="$cudaq_prefix/lib/cmake/cudaq/" \
   -DCUDAQX_ENABLE_LIBS="all" \
   -DCUDAQX_INCLUDE_TESTS=ON \
   -DCUDAQX_BINDINGS_PYTHON=ON \
-  -DCMAKE_INSTALL_PREFIX="$2" \
+  -DCMAKE_INSTALL_PREFIX="$install_prefix" \
   $_rt_flag
 
-cmake --build "$1" --target install -j 4
+cmake --build "$build_dir" --target install -j 4

--- a/.github/actions/build-lib/build_qec.sh
+++ b/.github/actions/build-lib/build_qec.sh
@@ -3,6 +3,10 @@ set -e
 
 . "$(dirname "$0")/setup_custabilizer.sh"
 
+build_dir=$1
+install_prefix=$2
+cudaq_prefix=$3
+
 # Build cuda-quantum realtime library + hololink tools (if CUDAQ_REALTIME_ROOT not set)
 if [ -z "$CUDAQ_REALTIME_ROOT" ]; then
   CUDAQ_REALTIME_ROOT=/tmp/cudaq-realtime
@@ -113,19 +117,19 @@ fi
 HSB_ROOT=/tmp/holoscan-sensor-bridge
 HSB_BUILD=${HSB_ROOT}/build
 
-cmake -S libs/qec -B "$1" \
+cmake -S libs/qec -B "$build_dir" \
   -DCMAKE_BUILD_TYPE=Release \
   -DCMAKE_C_COMPILER=gcc-12 \
   -DCMAKE_CXX_COMPILER=g++-12 \
   -DCMAKE_C_COMPILER_LAUNCHER=ccache \
   -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
-  -DCUDAQ_DIR=/cudaq-install/lib/cmake/cudaq/ \
+  -DCUDAQ_DIR="$cudaq_prefix/lib/cmake/cudaq/" \
   -DCUDAQX_INCLUDE_TESTS=ON \
   -DCUDAQX_BINDINGS_PYTHON=ON \
-  -DCMAKE_INSTALL_PREFIX="$2" \
+  -DCMAKE_INSTALL_PREFIX="$install_prefix" \
   -DCUDAQ_REALTIME_ROOT=$CUDAQ_REALTIME_ROOT \
   -DCUDAQX_QEC_ENABLE_HOLOLINK_TOOLS=ON \
   -DHOLOSCAN_SENSOR_BRIDGE_SOURCE_DIR=$HSB_ROOT \
   -DHOLOSCAN_SENSOR_BRIDGE_BUILD_DIR=$HSB_BUILD
 
-cmake --build "$1" --target install -j 4
+cmake --build "$build_dir" --target install -j 4

--- a/.github/actions/build-lib/build_solvers.sh
+++ b/.github/actions/build-lib/build_solvers.sh
@@ -1,14 +1,18 @@
 #!/bin/sh
 
-cmake -S libs/solvers -B "$1" \
+build_dir=$1
+install_prefix=$2
+cudaq_prefix=$3
+
+cmake -S libs/solvers -B "$build_dir" \
   -DCMAKE_BUILD_TYPE=Release \
   -DCMAKE_C_COMPILER=gcc-12 \
   -DCMAKE_CXX_COMPILER=g++-12 \
   -DCMAKE_C_COMPILER_LAUNCHER=ccache \
   -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
-  -DCUDAQ_DIR=/cudaq-install/lib/cmake/cudaq/ \
+  -DCUDAQ_DIR="$cudaq_prefix/lib/cmake/cudaq/" \
   -DCUDAQX_INCLUDE_TESTS=ON \
   -DCUDAQX_BINDINGS_PYTHON=ON \
-  -DCMAKE_INSTALL_PREFIX="$2"
+  -DCMAKE_INSTALL_PREFIX="$install_prefix"
 
-cmake --build "$1" --target install -j 4
+cmake --build "$build_dir" --target install -j 4

--- a/.github/workflows/all_libs_release.yaml
+++ b/.github/workflows/all_libs_release.yaml
@@ -121,17 +121,21 @@ jobs:
       # Build
       # ========================================================================
 
-      - name: Debug CUDA-Q install
+      - name: Debug CUDA-Q paths
         shell: bash
         run: |
           set -euxo pipefail
           uname -m
+          env | sort | grep -E 'CUDAQ|CMAKE|PATH' || true
           if [[ -d /cudaq-install/lib/cmake/cudaq ]]; then
             ls -la /cudaq-install/lib/cmake/cudaq
           else
             echo "/cudaq-install/lib/cmake/cudaq is missing"
           fi
           find /cudaq-install \( -iname '*nlopt*' -o -iname '*Nlopt*' \) -print || true
+          find /usr/local -path '*/lib/cmake/cudaq' -type d -print
+          find /usr/local \( -name 'CUDAQConfig.cmake' -o -name 'CUDAQNloptConfig.cmake' \) -print || true
+          find / -name 'CUDAQNloptConfig.cmake' 2>/dev/null || true
 
       - name: Build
         id: build

--- a/.github/workflows/all_libs_release.yaml
+++ b/.github/workflows/all_libs_release.yaml
@@ -121,22 +121,6 @@ jobs:
       # Build
       # ========================================================================
 
-      - name: Debug CUDA-Q paths
-        shell: bash
-        run: |
-          set -euxo pipefail
-          uname -m
-          env | sort | grep -E 'CUDAQ|CMAKE|PATH' || true
-          if [[ -d /cudaq-install/lib/cmake/cudaq ]]; then
-            ls -la /cudaq-install/lib/cmake/cudaq
-          else
-            echo "/cudaq-install/lib/cmake/cudaq is missing"
-          fi
-          find /cudaq-install \( -iname '*nlopt*' -o -iname '*Nlopt*' \) -print || true
-          find /usr/local -path '*/lib/cmake/cudaq' -type d -print
-          find /usr/local \( -name 'CUDAQConfig.cmake' -o -name 'CUDAQNloptConfig.cmake' \) -print || true
-          find / -name 'CUDAQNloptConfig.cmake' 2>/dev/null || true
-
       - name: Build
         id: build
         uses: ./.github/actions/build-lib
@@ -145,6 +129,7 @@ jobs:
           cuda_version: ${{ matrix.cuda_version }}
           platform: ${{ matrix.runner.arch }}
           install-prefix: /usr/local/cudaq
+          cudaq-prefix: /usr/local/cudaq
 
       - name: Save build artifacts
         run: |

--- a/.github/workflows/all_libs_release.yaml
+++ b/.github/workflows/all_libs_release.yaml
@@ -121,6 +121,18 @@ jobs:
       # Build
       # ========================================================================
 
+      - name: Debug CUDA-Q install
+        shell: bash
+        run: |
+          set -euxo pipefail
+          uname -m
+          if [[ -d /cudaq-install/lib/cmake/cudaq ]]; then
+            ls -la /cudaq-install/lib/cmake/cudaq
+          else
+            echo "/cudaq-install/lib/cmake/cudaq is missing"
+          fi
+          find /cudaq-install \( -iname '*nlopt*' -o -iname '*Nlopt*' \) -print || true
+
       - name: Build
         id: build
         uses: ./.github/actions/build-lib
@@ -193,4 +205,3 @@ jobs:
         run: |
           ln -s /usr/local/cudaq /cudaq-install
           bash scripts/ci/test_examples.sh all 
-


### PR DESCRIPTION
<!--
Thanks for contributing to CUDA-Q Libraries!

Please read the full Pull Request Guidelines in Contributing.md:
https://github.com/NVIDIA/cudaqx/blob/main/Contributing.md#pull-request-guidelines
-->

## Description

Fixes the `All Libs (Release)` workflow, which was failing to find the correct location of CUDA-Q. The `build-lib` action can now accept a custom path for CUDA-Q, rather than always assuming it will be at `/cudaq-install`.

Latest test run: https://github.com/NVIDIA/cudaqx/actions/runs/26300841438

<!-- What does this PR change, and why? Link related issues. -->

## Runtime / performance impact

<!--
If this change affects performance, paste benchmark numbers here.
Otherwise write "N/A".
-->

## Self-review checklist

Please confirm each item before requesting review. Check `[x]` or strike
through and explain.

### Before requesting review
- [x] I reviewed my own full diff in GitHub or my editor.
- [x] PR is in Draft if it is not yet ready for review.
- [x] Temporary / debugging changes have been removed.
- [x] Local test logs reviewed; no unexplained warnings or errors.
- [x] CI logs reviewed; no unexplained warnings or errors.
- [x] Full CI has been run.

### Scope and size
- [x] PR is under ~1000 lines, or an exception is justified in the description.
- [x] Refactoring-only changes are isolated in their own PR(s).
- [x] No existing tests were disabled or modified just to make this PR pass
      (if so, an issue has been raised).

### Tests
- [x] New functionality has new tests.
- [x] Tests fail if the new functionality is broken (including crashes), not
      just when it is missing.
- [x] Negative tests added where exceptions are expected.
- [x] Truth data added where simple `EXPECT_*` / `assert` checks are
      insufficient for algorithmic correctness.
- [x] CI runtime impact considered; team notified if significant.

### Documentation
- [x] Public-facing APIs have Doxygen docs.
- [x] User-visible behavior changes have public docs, or a follow-up is
      tracked.
- [x] User-facing docs for new features are in a **separate PR** held until
      release (the docs site publishes immediately on merge to the default
      branch, so feature docs must not land before the feature ships).

### Code style
- [x] Naming follows the existing convention (`snake_case` vs `camelCase`) for
      the area being modified.

### Dependencies
- [x] No new third-party dependencies, **or** the team has been notified and
      OSRB tickets filed.
