### PR TITLE
Add wheel build and test to CI PR checks

### DIFF
--- a/.github/workflows/build_wheels.yaml
+++ b/.github/workflows/build_wheels.yaml
@@ -61,9 +61,14 @@ on:
         type: string
         default: ''
         required: false
+    secrets:
+      CUDAQ_ACCESS_TOKEN:
+        required: false
+      WORKFLOW_TOKEN:
+        required: false
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-build-wheels-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
@@ -78,7 +83,9 @@ jobs:
     container:
       image: ghcr.io/nvidia/cuda-quantum-devdeps:manylinux-${{ matrix.platform }}-cu${{ matrix.cuda_version }}-gcc12-main
       options: --ulimit nofile=1048576:1048576
-    permissions: write-all
+    permissions:
+      actions: write
+      contents: read
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/pr_workflow.yaml
+++ b/.github/workflows/pr_workflow.yaml
@@ -21,6 +21,7 @@ jobs:
       build-solvers: ${{ steps.filter.outputs.build-solvers }}
       build-examples-qec: ${{ steps.filter.outputs.build-examples-qec }}
       build-examples-solvers: ${{ steps.filter.outputs.build-examples-solvers }}
+      build-wheels: ${{ steps.filter.outputs.build-wheels }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -42,7 +43,6 @@ jobs:
             build-cudaq:
               - '.github/actions/get-cudaq-build/**'
               - '.github/actions/get-cudaq-version/**'
-              - '.github/workflows/scripts/build_cudaq.sh'
               - '.cudaq_version'
             build-docs:
               - '.github/workflows/docs.yaml'
@@ -90,6 +90,21 @@ jobs:
               - 'docs/sphinx/examples/qec/**'
             build-examples-solvers:
               - 'docs/sphinx/examples/solvers/**'
+            build-wheels:
+              - '.github/actions/get-cudaq-wheels/**'
+              - '.github/workflows/build_wheels.yaml'
+              - '.github/workflows/scripts/build_cudaq.sh'
+              - '.github/workflows/scripts/build_wheels.sh'
+              - 'scripts/ci/build_metapackages.sh'
+              - 'scripts/ci/test_wheels.sh'
+              - 'libs/qec/pyproject.toml.cu*'
+              - 'libs/qec/python/metapackages/MANIFEST.in'
+              - 'libs/qec/python/metapackages/pyproject.toml'
+              - 'libs/qec/python/metapackages/setup.py'
+              - 'libs/solvers/pyproject.toml.cu*'
+              - 'libs/solvers/python/metapackages/MANIFEST.in'
+              - 'libs/solvers/python/metapackages/pyproject.toml'
+              - '.cudaq_version'
 
   build-cudaq:
     name: Build CUDAQ
@@ -179,6 +194,19 @@ jobs:
       )
     uses: ./.github/workflows/lib_solvers.yaml
 
+  build-wheels:
+    name: Wheels
+    needs: [check-changes]
+    if: |
+      !failure() && !cancelled() &&
+      needs.check-changes.outputs.build-wheels == 'true'
+    uses: ./.github/workflows/build_wheels.yaml
+    with:
+      build_type: Release
+      cudaq_wheels: Custom
+    secrets:
+      CUDAQ_ACCESS_TOKEN: ${{ secrets.CUDAQ_ACCESS_TOKEN }}
+
   # This job is used for branch protection checks.
   verify:
     name: Verify PR
@@ -188,6 +216,7 @@ jobs:
       - build-all
       - build-qec
       - build-solvers
+      - build-wheels
     runs-on: ubuntu-latest
     steps:
       - name: Check results
@@ -210,6 +239,7 @@ jobs:
           check_result "build-all"     "${{needs.build-all.result}}"
           check_result "build-qec"     "${{needs.build-qec.result}}"
           check_result "build-solvers" "${{needs.build-solvers.result}}"
+          check_result "build-wheels"  "${{needs.build-wheels.result}}"
 
           if [[ "$status" != "success" ]]; then
             exit 1


### PR DESCRIPTION
<!--
Thanks for contributing to CUDA-Q Libraries!

Please read the full Pull Request Guidelines in Contributing.md:
https://github.com/NVIDIA/cudaqx/blob/main/Contributing.md#pull-request-guidelines
-->

## Description

<!-- What does this PR change, and why? Link related issues. -->

Adds a build and test of our Python wheels when relevant files are changed. This will make the CI slower for those PRs (current full PR CI takes ~45 minutes, versus the wheel build takes 1 hour 15 minutes on average, with some recent builds taking closer to 2 hours).

Adds wheel build to PRs that change:
- `.cudaq_version`
- Wheel workflow, action, build script, or validation logic
- Wheel package dependency/metadata files
- Python metapackage build logic or package definitions

## Runtime / performance impact
This will increase the time that the PR CI checks take when the wheel build is triggered. Currently, a full run of all PR checks takes ~45 minutes. The wheel build takes an average of 1hr 15minutes to run, with recent builds commonly taking closer to 2 hours. 

<!--
If this change affects performance, paste benchmark numbers here.
Otherwise write "N/A".
-->

## Self-review checklist

Please confirm each item before requesting review. Check `[x]` or strike
through and explain.

### Before requesting review
- [x] I reviewed my own full diff in GitHub or my editor.
- [x] PR is in Draft if it is not yet ready for review.
- [x] Temporary / debugging changes have been removed.
- [x] Local test logs reviewed; no unexplained warnings or errors.
- [x] CI logs reviewed; no unexplained warnings or errors.
- [x] Full CI has been run.

### Scope and size
- [x] PR is under ~1000 lines, or an exception is justified in the description.
- [x] Refactoring-only changes are isolated in their own PR(s).
- [x] No existing tests were disabled or modified just to make this PR pass
      (if so, an issue has been raised).

### Tests
- [x] New functionality has new tests.
- [x] Tests fail if the new functionality is broken (including crashes), not
      just when it is missing.
- [x] Negative tests added where exceptions are expected.
- [x] Truth data added where simple `EXPECT_*` / `assert` checks are
      insufficient for algorithmic correctness.
- [x] CI runtime impact considered; team notified if significant.
    - See note in Runtime/Performance Impact

### Documentation
- [x] Public-facing APIs have Doxygen docs.
- [x] User-visible behavior changes have public docs, or a follow-up is
      tracked.
- [x] User-facing docs for new features are in a **separate PR** held until
      release (the docs site publishes immediately on merge to the default
      branch, so feature docs must not land before the feature ships).

### Code style
- [x] Naming follows the existing convention (`snake_case` vs `camelCase`) for
      the area being modified.

### Dependencies
- [x] No new third-party dependencies, **or** the team has been notified and
      OSRB tickets filed.
