### PR TITLE
Cleanup for actions and workflows

### DIFF
--- a/.github/workflows/all_libs.yaml
+++ b/.github/workflows/all_libs.yaml
@@ -16,6 +16,7 @@ jobs:
     container: ghcr.io/nvidia/cuda-quantum-devcontainer:${{ matrix.platform }}-cu${{ matrix.cuda_version }}-gcc12-main
     permissions:
       actions: write
+      contents: read
       pull-requests: read
     steps:
       - name: Checkout repository

--- a/.github/workflows/cudaq_cache.yaml
+++ b/.github/workflows/cudaq_cache.yaml
@@ -2,9 +2,6 @@ name: CUDAQ cache
 
 on:
   workflow_dispatch:
-    branches:
-      - main
-
   push:
     branches:
       - main
@@ -56,4 +53,3 @@ jobs:
           save-build: true
           save-ccache: true
           platform: ${{ matrix.platform }}-cu${{ steps.config.outputs.cuda_major }}
-

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -2,11 +2,7 @@ name: Documentation
 
 on:
   workflow_call:
-
   workflow_dispatch:
-    branches:
-      - main
-
   push:
     branches:
       - main

--- a/.github/workflows/lib_qec.yaml
+++ b/.github/workflows/lib_qec.yaml
@@ -16,6 +16,7 @@ jobs:
     container: ghcr.io/nvidia/cuda-quantum-devcontainer:${{ matrix.platform }}-cu${{ matrix.cuda_version }}-gcc12-main
     permissions:
       actions: write
+      contents: read
       pull-requests: read
     steps:
       - name: Checkout repository

--- a/.github/workflows/pr_workflow.yaml
+++ b/.github/workflows/pr_workflow.yaml
@@ -40,7 +40,6 @@ jobs:
           base: ${{ fromJSON(steps.get-pr-info.outputs.pr-info).base.sha }}
           filters: |
             build-cudaq:
-              - '.github/workflows/cudaq_cache.yaml'
               - '.github/actions/get-cudaq-build/**'
               - '.github/actions/get-cudaq-version/**'
               - '.github/workflows/scripts/build_cudaq.sh'

--- a/.github/workflows/pr_workflow.yaml
+++ b/.github/workflows/pr_workflow.yaml
@@ -40,8 +40,9 @@ jobs:
           base: ${{ fromJSON(steps.get-pr-info.outputs.pr-info).base.sha }}
           filters: |
             build-cudaq:
-              - '.github/workflows/cudaq_bump.yml'
+              - '.github/workflows/cudaq_cache.yaml'
               - '.github/actions/get-cudaq-build/**'
+              - '.github/actions/get-cudaq-version/**'
               - '.github/workflows/scripts/build_cudaq.sh'
               - '.cudaq_version'
             build-docs:
@@ -53,13 +54,14 @@ jobs:
             build-all:
               - '.github/actions/build-lib/action.yaml'
               - '.github/actions/build-lib/build_all.sh'
-              - '.github/actions/build-lib/build_all.yaml'
+              - '.github/actions/build-lib/setup_custabilizer.sh'
               - '.github/workflows/all_libs.yaml'
               - 'cmake/Modules/**'
               - '**/CMakeLists.txt'
             build-qec:
               - '.github/actions/build-lib/action.yaml'
               - '.github/actions/build-lib/build_qec.sh'
+              - '.github/actions/build-lib/setup_custabilizer.sh'
               - '.github/workflows/lib_qec.yaml'
               - 'cmake/Modules/**'
               - 'libs/core/**/*.cpp'


### PR DESCRIPTION
<!--
Thanks for contributing to CUDA-Q Libraries!

Please read the full Pull Request Guidelines in Contributing.md:
https://github.com/NVIDIA/cudaqx/blob/main/Contributing.md#pull-request-guidelines
-->

## Description

Light cleanup for actions and workflows.
- Remove incorrect branch filters on `workflow_dispatch` triggers
- Update `pr_workflow` filters
- Add explicit read-level permissions where we checkout code

<!-- What does this PR change, and why? Link related issues. -->

## Runtime / performance impact
N/A
<!--
If this change affects performance, paste benchmark numbers here.
Otherwise write "N/A".
-->

## Self-review checklist

### Before requesting review
- [x] I reviewed my own full diff in GitHub or my editor.
- [x] PR is in Draft if it is not yet ready for review.
- [x] Temporary / debugging changes have been removed.
- [x] Local test logs reviewed; no unexplained warnings or errors.
- [x] CI logs reviewed; no unexplained warnings or errors.
- [x] Full CI has been run.

### Scope and size
- [x] PR is under ~1000 lines, or an exception is justified in the description.
- [x] Refactoring-only changes are isolated in their own PR(s).
   - This is that refactoring-only-changes PR!
- [x] No existing tests were disabled or modified just to make this PR pass
      (if so, an issue has been raised).

### Tests
- [x] New functionality has new tests.
- [x] Tests fail if the new functionality is broken (including crashes), not
      just when it is missing.
- [x] Negative tests added where exceptions are expected.
- [x] Truth data added where simple `EXPECT_*` / `assert` checks are
      insufficient for algorithmic correctness.
- [x] CI runtime impact considered; team notified if significant.

### Documentation
- [x] Public-facing APIs have Doxygen docs.
- [x] User-visible behavior changes have public docs, or a follow-up is
      tracked.
- [x] User-facing docs for new features are in a **separate PR** held until
      release (the docs site publishes immediately on merge to the default
      branch, so feature docs must not land before the feature ships).

### Code style
- [x] Naming follows the existing convention (`snake_case` vs `camelCase`) for
      the area being modified.

### Dependencies
- [x] No new third-party dependencies, **or** the team has been notified and
      OSRB tickets filed.
