### PR TITLE
Adapt to CUDA-Q internal-namespace unification (`cudaq::detail`)

### DIFF
--- a/.cudaq_version
+++ b/.cudaq_version
@@ -1,6 +1,6 @@
 {
   "cudaq": {
     "repository": "NVIDIA/cuda-quantum",
-    "ref": "ae64ffbb01cd277d742c4a838bf6175382c8cedf"
+    "ref": "f14de75d0dad64fa8b82f8ac1b28a46206b8b73d"
   }
 }

--- a/libs/qec/lib/decoder.cpp
+++ b/libs/qec/lib/decoder.cpp
@@ -287,7 +287,7 @@ bool decoder::enqueue_syndrome(const uint8_t *syndrome,
     std::chrono::duration<double> log_dur1, log_dur2, log_dur3;
 
     const bool log_due_to_log_level =
-        cudaq::details::should_log(cudaq::details::LogLevel::info);
+        cudaq::detail::should_log(cudaq::detail::LogLevel::info);
     const bool should_log = pimpl->should_log || log_due_to_log_level;
 
     if (should_log) {
@@ -423,7 +423,7 @@ void decoder::clear_corrections() {
   pimpl->corrections.clear();
   pimpl->corrections.resize(O_sparse.size());
   const bool log_due_to_log_level =
-      cudaq::details::should_log(cudaq::details::LogLevel::info);
+      cudaq::detail::should_log(cudaq::detail::LogLevel::info);
   const bool should_log = pimpl->should_log || log_due_to_log_level;
   if (should_log) {
     pimpl->log_counter++;
@@ -439,7 +439,7 @@ void decoder::clear_corrections() {
 
 const uint8_t *decoder::get_obs_corrections() const {
   const bool log_due_to_log_level =
-      cudaq::details::should_log(cudaq::details::LogLevel::info);
+      cudaq::detail::should_log(cudaq::detail::LogLevel::info);
   const bool should_log = pimpl->should_log || log_due_to_log_level;
   if (should_log) {
     pimpl->log_counter++;
@@ -465,7 +465,7 @@ void decoder::reset_decoder() {
   pimpl->corrections.clear();
   pimpl->corrections.resize(O_sparse.size());
   const bool log_due_to_log_level =
-      cudaq::details::should_log(cudaq::details::LogLevel::info);
+      cudaq::detail::should_log(cudaq::detail::LogLevel::info);
   const bool should_log = pimpl->should_log || log_due_to_log_level;
   if (should_log) {
     pimpl->log_counter++;

--- a/libs/qec/lib/decoders/plugins/trt_decoder/trt_decoder.cpp
+++ b/libs/qec/lib/decoders/plugins/trt_decoder/trt_decoder.cpp
@@ -915,7 +915,7 @@ std::vector<decoder_result> trt_decoder::decode_batch_impl(
     size_t total_input_nonzero = 0;
     size_t total_residual_nonzero = 0;
     const bool log_residual_counts =
-        cudaq::details::should_log(cudaq::details::LogLevel::info);
+        cudaq::detail::should_log(cudaq::detail::LogLevel::info);
 
     for (size_t batch_start = 0; batch_start < syndromes.size();
          batch_start += model_batch_size_) {

--- a/libs/qec/lib/realtime/config.cpp
+++ b/libs/qec/lib/realtime/config.cpp
@@ -557,7 +557,7 @@ void log_config(const char *config_str, bool from_file) {
   }();
 
   if (dump_config) {
-    if (cudaq::details::should_log(cudaq::details::LogLevel::info)) {
+    if (cudaq::detail::should_log(cudaq::detail::LogLevel::info)) {
       CUDAQ_INFO(
           "Initializing realtime decoding library with config string: {}",
           config_str);

--- a/libs/solvers/include/cudaq/solvers/observe_gradient.h
+++ b/libs/solvers/include/cudaq/solvers/observe_gradient.h
@@ -60,7 +60,7 @@ protected:
     auto &platform = cudaq::get_platform();
     std::string kernelName =
         "auto_gradient_kernel_calc_" + std::to_string(batchIdx);
-    auto result = cudaq::details::runObservation(
+    auto result = cudaq::detail::runObservation(
         [&]() { quantumFunction(x); }, const_cast<spin_op &>(op), platform,
         shots, kernelName, 0, nullptr, batchIdx, numRequiredExpectations);
     data.emplace_back(x, result.value(), observe_execution_type::gradient);


### PR DESCRIPTION
<!--
Thanks for contributing to CUDA-Q Libraries!

Please read the full Pull Request Guidelines in Contributing.md:
https://github.com/NVIDIA/cudaqx/blob/main/Contributing.md#pull-request-guidelines
-->

## Description

Adapt CUDA-QX to CUDA-Q [PR #4663](https://github.com/NVIDIA/cuda-quantum/pull/4663), which unified CUDA-Q's internal-use namespaces (`details` / `internal` / `__internal__` / `__internal`) into a single `cudaq::detail`.

- Update references `cudaq::details::` → `cudaq::detail::`:
  - `should_log` / `LogLevel` — `libs/qec/lib/decoder.cpp`, `libs/qec/lib/realtime/config.cpp`, `libs/qec/lib/decoders/plugins/trt_decoder/trt_decoder.cpp`
  - `runObservation` — `libs/solvers/include/cudaq/solvers/observe_gradient.h`
- Bump `.cudaq_version` to the #4663 commit (`f14de75d0dad64fa8b82f8ac1b28a46206b8b73d`).

Pinned to exactly the #4663 commit rather than top-of-tree to avoid pulling in CUDA-Q #4655 ("Deprecating library
mode," which removes nvq++'s `--enable-mlir`) — that is an unrelated adaptation best handled in its own PR.

## Runtime / performance impact

N/A — namespace rename and version-pin bump only; no behavior change.

## Self-review checklist

### Before requesting review
- [x] I reviewed my own full diff in GitHub or my editor.
- [x] PR is in Draft if it is not yet ready for review. 
- [x] Temporary / debugging changes have been removed. 
- [x] Local test logs reviewed; no unexplained warnings or errors.
- [x] CI logs reviewed; no unexplained warnings or errors.
- [x] Full CI has been run.

### Scope and size
- [x] PR is under ~1000 lines, or an exception is justified in the description.
- [x] Refactoring-only changes are isolated in their own PR(s).
- [x] No existing tests were disabled or modified just to make this PR pass.

### Tests
- [x] New functionality has new tests: N/A — no new functionality; this restores buildability against CUDA-Q #4663. The existing qec/solvers unittests (`test_vqe`, `test_adapt`, `test_uccsd`, `test_qec_*`) exercise the touched code and act as the regression guard: they failed to compile before the fix and build + pass after it.
- [x] Tests fail if the new functionality is broken (including crashes): N/A 
- [x] Negative tests added where exceptions are expected: N/A — no new error paths.
- [x] Truth data added where simple `EXPECT_*` / `assert` checks are insufficient: N/A — no algorithmic change.
- [x] CI runtime impact considered; team notified if significant. (Negligible - no new tests.)

### Documentation
- [x] Public-facing APIs have Doxygen docs: N/A — no API surface changes; the touched call sites use CUDA-Q internal helpers.
- [x] User-visible behavior changes have public docs, or a follow-up is tracked: N/A — no user-visible behavior change.
- [x] User-facing docs for new features are in a separate PR held until release: N/A — no new features.

### Code style
- [x] Naming follows the existing convention for the area being modified.

### Dependencies
- [x] No new third-party dependencies, or the team has been notified and OSRB tickets filed. 