### PR TITLE
Remove --enable-mlir (hasn't been needed for a while)

### DIFF
--- a/cmake/Modules/CUDA-QX.cmake
+++ b/cmake/Modules/CUDA-QX.cmake
@@ -53,7 +53,6 @@ Example usage:
       ${CMAKE_CURRENT_SOURCE_DIR}/file1.cpp
       ${CMAKE_CURRENT_SOURCE_DIR}/file2.cpp
     COMPILER_FLAGS
-      --enable-mlir
       -v
     DEPENDS_ON
       SomeOtherTarget
@@ -94,7 +93,7 @@ function(cudaqx_add_device_code LIBRARY_NAME)
     add_custom_command(
       OUTPUT ${output_file}
       COMMAND ${COMPILER}
-        ${ARGS_COMPILER_FLAGS} -c -fPIC --enable-mlir
+        ${ARGS_COMPILER_FLAGS} -c -fPIC
         ${CMAKE_CURRENT_SOURCE_DIR}/${source} -o ${baseName}
         "$<$<BOOL:${prop}>:-I $<JOIN:${prop}, -I >>"
       DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/${source} ${ARGS_DEPENDS_ON}

--- a/docs/sphinx/components/qec/introduction.rst
+++ b/docs/sphinx/components/qec/introduction.rst
@@ -1285,7 +1285,7 @@ Example of running a memory experiment:
     .. code-block:: cpp
 
         // Compile and run with:
-        // nvq++ --enable-mlir --target=stim -lcudaq-qec example.cpp
+        // nvq++ --target=stim -lcudaq-qec example.cpp
         // ./a.out
 
         #include "cudaq.h"

--- a/docs/sphinx/components/solvers/introduction.rst
+++ b/docs/sphinx/components/solvers/introduction.rst
@@ -398,7 +398,7 @@ Basic Usage
         #include "cudaq/solvers/operators.h"
 
         // compile with 
-        // nvq++ adaptEx.cpp --enable-mlir -lcudaq-solvers
+        // nvq++ adaptEx.cpp -lcudaq-solvers
         // ./a.out 
 
         int main() {

--- a/docs/sphinx/examples/qec/cpp/circuit_level_noise.cpp
+++ b/docs/sphinx/examples/qec/cpp/circuit_level_noise.cpp
@@ -7,7 +7,7 @@
  ******************************************************************************/
 // [Begin Documentation]
 // Compile and run with:
-// nvq++ --enable-mlir --target=stim -lcudaq-qec circuit_level_noise.cpp
+// nvq++ --target=stim -lcudaq-qec circuit_level_noise.cpp -o circuit_level_noise
 // ./a.out
 
 #include "cudaq.h"

--- a/docs/sphinx/examples/qec/cpp/circuit_level_noise.cpp
+++ b/docs/sphinx/examples/qec/cpp/circuit_level_noise.cpp
@@ -7,7 +7,7 @@
  ******************************************************************************/
 // [Begin Documentation]
 // Compile and run with:
-// nvq++ --target=stim -lcudaq-qec circuit_level_noise.cpp -o circuit_level_noise
+// nvq++ --target=stim -lcudaq-qec circuit_level_noise.cpp
 // ./a.out
 
 #include "cudaq.h"

--- a/docs/sphinx/examples/qec/cpp/code_capacity_noise.cpp
+++ b/docs/sphinx/examples/qec/cpp/code_capacity_noise.cpp
@@ -10,7 +10,7 @@
 // decoder, code
 //
 // Compile and run with
-// nvq++ --enable-mlir --target=stim -lcudaq-qec code_capacity_noise.cpp
+// nvq++ --target=stim -lcudaq-qec code_capacity_noise.cpp
 // ./a.out
 
 #include <algorithm>

--- a/docs/sphinx/examples/solvers/cpp/adapt_h2.cpp
+++ b/docs/sphinx/examples/solvers/cpp/adapt_h2.cpp
@@ -11,7 +11,7 @@
 #include "cudaq/solvers/operators.h"
 
 // Compile and run with
-// nvq++ --enable-mlir -lcudaq-solvers adapt_h2.cpp -o adapt_ex
+// nvq++ -lcudaq-solvers adapt_h2.cpp -o adapt_ex
 // ./adapt_ex
 
 int main() {

--- a/docs/sphinx/examples/solvers/cpp/molecular_docking_qaoa.cpp
+++ b/docs/sphinx/examples/solvers/cpp/molecular_docking_qaoa.cpp
@@ -11,7 +11,7 @@
 #include "cudaq/solvers/qaoa.h"
 
 // Compile and run with
-// nvq++ --enable-mlir -lcudaq-solvers molecular_docking_qaoa.cpp
+// nvq++ -lcudaq-solvers molecular_docking_qaoa.cpp
 // ./a.out
 
 int main() {

--- a/docs/sphinx/examples/solvers/cpp/uccsd_vqe.cpp
+++ b/docs/sphinx/examples/solvers/cpp/uccsd_vqe.cpp
@@ -12,7 +12,7 @@
 #include "cudaq/solvers/vqe.h"
 
 // Compile and run with
-// nvq++ --enable-mlir -lcudaq-solvers uccsd_vqe.cpp -o uccsd_vqe
+// nvq++ -lcudaq-solvers uccsd_vqe.cpp -o uccsd_vqe
 // ./uccsd_vqe
 
 int main() {

--- a/docs/sphinx/examples_rst/qec/circuit_level_noise.rst
+++ b/docs/sphinx/examples_rst/qec/circuit_level_noise.rst
@@ -38,7 +38,7 @@ Here's how to use CUDA-Q QEC to perform a circuit-level noise model experiment i
 
    .. code-block:: bash
 
-      nvq++ --enable-mlir --target=stim -lcudaq-qec circuit_level_noise.cpp -o circuit_level_noise
+      nvq++ --target=stim -lcudaq-qec circuit_level_noise.cpp -o circuit_level_noise
       ./circuit_level_noise
 
 

--- a/docs/sphinx/examples_rst/qec/code_capacity_noise.rst
+++ b/docs/sphinx/examples_rst/qec/code_capacity_noise.rst
@@ -48,7 +48,7 @@ Here's how to use CUDA-Q QEC to perform a code capacity noise model experiment i
 
    .. code-block:: bash
 
-      nvq++ --enable-mlir --target=stim -lcudaq-qec code_capacity_noise.cpp -o code_capacity_noise
+      nvq++ --target=stim -lcudaq-qec code_capacity_noise.cpp -o code_capacity_noise
       ./code_capacity_noise
 
 

--- a/docs/sphinx/examples_rst/solvers/adapt.rst
+++ b/docs/sphinx/examples_rst/solvers/adapt.rst
@@ -37,5 +37,5 @@ Here we demonstrate how to use the CUDA-Q Solvers library to execute the ADAPT-V
 
    .. code:: bash
 
-       nvq++ --enable-mlir -lcudaq-solvers adapt_h2.cpp -o adapt_h2
+       nvq++ -lcudaq-solvers adapt_h2.cpp -o adapt_h2
       ./adapt_h2

--- a/docs/sphinx/examples_rst/solvers/qaoa.rst
+++ b/docs/sphinx/examples_rst/solvers/qaoa.rst
@@ -26,7 +26,7 @@ Key features of QAOA:
 
    .. code-block:: bash
 
-      nvq++ --enable-mlir -lcudaq-solvers molecular_docking_qaoa.cpp -o molecular_docking_qaoa
+      nvq++ -lcudaq-solvers molecular_docking_qaoa.cpp -o molecular_docking_qaoa
       ./molecular_docking_qaoa
 
 CUDA-Q Solvers Implementation

--- a/docs/sphinx/examples_rst/solvers/vqe.rst
+++ b/docs/sphinx/examples_rst/solvers/vqe.rst
@@ -38,7 +38,7 @@ CUDA-Q Solvers provides a high-level interface for running VQE simulations. Here
 
    .. code-block:: bash
 
-      nvq++ --enable-mlir -lcudaq-solvers uccsd_vqe.cpp -o uccsd_vqe
+      nvq++ -lcudaq-solvers uccsd_vqe.cpp -o uccsd_vqe
       ./uccsd_vqe
 
 Code Explanation

--- a/libs/qec/lib/decoders/plugins/example/decoder_plugins_demo.cpp
+++ b/libs/qec/lib/decoders/plugins/example/decoder_plugins_demo.cpp
@@ -9,7 +9,7 @@
 // This example shows how to use decoders from decoder plugins
 //
 // Compile and run with
-// nvq++ --enable-mlir -lcudaq-qec decoder_plugins_demo.cpp -o
+// nvq++ -lcudaq-qec decoder_plugins_demo.cpp -o
 // decoder_plugins_demo
 // ./decoder_plugins_demo
 

--- a/libs/solvers/unittests/nvqpp/CMakeLists.txt
+++ b/libs/solvers/unittests/nvqpp/CMakeLists.txt
@@ -7,5 +7,5 @@
 # ============================================================================ #
 include_directories(${CUDAQX_SOLVERS_INCLUDE_DIR})
 set(CMAKE_CXX_COMPILER "${CUDAQ_INSTALL_DIR}/bin/nvq++")
-set(CMAKE_CXX_COMPILE_OBJECT "<CMAKE_CXX_COMPILER> --enable-mlir -fPIC <DEFINES> <INCLUDES> -o <OBJECT> -c <SOURCE>")
+set(CMAKE_CXX_COMPILE_OBJECT "<CMAKE_CXX_COMPILER> -fPIC <DEFINES> <INCLUDES> -o <OBJECT> -c <SOURCE>")
 add_library(test-kernels SHARED test_kernels.cpp)

--- a/scripts/ci/test_examples.sh
+++ b/scripts/ci/test_examples.sh
@@ -43,7 +43,7 @@ run_cpp_test() {
     echo "Compiling and running C++ example: $file"
     echo "-----------------------------------------"
     
-    nvq++ --enable-mlir $lib_flag \
+    nvq++ $lib_flag \
         -I"$CUDAQX_INCLUDE" -L"$CUDAQX_LIB" -Wl,-rpath,"$CUDAQX_LIB" \
         "$file"
     

--- a/scripts/validation/container/validate_container.sh
+++ b/scripts/validation/container/validate_container.sh
@@ -168,7 +168,7 @@ test_examples() {
                             \$compile_cmd -o test_prog && \
                             ./test_prog || exit 1; \
                         else \
-                            nvq++ --enable-mlir -lcudaq-${domain} --target ${target} \$f -o test_prog && \
+                            nvq++ -lcudaq-${domain} --target ${target} \$f -o test_prog && \
                             ./test_prog || exit 1; \
                         fi; \
                         rm test_prog; \


### PR DESCRIPTION
Preparing for https://github.com/NVIDIA/cuda-quantum/pull/4655

The above PR removes support for the flag, but the default of enabling MLIR has been the default for quite some time now, so the changes in this PR should have no effect, even if they are merged before 4655.

Normally changes to docs and examples would need to wait for a release to occur first, but since these changes are backwards compatible with older versions of nvq++, this isn't necessary.