### PR TITLE
fix: To throw an error if no noise is provided to DEM Python binding functions

### DIFF
--- a/libs/qec/python/bindings/py_code.cpp
+++ b/libs/qec/python/bindings/py_code.cpp
@@ -538,6 +538,10 @@ void bindCode(nb::module_ &mod) {
       "dem_from_memory_circuit",
       [](code &code, operation op, std::size_t numRounds,
          std::optional<cudaq::noise_model> noise = std::nullopt) {
+        if (!noise)
+          throw std::runtime_error(
+              "dem_from_memory_circuit requires a noise model; noise=None is "
+              "not supported.");
         return dem_from_memory_circuit(code, op, numRounds, *noise);
       },
       R"pbdoc(
@@ -546,7 +550,7 @@ void bindCode(nb::module_ &mod) {
         This function generates a detector error model from a memory circuit.
         The memory circuit is specified by the code, the initial state preparation
         operation, and the number of stabilizer measurement rounds. The noise
-        model is optional and defaults to no noise.
+        model is required.
 
         Args:
             code: The code to generate the detector error model for.
@@ -564,6 +568,10 @@ void bindCode(nb::module_ &mod) {
       "x_dem_from_memory_circuit",
       [](code &code, operation op, std::size_t numRounds,
          std::optional<cudaq::noise_model> noise = std::nullopt) {
+        if (!noise)
+          throw std::runtime_error(
+              "x_dem_from_memory_circuit requires a noise model; noise=None "
+              "is not supported.");
         return x_dem_from_memory_circuit(code, op, numRounds, *noise);
       },
       R"pbdoc(
@@ -572,7 +580,7 @@ void bindCode(nb::module_ &mod) {
         This function generates a detector error model from a memory circuit in
         the X basis. The memory circuit is specified by the code, the initial
         state preparation operation, and the number of stabilizer measurement
-        rounds. The noise model is optional and defaults to no noise.
+        rounds. The noise model is required.
 
         Args:
             code: The code to generate the detector error model for.
@@ -590,6 +598,10 @@ void bindCode(nb::module_ &mod) {
       "z_dem_from_memory_circuit",
       [](code &code, operation op, std::size_t numRounds,
          std::optional<cudaq::noise_model> noise = std::nullopt) {
+        if (!noise)
+          throw std::runtime_error(
+              "z_dem_from_memory_circuit requires a noise model; noise=None "
+              "is not supported.");
         return z_dem_from_memory_circuit(code, op, numRounds, *noise);
       },
       R"pbdoc(
@@ -598,7 +610,7 @@ void bindCode(nb::module_ &mod) {
         This function generates a detector error model from a memory circuit in
         the Z basis. The memory circuit is specified by the code, the initial
         state preparation operation, and the number of stabilizer measurement
-        rounds. The noise model is optional and defaults to no noise.
+        rounds. The noise model is required.
 
         Args:
             code: The code to generate the detector error model for.

--- a/libs/qec/python/tests/test_dem.py
+++ b/libs/qec/python/tests/test_dem.py
@@ -66,6 +66,27 @@ def set_target():
     cudaq.reset_target()
 
 
+@pytest.mark.parametrize(
+    "dem_fn",
+    [
+        qec.dem_from_memory_circuit,
+        qec.x_dem_from_memory_circuit,
+        qec.z_dem_from_memory_circuit,
+    ],
+)
+def test_dem_from_memory_circuit_requires_noise_model(dem_fn):
+    # DEM generation needs noise mechanisms, so omitted/None noise must fail
+    # before the binding dereferences an empty optional noise model.
+    code = qec.get_code('steane')
+    statePrep = qec.operation.prep0
+
+    with pytest.raises(RuntimeError, match="requires a noise model"):
+        dem_fn(code, statePrep, 1)
+
+    with pytest.raises(RuntimeError, match="requires a noise model"):
+        dem_fn(code, statePrep, 1, None)
+
+
 def test_dem_from_memory_circuit():
     code = qec.get_code('steane')
     p = 0.01


### PR DESCRIPTION
For the DEM Python binding functions at [L541](https://github.com/NVIDIA/cudaqx/blob/d90d5b914baf2341333b98b24c9754b691aef268/libs/qec/python/bindings/py_code.cpp#L541), [L567](https://github.com/NVIDIA/cudaqx/blob/d90d5b914baf2341333b98b24c9754b691aef268/libs/qec/python/bindings/py_code.cpp#L567) and [L593](https://github.com/NVIDIA/cudaqx/blob/d90d5b914baf2341333b98b24c9754b691aef268/libs/qec/python/bindings/py_code.cpp#L593), the doc says "The noise model is optional and defaults to no noise.", but if the noise is really not provided, it becomes `std::nullopt` in the lambda function, and dereferencing `std::nullopt` is an undefined behaviour.

This PR tries to fix this bug in a way that will throw an error message if no noise model is provided.
Thanks for reviewing it.