### PR TITLE
Update test_qec_stim to use nvq++

### DIFF
--- a/libs/qec/unittests/backend-specific/stim/CMakeLists.txt
+++ b/libs/qec/unittests/backend-specific/stim/CMakeLists.txt
@@ -1,19 +1,31 @@
 # ============================================================================ #
-# Copyright (c) 2024 - 2025 NVIDIA Corporation & Affiliates.                   #
+# Copyright (c) 2024 - 2026 NVIDIA Corporation & Affiliates.                   #
 # All rights reserved.                                                         #
 #                                                                              #
 # This source code and the accompanying materials are made available under     #
-# the terms of the Apache License 2.0 which accompanies this distribution.     #
+# the terms of the Apache License 2.0 which accompanies this distribution.    #
 # ============================================================================ #
 
-cudaqx_set_target(stim) 
+# Compile test_qec_stim.cpp with nvq++ so that the inline __qpu__ kernels
+# go through the MLIR pipeline, the same way memory-circuit kernels in
+# libs/qec/lib/device are built.
+add_executable(test_qec_stim)
+set_target_properties(test_qec_stim PROPERTIES LINKER_LANGUAGE CXX)
 
-add_executable(test_qec_stim test_qec_stim.cpp)
+cudaqx_add_device_code(test_qec_stim
+  SOURCES
+    test_qec_stim.cpp
+)
+
+target_link_directories(test_qec_stim
+  PRIVATE ${CUDAQ_INSTALL_DIR}/lib)
+
 target_link_libraries(test_qec_stim
   PRIVATE
     GTest::gtest_main
-    cudaq::cudaq_stim
     cudaq-qec
-)
+    cudaq::cudaq cudaq::cudaq-common cudaq-mlir-runtime
+    nvqir nvqir-stim)
+
 add_dependencies(CUDAQXQECUnitTests test_qec_stim)
 gtest_discover_tests(test_qec_stim)


### PR DESCRIPTION
Related: #563

## Description

This updates one of our tests to use `nvq++`. All C++ files that have `__qpu__` functions should be using `nvq++`.

## Runtime / performance impact

N/A

## Self-review checklist

Please confirm each item before requesting review. Check `[x]` or strike
through and explain.

### Before requesting review
- [x] I reviewed my own full diff in GitHub or my editor.
- [x] PR is in Draft if it is not yet ready for review.
- [x] Temporary / debugging changes have been removed.
- [x] Local test logs reviewed; no unexplained warnings or errors.
- [x] CI logs reviewed; no unexplained warnings or errors.
- [x] Full CI has been run.

### Scope and size
- [x] PR is under ~1000 lines, or an exception is justified in the description.
- [x] Refactoring-only changes are isolated in their own PR(s).
- [x] No existing tests were disabled or modified just to make this PR pass
      (if so, an issue has been raised).

### Tests
- [x] New functionality has new tests.
- [x] Tests fail if the new functionality is broken (including crashes), not
      just when it is missing.
- [x] Negative tests added where exceptions are expected.
- [x] Truth data added where simple `EXPECT_*` / `assert` checks are
      insufficient for algorithmic correctness.
- [x] CI runtime impact considered; team notified if significant.

### Documentation
- [x] Public-facing APIs have Doxygen docs.
- [x] User-visible behavior changes have public docs, or a follow-up is
      tracked.
- [x] User-facing docs for new features are in a **separate PR** held until
      release (the docs site publishes immediately on merge to the default
      branch, so feature docs must not land before the feature ships).

### Code style
- [x] Naming follows the existing convention (`snake_case` vs `camelCase`) for
      the area being modified.

### Dependencies
- [x] No new third-party dependencies, **or** the team has been notified and
      OSRB tickets filed.
