### PR TITLE
Bump CUDAQ commit and set library mode in cudaqx_set_target

### DIFF
--- a/.cudaq_version
+++ b/.cudaq_version
@@ -1,6 +1,6 @@
 {
   "cudaq": {
     "repository": "NVIDIA/cuda-quantum",
-    "ref": "67404cea365c0f78a9319f89ef634afca15011c8"
+    "ref": "b04dee5177fcdc0b2370a1f983cf6d4d75f9893b"
   }
 }

--- a/cmake/Modules/CUDA-QX.cmake
+++ b/cmake/Modules/CUDA-QX.cmake
@@ -283,6 +283,9 @@ function(cudaqx_set_target TARGETNAME)
   # Add the additional target-specific library
   target_link_libraries(cudaq_${TARGETNAME} INTERFACE cudaq::cudaq-${TARGETNAME}-target)
 
+  # The target is built with the toolchain's compiler, therefore running in library mode.
+  target_compile_definitions(cudaq_${TARGETNAME} INTERFACE CUDAQ_LIBRARY_MODE)
+
   # Create an alias target to make it easier to use
   add_library(cudaq::cudaq_${TARGETNAME} ALIAS cudaq_${TARGETNAME})
 endfunction()


### PR DESCRIPTION
1. Bumping the CUDAQ commit because it is the one I have been validating my cudaq changes against. I know for it to be good up to that point.
2. Ahead of the runtime refactor, I need to make `CUDAQ_LIBRARY_MODE` explicit in `cudaqx_set_target`. I am hoping that  `cudaqx_set_target` is not a feature.