### PR TITLE
Adopt scipy.sparse as optional interop

### DIFF
--- a/docs/sphinx/api/qec/nv_qldpc_decoder_api.rst
+++ b/docs/sphinx/api/qec/nv_qldpc_decoder_api.rst
@@ -33,10 +33,10 @@
                           [0, 1, 0, 1, 1, 0, 1],
                           [0, 0, 1, 0, 1, 1, 1]], dtype=np.uint8) # sample 3x7 PCM
             opts = dict() # see below for options
-            # Note: H must be in row-major order. If you use
-            # `scipy.sparse.csr_matrix.todense()` to get the parity check
-            # matrix, you must specify todense(order='C') to get a row-major
-            # matrix.
+            # H may also be a scipy.sparse matrix (CSR, CSC, COO, or any
+            # other scipy.sparse format), which avoids a full dense rows×cols
+            # allocation for large PCMs.  Any format is normalised to CSR
+            # internally; no call to .toarray() or .todense() is needed.
             nvdec = qec.get_decoder('nv-qldpc-decoder', H, **opts)
 
       .. tab:: C++

--- a/docs/sphinx/components/qec/introduction.rst
+++ b/docs/sphinx/components/qec/introduction.rst
@@ -644,6 +644,10 @@ CUDA-Q QEC supports implementing decoders in Python using the :code:`@qec.decode
     @qec.decoder("my_decoder")
     class MyDecoder:
         def __init__(self, H, **kwargs):
+            # H is a scipy.sparse matrix or a dense numpy uint8 array,
+            # mirroring whatever was passed to qec.get_decoder().
+            # Pass it unchanged to Decoder.__init__ so the C++ base class
+            # stores a compact sparse representation without a dense allocation.
             qec.Decoder.__init__(self, H)
             self.H = H
             # Initialize with optional kwargs

--- a/docs/sphinx/examples/qec/python/nv-qldpc-decoder.py
+++ b/docs/sphinx/examples/qec/python/nv-qldpc-decoder.py
@@ -41,9 +41,8 @@ def parse_csr_mat(j, dims, mat_name):
     # Create a data array of ones.
     data = np.ones(indptr[-1], dtype=np.uint8)
 
-    # Build the CSR matrix and return it as a dense numpy array.
-    csr = csr_matrix((data, indices, indptr), shape=dims, dtype=np.uint8)
-    return csr.toarray()
+    # Build and return the sparse matrix directly — no dense allocation.
+    return csr_matrix((data, indices, indptr), shape=dims, dtype=np.uint8)
 
 
 def parse_H_csr(j, dims):
@@ -57,7 +56,7 @@ def parse_obs_csr(j, dims):
     """
     Parse a CSR-style observable matrix from an input file in JSON format"
     """
-    return parse_csr_mat(j, dims, "obs_mat")
+    return parse_csr_mat(j, dims, "obs_mat").toarray()
 
 
 ### Main decoder loop ###

--- a/docs/sphinx/examples_rst/qec/decoders.rst
+++ b/docs/sphinx/examples_rst/qec/decoders.rst
@@ -9,6 +9,16 @@ The relationship between errors and syndromes is captured mathematically by the 
 stabilizer measurement, while each column represents a possible error. When we multiply an error pattern by this matrix, we get the syndrome 
 that would result from those errors.
 
+.. note::
+   **scipy.sparse interop** — :func:`cudaq_qec.get_decoder` and
+   :class:`cudaq_qec.Decoder` accept a ``scipy.sparse`` matrix (CSR, CSC,
+   COO, or any other ``scipy.sparse`` format) as the parity-check matrix
+   ``H``.  This is the preferred form for large PCMs because no dense
+   ``rows x cols`` allocation is made — the matrix is normalised to CSR
+   internally.  Dense NumPy ``uint8`` arrays remain supported.
+   ``scipy`` is an optional dependency; if it is not installed, pass a dense
+   NumPy array instead.
+
 Detector Error Model
 +++++++++++++++++++++
 

--- a/libs/qec/include/cudaq/qec/pcm_utils.h
+++ b/libs/qec/include/cudaq/qec/pcm_utils.h
@@ -223,8 +223,8 @@ cudaqx::tensor<uint8_t> generate_random_pcm(std::size_t n_rounds,
 
 /// @brief Same distribution as generate_random_pcm, but constructs a CSC
 /// sparse_binary_matrix directly without allocating a dense rank-2 tensor.
-/// Intended for large PCMs whose dense form would exceed
-/// k_max_dense_pcm_elements.
+/// Intended for large PCMs whose dense form would be impractical or impossible
+/// to allocate.
 sparse_binary_matrix
 generate_random_pcm_sparse(std::size_t n_rounds, std::size_t n_errs_per_round,
                            std::size_t n_syndromes_per_round, int weight,

--- a/libs/qec/include/cudaq/qec/pcm_utils.h
+++ b/libs/qec/include/cudaq/qec/pcm_utils.h
@@ -205,22 +205,10 @@ get_pcm_for_rounds(const sparse_binary_matrix &pcm,
                    bool straddle_end_round = false,
                    bool pcm_is_canonical = false);
 
-/// @brief Upper bound on \f$\texttt{rows} \times \texttt{cols}\f$ for the
-/// dense `generate_random_pcm` path. Above this, the call throws and the
-/// caller should switch to `generate_random_pcm_sparse`. Exposed as a named
-/// symbol so tests and users can reference it without grepping the source.
-inline constexpr std::size_t k_max_dense_pcm_elements =
-    static_cast<std::size_t>(400u) * 1024u * 1024u;
-
 /// @brief Generate a random PCM with the given parameters.
 ///
 /// The PCM has shape `(n_rounds * n_syndromes_per_round) × (n_rounds *
-/// n_errs_per_round)`. If the product
-/// \f$n\_rounds^2 \times n\_syndromes\_per\_round \times n\_errs\_per\_round\f$
-/// exceeds `k_max_dense_pcm_elements`
-/// (\f$400 \times 1024 \times 1024 \approx 4.19 \times 10^8\f$ entries),
-/// throws `std::invalid_argument`; use `generate_random_pcm_sparse` for
-/// matrices that large without a dense allocation.
+/// n_errs_per_round)`.
 /// @param n_rounds The number of rounds in the PCM.
 /// @param n_errs_per_round The number of errors per round in the PCM.
 /// @param n_syndromes_per_round The number of syndromes per round in the PCM.

--- a/libs/qec/lib/pcm_utils.cpp
+++ b/libs/qec/lib/pcm_utils.cpp
@@ -511,9 +511,32 @@ cudaqx::tensor<uint8_t> generate_random_pcm(std::size_t n_rounds,
         std::to_string(weight) +
         ", n_syndromes_per_round=" + std::to_string(n_syndromes_per_round));
   }
-
+  constexpr auto kSizeMax = std::numeric_limits<std::size_t>::max();
+  // Overflow-safe cap check in (a > limit / b) form; otherwise size_t wrap
+  // could bypass the cap.
+  auto exceeds_cap = [](std::size_t a, std::size_t b) {
+    return a != 0 && b > kSizeMax / a;
+  };
+  if (exceeds_cap(n_rounds, n_errs_per_round) ||
+      exceeds_cap(n_rounds, n_syndromes_per_round)) {
+    throw std::invalid_argument(
+        "generate_random_pcm: n_rounds * n_errs_per_round and "
+        "n_rounds * n_syndromes_per_round must not overflow size_t; got "
+        "n_rounds=" +
+        std::to_string(n_rounds) +
+        ", n_errs_per_round=" + std::to_string(n_errs_per_round) +
+        ", n_syndromes_per_round=" + std::to_string(n_syndromes_per_round) +
+        ". Use cudaq::qec::generate_random_pcm_sparse(...) instead.");
+  }
   std::size_t n_cols = n_rounds * n_errs_per_round;
   std::size_t n_rows = n_rounds * n_syndromes_per_round;
+  if (exceeds_cap(n_rows, n_cols)) {
+    throw std::invalid_argument(
+        std::string("generate_random_pcm: total dense size n_rows * n_cols (") +
+        std::to_string(n_rows) + " × " + std::to_string(n_cols) +
+        ") must not overflow size_t; use "
+        "cudaq::qec::generate_random_pcm_sparse(...) instead.");
+  }
 
   cudaqx::tensor<uint8_t> pcm(std::vector<std::size_t>{n_rows, n_cols});
 

--- a/libs/qec/lib/pcm_utils.cpp
+++ b/libs/qec/lib/pcm_utils.cpp
@@ -511,34 +511,9 @@ cudaqx::tensor<uint8_t> generate_random_pcm(std::size_t n_rounds,
         std::to_string(weight) +
         ", n_syndromes_per_round=" + std::to_string(n_syndromes_per_round));
   }
-  // Overflow-safe cap check in (a > limit / b) form; otherwise size_t wrap
-  // could bypass the cap.
-  auto exceeds_cap = [](std::size_t a, std::size_t b) {
-    return a != 0 && b > k_max_dense_pcm_elements / a;
-  };
-  if (exceeds_cap(n_rounds, n_errs_per_round) ||
-      exceeds_cap(n_rounds, n_syndromes_per_round)) {
-    throw std::invalid_argument(
-        std::string("generate_random_pcm: n_rounds * n_errs_per_round and "
-                    "n_rounds * n_syndromes_per_round must each fit within "
-                    "the dense allocation limit (") +
-        std::to_string(k_max_dense_pcm_elements) +
-        "); got n_rounds=" + std::to_string(n_rounds) +
-        ", n_errs_per_round=" + std::to_string(n_errs_per_round) +
-        ", n_syndromes_per_round=" + std::to_string(n_syndromes_per_round) +
-        ". Use cudaq::qec::generate_random_pcm_sparse(...) instead.");
-  }
+
   std::size_t n_cols = n_rounds * n_errs_per_round;
   std::size_t n_rows = n_rounds * n_syndromes_per_round;
-  if (exceeds_cap(n_rows, n_cols)) {
-    throw std::invalid_argument(
-        std::string("generate_random_pcm: PCM size (") +
-        std::to_string(n_rows) + " × " + std::to_string(n_cols) +
-        " elements) exceeds the dense allocation limit (" +
-        std::to_string(k_max_dense_pcm_elements) +
-        ") for this API; use cudaq::qec::generate_random_pcm_sparse(...) "
-        "instead.");
-  }
 
   cudaqx::tensor<uint8_t> pcm(std::vector<std::size_t>{n_rows, n_cols});
 

--- a/libs/qec/python/bindings/py_decoder.cpp
+++ b/libs/qec/python/bindings/py_decoder.cpp
@@ -60,12 +60,11 @@ checked_narrow_to_index_type(std::size_t value, const char *field_name) {
 static sparse_binary_matrix sparse_binary_matrix_from_scipy(nb::object mat) {
   // Normalize to CSR so that indptr == row_offsets, indices == col_indices.
   nb::object csr = mat.attr("tocsr")();
-  // Drop explicitly-stored zeros: we only copy indptr/indices below, so a
-  // structural zero would otherwise be treated as a nonzero PCM entry.
-  // tocsr() returns the same object when mat is already CSR, so copy first to
-  // avoid mutating the caller's matrix.
+  // Avoid mutating the caller's matrix and clean it up for our internal use.
   csr = csr.attr("copy")();
+  csr.attr("sum_duplicates")();
   csr.attr("eliminate_zeros")();
+  csr.attr("sort_indices")();
   nb::tuple shape_t = nb::cast<nb::tuple>(csr.attr("shape"));
   auto num_rows = checked_narrow_to_index_type(
       nb::cast<std::size_t>(shape_t[0]), "num_rows");
@@ -171,9 +170,12 @@ public:
           // Dense numpy array of any dtype: build sparse storage directly so
           // qec.Decoder.__init__(self, H) has the same memory behavior as
           // native get_decoder(..., H) (no intermediate dense tensor copy).
+          // copy=False makes astype a no-op when the input is already uint8;
+          // make_sparse_from_dense reads strides directly, so a non-contiguous
+          // uint8 input is also handled without a copy.
           return make_sparse_from_dense(
               nb::cast<nb::ndarray<nb::numpy, uint8_t>>(
-                  mat.attr("astype")("uint8")));
+                  mat.attr("astype")("uint8", nb::arg("copy") = false)));
         }()) {}
 
   decoder_result decode(const std::vector<float_t> &syndrome) override {

--- a/libs/qec/python/bindings/py_decoder.cpp
+++ b/libs/qec/python/bindings/py_decoder.cpp
@@ -942,10 +942,6 @@ void bindDecoder(nb::module_ &mod) {
         This function creates a random parity check matrix for quantum error correction
         with specified parameters controlling the structure and randomness.
 
-        If ``n_rounds * n_syndromes_per_round * n_rounds * n_errs_per_round`` is
-        larger than the internal dense limit (see C++ API), this raises
-        ``ValueError`` / ``RuntimeError``.
-
         Args:
             n_rounds: Number of measurement rounds in the error correction protocol
             n_errs_per_round: Number of error mechanisms per round

--- a/libs/qec/python/bindings/py_decoder.cpp
+++ b/libs/qec/python/bindings/py_decoder.cpp
@@ -106,19 +106,21 @@ class PyDecoder : public decoder {
 public:
   NB_TRAMPOLINE(decoder, 1);
 
-  PyDecoder(const nb::ndarray<nb::numpy, uint8_t> &H)
-      : decoder([&H]() {
+  /// @brief Construct from a scipy sparse matrix (CSR, CSC, COO, ...) or a
+  ///        dense numpy array of any numeric dtype.
+  PyDecoder(nb::object mat)
+      : decoder([&mat]() -> cudaq::qec::sparse_binary_matrix {
+          if (nb::hasattr(mat, "indptr") && nb::hasattr(mat, "indices"))
+            return sparse_binary_matrix_from_scipy(mat);
+          // Dense numpy array of any dtype
+          auto H = nb::cast<nb::ndarray<nb::numpy, uint8_t>>(
+              mat.attr("astype")("uint8"));
           auto borrow = toTensor(H);
           cudaqx::tensor<uint8_t> owned(borrow.shape());
           owned.copy(borrow.data(), borrow.shape());
-          // Force CSC to match get_decoder(ndarray); avoids CSR→CSC transposes
-          // in downstream to_nested_csc() calls.
           return cudaq::qec::sparse_binary_matrix(
               owned, cudaq::qec::sparse_binary_matrix_layout::csc);
         }()) {}
-
-  /// @brief Construct from any scipy sparse matrix (CSR, CSC, COO, ...)
-  PyDecoder(nb::object mat) : decoder(sparse_binary_matrix_from_scipy(mat)) {}
 
   decoder_result decode(const std::vector<float_t> &syndrome) override {
     NB_OVERRIDE_PURE(decode, syndrome);
@@ -568,7 +570,6 @@ void bindDecoder(nb::module_ &mod) {
 
   nb::class_<decoder, PyDecoder>(
       qecmod, "Decoder", "Represents a decoder for quantum error correction")
-      .def(nb::init<const nb::ndarray<nb::numpy, uint8_t> &>())
       .def(nb::init<nb::object>(),
            R"pbdoc(
         Construct from a scipy sparse matrix (CSR, CSC, COO or any other

--- a/libs/qec/python/bindings/py_decoder.cpp
+++ b/libs/qec/python/bindings/py_decoder.cpp
@@ -18,6 +18,7 @@
 #include "cudaq/qec/sparse_binary_matrix.h"
 #include "cudaq/runtime/logger/logger.h"
 #include <algorithm>
+#include <cstring>
 #include <filesystem>
 #include <functional>
 #include <limits>
@@ -54,40 +55,51 @@ checked_narrow_to_index_type(std::size_t value, const char *field_name) {
   return static_cast<sparse_binary_matrix::index_type>(value);
 }
 
-/// Build sparse_binary_matrix from Python dict with keys layout, num_rows,
-/// num_cols, nested (nested_csc or nested_csr format).
-static sparse_binary_matrix
-sparse_binary_matrix_from_py_dict(const nb::dict &d) {
-  if (!d.contains("layout") || !d.contains("num_rows") ||
-      !d.contains("num_cols") || !d.contains("nested"))
-    throw std::runtime_error(
-        "Sparse H dict must have keys: layout, num_rows, num_cols, "
-        "nested. Use layout \"nested_csc\": nested has one list per COLUMN "
-        "with ROW indices where that column has a one; \"nested_csr\": one "
-        "list per ROW with COLUMN indices for that row.");
-  std::string layout = nb::cast<std::string>(d["layout"]);
+/// Build sparse_binary_matrix directly from a scipy sparse matrix.
+/// Any scipy sparse format is accepted; it is normalized to CSR internally.
+static sparse_binary_matrix sparse_binary_matrix_from_scipy(nb::object mat) {
+  // Normalize to CSR so that indptr == row_offsets, indices == col_indices.
+  nb::object csr = mat.attr("tocsr")();
+  nb::tuple shape_t = nb::cast<nb::tuple>(csr.attr("shape"));
   auto num_rows = checked_narrow_to_index_type(
-      nb::cast<std::size_t>(d["num_rows"]), "num_rows");
+      nb::cast<std::size_t>(shape_t[0]), "num_rows");
   auto num_cols = checked_narrow_to_index_type(
-      nb::cast<std::size_t>(d["num_cols"]), "num_cols");
-  nb::list nested_py = nb::cast<nb::list>(d["nested"]);
-  std::vector<std::vector<sparse_binary_matrix::index_type>> nested;
-  nested.reserve(nested_py.size());
-  for (size_t i = 0; i < nested_py.size(); ++i) {
-    nb::list inner = nb::cast<nb::list>(nested_py[i]);
-    std::vector<sparse_binary_matrix::index_type> row;
-    row.reserve(inner.size());
-    for (size_t j = 0; j < inner.size(); ++j)
-      row.push_back(checked_narrow_to_index_type(
-          nb::cast<std::size_t>(inner[j]), "nested entry"));
-    nested.push_back(std::move(row));
-  }
-  if (layout == "nested_csc")
-    return sparse_binary_matrix::from_nested_csc(num_rows, num_cols, nested);
-  if (layout == "nested_csr")
-    return sparse_binary_matrix::from_nested_csr(num_rows, num_cols, nested);
-  throw std::runtime_error(
-      "Sparse H dict layout must be \"nested_csc\" or \"nested_csr\".");
+      nb::cast<std::size_t>(shape_t[1]), "num_cols");
+
+  // Copy a numpy integer array to vector<uint32_t> using pure C++ dtype
+  // dispatch — handles int32, int64, uint32, uint64 (all common scipy dtypes).
+  auto copy_to_uint32 = [](nb::handle arr_h) {
+    auto arr = nb::cast<nb::ndarray<>>(arr_h);
+    std::vector<sparse_binary_matrix::index_type> out(arr.size());
+    auto dtype = arr.dtype();
+    if (dtype == nb::dtype<int32_t>()) {
+      auto *p = static_cast<const int32_t *>(arr.data());
+      for (size_t i = 0; i < arr.size(); ++i)
+        out[i] = static_cast<sparse_binary_matrix::index_type>(p[i]);
+    } else if (dtype == nb::dtype<int64_t>()) {
+      auto *p = static_cast<const int64_t *>(arr.data());
+      for (size_t i = 0; i < arr.size(); ++i)
+        out[i] = static_cast<sparse_binary_matrix::index_type>(p[i]);
+    } else if (dtype == nb::dtype<uint32_t>()) {
+      std::memcpy(out.data(), arr.data(),
+                  arr.size() * sizeof(sparse_binary_matrix::index_type));
+    } else if (dtype == nb::dtype<uint64_t>()) {
+      auto *p = static_cast<const uint64_t *>(arr.data());
+      for (size_t i = 0; i < arr.size(); ++i)
+        out[i] = static_cast<sparse_binary_matrix::index_type>(p[i]);
+    } else {
+      throw std::runtime_error(
+          "scipy sparse matrix indptr/indices has unsupported dtype; "
+          "expected int32, int64, uint32, or uint64.");
+    }
+    return out;
+  };
+
+  auto ptr = copy_to_uint32(csr.attr("indptr"));
+  auto idx = copy_to_uint32(csr.attr("indices"));
+
+  return sparse_binary_matrix::from_csr(num_rows, num_cols, std::move(ptr),
+                                        std::move(idx));
 }
 
 class PyDecoder : public decoder {
@@ -105,8 +117,8 @@ public:
               owned, cudaq::qec::sparse_binary_matrix_layout::csc);
         }()) {}
 
-  PyDecoder(const nb::dict &d)
-      : decoder(sparse_binary_matrix_from_py_dict(d)) {}
+  /// @brief Construct from any scipy sparse matrix (CSR, CSC, COO, ...)
+  PyDecoder(nb::object mat) : decoder(sparse_binary_matrix_from_scipy(mat)) {}
 
   decoder_result decode(const std::vector<float_t> &syndrome) override {
     NB_OVERRIDE_PURE(decode, syndrome);
@@ -557,12 +569,12 @@ void bindDecoder(nb::module_ &mod) {
   nb::class_<decoder, PyDecoder>(
       qecmod, "Decoder", "Represents a decoder for quantum error correction")
       .def(nb::init<const nb::ndarray<nb::numpy, uint8_t> &>())
-      .def(nb::init<const nb::dict &>(),
+      .def(nb::init<nb::object>(),
            R"pbdoc(
-        Construct from sparse dict ``H`` with keys ``layout``, ``num_rows``,
-        ``num_cols``, and ``nested``. For bring-your-own-decoder classes that
-        receive the same sparse dict in ``cudaq.Decoder.__init__(self, H)`` as
-        was passed to ``get_decoder``.
+        Construct from a scipy sparse matrix (CSR, CSC, COO or any other
+        ``scipy.sparse`` format).  For bring-your-own-decoder classes that
+        call ``qec.Decoder.__init__(self, H)`` where ``H`` is a scipy sparse
+        matrix passed to ``get_decoder``.
       )pbdoc")
       .def(
           "decode",
@@ -731,8 +743,8 @@ void bindDecoder(nb::module_ &mod) {
                   tensor_H, cudaq::qec::sparse_binary_matrix_layout::csc);
             };
 
-        if (nb::isinstance<nb::dict>(H))
-          H_sparse = sparse_binary_matrix_from_py_dict(nb::cast<nb::dict>(H));
+        if (nb::hasattr(H, "indptr") && nb::hasattr(H, "indices"))
+          H_sparse = sparse_binary_matrix_from_scipy(nb::cast<nb::object>(H));
         else
           H_sparse = make_sparse_from_dense(
               nb::cast<nb::ndarray<nb::numpy, uint8_t>>(H));
@@ -751,19 +763,17 @@ void bindDecoder(nb::module_ &mod) {
 
         ``H`` may be:
 
+        - A scipy sparse matrix (CSR, CSC, COO, or any ``scipy.sparse`` format):
+          the preferred input — no dense allocation occurs, and any format is
+          normalised to CSR internally before building the C++ sparse storage.
         - A dense 2D NumPy ``uint8`` array in row-major order: a full dense
           ``cudaqx::tensor`` is built first, then converted to CSC sparse storage.
           For large PCMs this can allocate as much memory as ``rows * cols``.
-        - A sparse dict with keys ``layout``, ``num_rows``, ``num_cols``, ``nested``:
-          builds ``sparse_binary_matrix`` directly (no dense tensor for ``H``),
-          allowing native C++ decoders like ``pymatching`` to be constructed
-          from very large parity-check matrices.
 
         For Python-registered decoders (``cudaq.qec.decoder`` decorator), ``H``
-        is passed through to ``__init__`` unchanged (NumPy array or sparse dict).
-        Call ``Decoder.__init__(self, H)`` so nanobind can store the PCM in CSC
-        form when ``H`` is a dict without building a dense ``rows × cols``
-        allocation.
+        is passed through to ``__init__`` unchanged (NumPy array or scipy sparse
+        matrix).  Call ``Decoder.__init__(self, H)`` so nanobind can store the
+        PCM internally without building a dense ``rows x cols`` allocation.
       )pbdoc");
 
   qecmod.def(
@@ -934,7 +944,7 @@ void bindDecoder(nb::module_ &mod) {
 
         If ``n_rounds * n_syndromes_per_round * n_rounds * n_errs_per_round`` is
         larger than the internal dense limit (see C++ API), this raises
-        ``ValueError`` / ``RuntimeError``; use :func:`generate_random_pcm_sparse`.
+        ``ValueError`` / ``RuntimeError``.
 
         Args:
             n_rounds: Number of measurement rounds in the error correction protocol
@@ -952,42 +962,6 @@ void bindDecoder(nb::module_ &mod) {
       )pbdoc",
       nb::arg("n_rounds"), nb::arg("n_errs_per_round"),
       nb::arg("n_syndromes_per_round"), nb::arg("weight"), nb::arg("seed") = 0);
-
-  qecmod.def(
-      "generate_random_pcm_sparse",
-      // Signed `weight` for the same reason as generate_random_pcm above.
-      [](std::uint32_t n_rounds, std::uint32_t n_errs_per_round,
-         std::uint32_t n_syndromes_per_round, int weight,
-         std::uint32_t seed) -> nb::dict {
-        std::mt19937_64 rng(seed);
-        if (seed == 0)
-          rng = std::mt19937_64(std::random_device()());
-
-        cudaq::qec::sparse_binary_matrix sparse =
-            cudaq::qec::generate_random_pcm_sparse(n_rounds, n_errs_per_round,
-                                                   n_syndromes_per_round,
-                                                   weight, std::move(rng));
-        nb::dict out;
-        out["layout"] = "nested_csc";
-        out["num_rows"] = sparse.num_rows();
-        out["num_cols"] = sparse.num_cols();
-        auto nested_py = nb::list();
-        for (auto &col : sparse.to_nested_csc()) {
-          nb::list col_py;
-          for (auto r : col)
-            col_py.append(static_cast<std::size_t>(r));
-          nested_py.append(col_py);
-        }
-        out["nested"] = nested_py;
-        return out;
-      },
-      nb::arg("n_rounds"), nb::arg("n_errs_per_round"),
-      nb::arg("n_syndromes_per_round"), nb::arg("weight"), nb::arg("seed") = 0,
-      R"pbdoc(
-        Same random PCM distribution as :func:`generate_random_pcm`, but
-        builds ``sparse_binary_matrix`` in CSC form without allocating a dense
-        ``rows x cols`` tensor (helps with large PCMs where dense allocation fails).
-      )pbdoc");
 
   qecmod.def(
       "get_pcm_for_rounds",

--- a/libs/qec/python/bindings/py_decoder.cpp
+++ b/libs/qec/python/bindings/py_decoder.cpp
@@ -60,6 +60,12 @@ checked_narrow_to_index_type(std::size_t value, const char *field_name) {
 static sparse_binary_matrix sparse_binary_matrix_from_scipy(nb::object mat) {
   // Normalize to CSR so that indptr == row_offsets, indices == col_indices.
   nb::object csr = mat.attr("tocsr")();
+  // Drop explicitly-stored zeros: we only copy indptr/indices below, so a
+  // structural zero would otherwise be treated as a nonzero PCM entry.
+  // tocsr() returns the same object when mat is already CSR, so copy first to
+  // avoid mutating the caller's matrix.
+  csr = csr.attr("copy")();
+  csr.attr("eliminate_zeros")();
   nb::tuple shape_t = nb::cast<nb::tuple>(csr.attr("shape"));
   auto num_rows = checked_narrow_to_index_type(
       nb::cast<std::size_t>(shape_t[0]), "num_rows");
@@ -158,16 +164,16 @@ public:
   ///        dense numpy array of any numeric dtype.
   PyDecoder(nb::object mat)
       : decoder([&mat]() -> cudaq::qec::sparse_binary_matrix {
-          if (nb::hasattr(mat, "indptr") && nb::hasattr(mat, "indices"))
+          // Any scipy sparse format exposes tocsr(); detect via that rather
+          // than indptr/indices, which COO and some other formats lack.
+          if (nb::hasattr(mat, "tocsr"))
             return sparse_binary_matrix_from_scipy(mat);
-          // Dense numpy array of any dtype
-          auto H = nb::cast<nb::ndarray<nb::numpy, uint8_t>>(
-              mat.attr("astype")("uint8"));
-          auto borrow = toTensor(H);
-          cudaqx::tensor<uint8_t> owned(borrow.shape());
-          owned.copy(borrow.data(), borrow.shape());
-          return cudaq::qec::sparse_binary_matrix(
-              owned, cudaq::qec::sparse_binary_matrix_layout::csc);
+          // Dense numpy array of any dtype: build sparse storage directly so
+          // qec.Decoder.__init__(self, H) has the same memory behavior as
+          // native get_decoder(..., H) (no intermediate dense tensor copy).
+          return make_sparse_from_dense(
+              nb::cast<nb::ndarray<nb::numpy, uint8_t>>(
+                  mat.attr("astype")("uint8")));
         }()) {}
 
   decoder_result decode(const std::vector<float_t> &syndrome) override {
@@ -785,7 +791,9 @@ void bindDecoder(nb::module_ &mod) {
 
         cudaq::qec::sparse_binary_matrix H_sparse;
 
-        if (nb::hasattr(H, "indptr") && nb::hasattr(H, "indices"))
+        // Any scipy sparse format exposes tocsr(); detect via that rather than
+        // indptr/indices, which COO and some other formats do not expose.
+        if (nb::hasattr(H, "tocsr"))
           H_sparse = sparse_binary_matrix_from_scipy(nb::cast<nb::object>(H));
         else
           H_sparse = make_sparse_from_dense(

--- a/libs/qec/python/cudaq_qec/__init__.py
+++ b/libs/qec/python/cudaq_qec/__init__.py
@@ -96,7 +96,6 @@ z_dem_from_memory_circuit = qecrt.z_dem_from_memory_circuit
 
 dump_pcm = qecrt.dump_pcm
 generate_random_pcm = qecrt.generate_random_pcm
-generate_random_pcm_sparse = qecrt.generate_random_pcm_sparse
 get_pcm_for_rounds = qecrt.get_pcm_for_rounds
 get_sorted_pcm_column_indices = qecrt.get_sorted_pcm_column_indices
 pcm_is_sorted = qecrt.pcm_is_sorted

--- a/libs/qec/python/tests/test_decoder.py
+++ b/libs/qec/python/tests/test_decoder.py
@@ -630,6 +630,62 @@ def test_get_decoder_scipy_csc_direct():
     assert len(result.result) == H_dense.shape[1]
 
 
+def test_get_decoder_scipy_coo_direct():
+    """get_decoder accepts a scipy COO matrix, which has no indptr/indices."""
+    scipy_sparse = pytest.importorskip("scipy.sparse")
+    np.random.seed(0)
+    H_dense = np.random.randint(0, 2, (6, 12)).astype(np.uint8)
+    H_coo = scipy_sparse.coo_matrix(H_dense)
+    # COO format does not expose indptr; detection must rely on tocsr().
+    assert not hasattr(H_coo, "indptr")
+    decoder = qec.get_decoder("single_error_lut_example", H_coo)
+    assert decoder is not None
+    syndrome = np.zeros(H_dense.shape[0], dtype=np.uint8)
+    result = decoder.decode(syndrome)
+    assert result is not None
+    assert len(result.result) == H_dense.shape[1]
+
+
+def test_get_decoder_scipy_coo_same_result_as_dense():
+    """A decoder built from a scipy COO matrix matches the dense build."""
+    scipy_sparse = pytest.importorskip("scipy.sparse")
+    np.random.seed(7)
+    H_dense = np.random.randint(0, 2, (8, 16)).astype(np.uint8)
+    syndrome = np.zeros(H_dense.shape[0], dtype=np.uint8)
+
+    dec_coo = qec.get_decoder("single_error_lut_example",
+                              scipy_sparse.coo_matrix(H_dense))
+    dec_dense = qec.get_decoder("single_error_lut_example", H_dense)
+
+    res_coo = dec_coo.decode(syndrome)
+    res_dense = dec_dense.decode(syndrome)
+    np.testing.assert_array_equal(res_coo.result, res_dense.result)
+
+
+def test_get_decoder_scipy_explicit_zeros_dropped():
+    """Explicitly-stored zeros in a scipy matrix are not treated as PCM ones."""
+    scipy_sparse = pytest.importorskip("scipy.sparse")
+    H_dense = np.array([[1, 0, 1], [0, 1, 0]], dtype=np.uint8)
+
+    # Build a CSR matrix that structurally stores a zero at (0, 1): the data
+    # array carries an explicit 0 whose position would otherwise look like a
+    # nonzero PCM entry if indptr/indices were copied verbatim.
+    data = np.array([1, 0, 1, 1], dtype=np.uint8)
+    indices = np.array([0, 1, 2, 1])
+    indptr = np.array([0, 3, 4])
+    H_explicit = scipy_sparse.csr_matrix((data, indices, indptr), shape=(2, 3))
+    assert H_explicit.nnz == 4  # the explicit zero is stored
+    np.testing.assert_array_equal(H_explicit.toarray(), H_dense)
+
+    syndrome = np.zeros(H_dense.shape[0], dtype=np.uint8)
+    dec_explicit = qec.get_decoder("single_error_lut_example", H_explicit)
+    dec_dense = qec.get_decoder("single_error_lut_example", H_dense)
+
+    res_explicit = dec_explicit.decode(syndrome)
+    res_dense = dec_dense.decode(syndrome)
+    np.testing.assert_array_equal(res_explicit.result, res_dense.result)
+
+
 def test_get_decoder_scipy_csr_csc_same_result():
     """Decoders built from scipy CSR and CSC of the same matrix produce identical results."""
     scipy_sparse = pytest.importorskip("scipy.sparse")

--- a/libs/qec/python/tests/test_decoder.py
+++ b/libs/qec/python/tests/test_decoder.py
@@ -379,15 +379,6 @@ def test_sort_pcm_columns_invalid_input():
         qec.get_sorted_pcm_column_indices(H_invalid)
 
 
-def test_generate_random_pcm_rejects_too_large_dense_allocation():
-    """Dense random PCM rejects sizes above the dense API limit (~400e6 entries)."""
-    with pytest.raises((ValueError, RuntimeError), match="generate_random_pcm"):
-        qec.generate_random_pcm(n_rounds=1,
-                                n_errs_per_round=25000,
-                                n_syndromes_per_round=20000,
-                                weight=1,
-                                seed=1)
-
 
 def test_gen_random_pcm():
     pcm = qec.generate_random_pcm(n_rounds=10,

--- a/libs/qec/python/tests/test_decoder.py
+++ b/libs/qec/python/tests/test_decoder.py
@@ -406,20 +406,6 @@ def test_gen_random_pcm():
     assert pcm.shape == (100, 200)
 
 
-def test_generate_random_pcm_sparse_matches_dense():
-    """Sparse generator matches dense generate_random_pcm for the same RNG seed."""
-    seed = 99
-    weight = 3
-    pcm_d = qec.generate_random_pcm(4, 5, 3, weight, seed=seed)
-    sp = qec.generate_random_pcm_sparse(4, 5, 3, weight, seed=seed)
-    assert sp["layout"] == "nested_csc"
-    assert sp["num_rows"] == pcm_d.shape[0]
-    assert sp["num_cols"] == pcm_d.shape[1]
-    pcm_s = np.zeros((sp["num_rows"], sp["num_cols"]), dtype=np.uint8)
-    for j, rows in enumerate(sp["nested"]):
-        for ri in rows:
-            pcm_s[int(ri), j] = 1
-    assert np.array_equal(pcm_d, pcm_s)
 
 
 def test_get_pcm_for_rounds():
@@ -541,131 +527,52 @@ def test_decoder_pymatching_results():
 # --- Sparse matrix (sparse_binary_matrix) tests ---
 
 
-def dense_to_nested_csc(H):
-    """Convert dense binary matrix (numpy) to sparse dict with nested_csc layout."""
-    rows, cols = H.shape
-    nested = []
-    for j in range(cols):
-        nested.append([i for i in range(rows) if H[i, j] != 0])
-    return {
-        "layout": "nested_csc",
-        "num_rows": int(rows),
-        "num_cols": int(cols),
-        "nested": nested,
-    }
-
-
-def dense_to_nested_csr(H):
-    """Convert dense binary matrix (numpy) to sparse dict with nested_csr layout."""
-    rows, cols = H.shape
-    nested = []
-    for i in range(rows):
-        nested.append([j for j in range(cols) if H[i, j] != 0])
-    return {
-        "layout": "nested_csr",
-        "num_rows": int(rows),
-        "num_cols": int(cols),
-        "nested": nested,
-    }
-
-
-def scipy_sparse_to_nested_csc(sp):
-    """Convert scipy.sparse (csc or csr) to our sparse dict (nested_csc). Binary only."""
-    sp = sp.tocsc()
-    num_rows, num_cols = sp.shape
-    nested = []
-    for j in range(num_cols):
-        start, end = sp.indptr[j], sp.indptr[j + 1]
-        nested.append(sp.indices[start:end].tolist())
-    return {
-        "layout": "nested_csc",
-        "num_rows": int(num_rows),
-        "num_cols": int(num_cols),
-        "nested": nested,
-    }
-
-
-def scipy_sparse_to_nested_csr(sp):
-    """Convert scipy.sparse (csr or csc) to our sparse dict (nested_csr). Binary only."""
-    sp = sp.tocsr()
-    num_rows, num_cols = sp.shape
-    nested = []
-    for i in range(num_rows):
-        start, end = sp.indptr[i], sp.indptr[i + 1]
-        nested.append(sp.indices[start:end].tolist())
-    return {
-        "layout": "nested_csr",
-        "num_rows": int(num_rows),
-        "num_cols": int(num_cols),
-        "nested": nested,
-    }
-
-
-def test_get_decoder_sparse_nested_csc():
-    """get_decoder with sparse H as dict (nested_csc) produces a working decoder."""
+def test_get_decoder_sparse_csc():
+    """get_decoder with a scipy CSC matrix produces a working decoder."""
+    scipy_sparse = pytest.importorskip("scipy.sparse")
     H_dense = create_test_matrix()
-    H_sparse = dense_to_nested_csc(H_dense)
-    decoder = qec.get_decoder("example_byod", H_sparse)
+    decoder = qec.get_decoder("example_byod", scipy_sparse.csc_matrix(H_dense))
     assert decoder is not None
     assert hasattr(decoder, "decode")
-    syndrome = create_test_syndrome()
-    result = decoder.decode(syndrome)
+    result = decoder.decode(create_test_syndrome())
     assert hasattr(result, "converged")
     assert hasattr(result, "result")
     assert len(result.result) == H_dense.shape[0]
 
 
-def test_get_decoder_sparse_nested_csr():
-    """get_decoder with sparse H as dict (nested_csr) produces a working decoder."""
+def test_get_decoder_sparse_csr():
+    """get_decoder with a scipy CSR matrix produces a working decoder."""
+    scipy_sparse = pytest.importorskip("scipy.sparse")
     H_dense = create_test_matrix()
-    H_sparse = dense_to_nested_csr(H_dense)
-    decoder = qec.get_decoder("example_byod", H_sparse)
+    decoder = qec.get_decoder("example_byod", scipy_sparse.csr_matrix(H_dense))
     assert decoder is not None
     assert hasattr(decoder, "decode")
-    syndrome = create_test_syndrome()
-    result = decoder.decode(syndrome)
+    result = decoder.decode(create_test_syndrome())
     assert hasattr(result, "converged")
     assert hasattr(result, "result")
     assert len(result.result) == H_dense.shape[0]
 
 
 def test_get_decoder_sparse_vs_dense_same_results():
-    """Decoder from sparse H (nested_csc) behaves like dense H: same shape and validity."""
+    """Decoder from scipy sparse H behaves like dense H: same shape and validity."""
+    scipy_sparse = pytest.importorskip("scipy.sparse")
     np.random.seed(123)
     H_dense = np.random.randint(0, 2, (8, 16)).astype(np.uint8)
     syndrome = np.random.random(8).tolist()
 
     dec_dense = qec.get_decoder("example_byod", H_dense)
-    dec_sparse = qec.get_decoder("example_byod", dense_to_nested_csc(H_dense))
+    dec_sparse = qec.get_decoder("example_byod", scipy_sparse.csc_matrix(H_dense))
 
     r_dense = dec_dense.decode(syndrome)
     r_sparse = dec_sparse.decode(syndrome)
 
     assert r_dense.converged == r_sparse.converged
     assert len(r_dense.result) == len(r_sparse.result)
-    assert all(0 <= x <= 1 for x in r_dense.result)
-    assert all(0 <= x <= 1 for x in r_sparse.result)
-
-
-def test_get_decoder_sparse_nested_csr_same_as_csc():
-    """Decoders from nested_csc and nested_csr (same matrix) produce valid results."""
-    H_dense = create_test_matrix()
-    syndrome = create_test_syndrome()
-
-    dec_csc = qec.get_decoder("example_byod", dense_to_nested_csc(H_dense))
-    dec_csr = qec.get_decoder("example_byod", dense_to_nested_csr(H_dense))
-
-    r_csc = dec_csc.decode(syndrome)
-    r_csr = dec_csr.decode(syndrome)
-
-    assert r_csc.converged == r_csr.converged
-    assert len(r_csc.result) == len(r_csr.result) == H_dense.shape[0]
-    assert all(0 <= x <= 1 for x in r_csc.result)
-    assert all(0 <= x <= 1 for x in r_csr.result)
 
 
 def test_get_decoder_sparse_pymatching():
-    """Native pymatching decoder accepts sparse H dict and returns valid result."""
+    """Native pymatching decoder accepts scipy sparse H and returns valid result."""
+    scipy_sparse = pytest.importorskip("scipy.sparse")
     pcm = qec.generate_random_pcm(
         n_rounds=2,
         n_errs_per_round=10,
@@ -674,12 +581,11 @@ def test_get_decoder_sparse_pymatching():
         seed=7,
     )
     pcm, _ = qec.simplify_pcm(pcm, np.ones(pcm.shape[1]), 10)
-    H_sparse = dense_to_nested_csc(pcm)
 
     columns = np.random.choice(pcm.shape[1], 3, replace=False)
     syndrome = (np.sum(pcm[:, columns], axis=1) % 2).tolist()
 
-    decoder = qec.get_decoder("pymatching", H_sparse)
+    decoder = qec.get_decoder("pymatching", scipy_sparse.csc_matrix(pcm))
     result = decoder.decode(syndrome)
     assert result.converged is True
     assert len(result.result) == pcm.shape[1]
@@ -687,63 +593,123 @@ def test_get_decoder_sparse_pymatching():
     assert all(0 <= x <= 1 for x in result.result)
 
 
-def test_get_decoder_sparse_dict_missing_keys():
-    """Sparse dict missing required keys raises RuntimeError."""
-    with pytest.raises(RuntimeError) as exc_info:
-        qec.get_decoder("example_byod", {"layout": "nested_csc"})
-    assert "layout" in str(exc_info.value) or "num_rows" in str(
-        exc_info.value) or "nested" in str(exc_info.value)
-
-
-def test_get_decoder_sparse_dict_invalid_layout():
-    """Sparse dict with invalid layout string raises RuntimeError."""
-    H_sparse = dense_to_nested_csc(create_test_matrix())
-    H_sparse["layout"] = "invalid_layout"
-    with pytest.raises(RuntimeError) as exc_info:
-        qec.get_decoder("example_byod", H_sparse)
-    assert "nested_csc" in str(exc_info.value) or "nested_csr" in str(
-        exc_info.value)
-
-
 def test_get_decoder_sparse_from_scipy():
-    """get_decoder accepts sparse H built from scipy.sparse (converted to our dict)."""
+    """get_decoder accepts a scipy sparse matrix directly."""
     scipy_sparse = pytest.importorskip("scipy.sparse")
     np.random.seed(42)
     H_dense = np.random.randint(0, 2, (6, 12)).astype(np.uint8)
-    H_scipy = scipy_sparse.csr_matrix(H_dense)
-    H_sparse_dict = scipy_sparse_to_nested_csc(H_scipy)
-    decoder = qec.get_decoder("example_byod", H_sparse_dict)
+    decoder = qec.get_decoder("example_byod", scipy_sparse.csr_matrix(H_dense))
     assert decoder is not None
     syndrome = np.random.random(6).tolist()
     result = decoder.decode(syndrome)
     assert result.converged is True
     assert len(result.result) == H_dense.shape[0]
-    assert all(0 <= x <= 1 for x in result.result)
+
+
+def test_get_decoder_scipy_csr_direct():
+    """get_decoder accepts a scipy CSR matrix directly (no dict conversion needed)."""
+    scipy_sparse = pytest.importorskip("scipy.sparse")
+    np.random.seed(0)
+    H_dense = np.random.randint(0, 2, (6, 12)).astype(np.uint8)
+    H_csr = scipy_sparse.csr_matrix(H_dense)
+    decoder = qec.get_decoder("single_error_lut_example", H_csr)
+    assert decoder is not None
+    syndrome = np.zeros(H_dense.shape[0], dtype=np.uint8)
+    result = decoder.decode(syndrome)
+    assert result is not None
+    assert len(result.result) == H_dense.shape[1]
+
+
+def test_get_decoder_scipy_csc_direct():
+    """get_decoder accepts a scipy CSC matrix directly."""
+    scipy_sparse = pytest.importorskip("scipy.sparse")
+    np.random.seed(0)
+    H_dense = np.random.randint(0, 2, (6, 12)).astype(np.uint8)
+    H_csc = scipy_sparse.csc_matrix(H_dense)
+    decoder = qec.get_decoder("single_error_lut_example", H_csc)
+    assert decoder is not None
+    syndrome = np.zeros(H_dense.shape[0], dtype=np.uint8)
+    result = decoder.decode(syndrome)
+    assert result is not None
+    assert len(result.result) == H_dense.shape[1]
+
+
+def test_get_decoder_scipy_csr_csc_same_result():
+    """Decoders built from scipy CSR and CSC of the same matrix produce identical results."""
+    scipy_sparse = pytest.importorskip("scipy.sparse")
+    np.random.seed(7)
+    H_dense = np.random.randint(0, 2, (8, 16)).astype(np.uint8)
+    syndrome = np.zeros(H_dense.shape[0], dtype=np.uint8)
+
+    dec_csr = qec.get_decoder("single_error_lut_example",
+                               scipy_sparse.csr_matrix(H_dense))
+    dec_csc = qec.get_decoder("single_error_lut_example",
+                               scipy_sparse.csc_matrix(H_dense))
+    dec_dense = qec.get_decoder("single_error_lut_example", H_dense)
+
+    res_csr = dec_csr.decode(syndrome)
+    res_csc = dec_csc.decode(syndrome)
+    res_dense = dec_dense.decode(syndrome)
+
+    np.testing.assert_array_equal(res_csr.result, res_dense.result)
+    np.testing.assert_array_equal(res_csc.result, res_dense.result)
+
+
+def test_get_decoder_scipy_int64_indices():
+    """get_decoder handles scipy matrices whose indptr/indices use int64 dtype."""
+    scipy_sparse = pytest.importorskip("scipy.sparse")
+    np.random.seed(0)
+    H_dense = np.random.randint(0, 2, (6, 12)).astype(np.uint8)
+    H_csr = scipy_sparse.csr_matrix(H_dense)
+    # Force int64 index dtype.
+    H_csr = H_csr.astype(H_csr.dtype)
+    H_csr.indptr = H_csr.indptr.astype(np.int64)
+    H_csr.indices = H_csr.indices.astype(np.int64)
+    decoder = qec.get_decoder("single_error_lut_example", H_csr)
+    assert decoder is not None
+    result = decoder.decode(np.zeros(H_dense.shape[0], dtype=np.uint8))
+    assert len(result.result) == H_dense.shape[1]
+
+
+def test_get_decoder_scipy_python_registered_decoder():
+    """Python BYOD factories receive the scipy object unchanged; the decoder
+    can call qec.Decoder.__init__(self, H) with a scipy sparse matrix."""
+    scipy_sparse = pytest.importorskip("scipy.sparse")
+    np.random.seed(0)
+    H_dense = np.random.randint(0, 2, (6, 12)).astype(np.uint8)
+    H_scipy = scipy_sparse.csr_matrix(H_dense)
+
+    @qec.decoder("_test_scipy_byod")
+    class _ScipyByod:
+        def __init__(self, H, **kwargs):
+            qec.Decoder.__init__(self, H)
+            self.H = H
+
+        def decode(self, syndrome):
+            res = qec.DecoderResult()
+            res.converged = True
+            res.result = [0.0] * self.H.shape[1]
+            res.opt_results = None
+            return res
+
+    decoder = qec.get_decoder("_test_scipy_byod", H_scipy)
+    assert decoder is not None
+    assert scipy_sparse.issparse(decoder.H)
+    result = decoder.decode(np.zeros(H_dense.shape[0]))
+    assert len(result.result) == H_dense.shape[1]
 
 
 def test_get_decoder_sparse_python_registered_decoder():
-    """Python BYOD factories receive sparse dict unchanged (no dense to_dense bridge)."""
+    """Python BYOD factories receive the scipy object unchanged."""
+    scipy_sparse = pytest.importorskip("scipy.sparse")
     H_dense = create_test_matrix()
-    H_sparse = dense_to_nested_csc(H_dense)
-    decoder = qec.get_decoder("example_byod", H_sparse)
+    H_scipy = scipy_sparse.csc_matrix(H_dense)
+    decoder = qec.get_decoder("example_byod", H_scipy)
     assert hasattr(decoder, "H")
-    assert isinstance(decoder.H, dict)
-    assert decoder.H["layout"] == "nested_csc"
+    assert scipy_sparse.issparse(decoder.H)
     result = decoder.decode(create_test_syndrome())
     assert result.converged is True
     assert len(result.result) == H_dense.shape[0]
-
-
-def test_pymatching_rejects_duplicate_sparse_input():
-    """PyMatching requires duplicate-free sparse inputs."""
-    sparse_dict = {
-        "layout": "nested_csc",
-        "num_rows": 2,
-        "num_cols": 3,
-        "nested": [[0, 0, 0], [0, 1], [1]],
-    }
-    with pytest.raises(ValueError, match="strictly increasing"):
-        qec.get_decoder("pymatching", sparse_dict)
 
 
 def test_generate_random_pcm_signed_weight_rejects_negative():
@@ -754,12 +720,6 @@ def test_generate_random_pcm_signed_weight_rejects_negative():
                                 n_syndromes_per_round=4,
                                 weight=-1,
                                 seed=1)
-    with pytest.raises((ValueError, RuntimeError), match="weight"):
-        qec.generate_random_pcm_sparse(n_rounds=2,
-                                       n_errs_per_round=3,
-                                       n_syndromes_per_round=4,
-                                       weight=-1,
-                                       seed=1)
 
 
 if __name__ == "__main__":

--- a/libs/qec/python/tests/test_decoder.py
+++ b/libs/qec/python/tests/test_decoder.py
@@ -379,7 +379,6 @@ def test_sort_pcm_columns_invalid_input():
         qec.get_sorted_pcm_column_indices(H_invalid)
 
 
-
 def test_gen_random_pcm():
     pcm = qec.generate_random_pcm(n_rounds=10,
                                   n_errs_per_round=20,
@@ -395,8 +394,6 @@ def test_gen_random_pcm():
     qec.dump_pcm(pcm)
     print('')
     assert pcm.shape == (100, 200)
-
-
 
 
 def test_get_pcm_for_rounds():
@@ -552,7 +549,8 @@ def test_get_decoder_sparse_vs_dense_same_results():
     syndrome = np.random.random(8).tolist()
 
     dec_dense = qec.get_decoder("example_byod", H_dense)
-    dec_sparse = qec.get_decoder("example_byod", scipy_sparse.csc_matrix(H_dense))
+    dec_sparse = qec.get_decoder("example_byod",
+                                 scipy_sparse.csc_matrix(H_dense))
 
     r_dense = dec_dense.decode(syndrome)
     r_sparse = dec_sparse.decode(syndrome)
@@ -633,9 +631,9 @@ def test_get_decoder_scipy_csr_csc_same_result():
     syndrome = np.zeros(H_dense.shape[0], dtype=np.uint8)
 
     dec_csr = qec.get_decoder("single_error_lut_example",
-                               scipy_sparse.csr_matrix(H_dense))
+                              scipy_sparse.csr_matrix(H_dense))
     dec_csc = qec.get_decoder("single_error_lut_example",
-                               scipy_sparse.csc_matrix(H_dense))
+                              scipy_sparse.csc_matrix(H_dense))
     dec_dense = qec.get_decoder("single_error_lut_example", H_dense)
 
     res_csr = dec_csr.decode(syndrome)
@@ -672,6 +670,7 @@ def test_get_decoder_scipy_python_registered_decoder():
 
     @qec.decoder("_test_scipy_byod")
     class _ScipyByod:
+
         def __init__(self, H, **kwargs):
             qec.Decoder.__init__(self, H)
             self.H = H

--- a/libs/qec/python/tests/test_decoder.py
+++ b/libs/qec/python/tests/test_decoder.py
@@ -686,6 +686,44 @@ def test_get_decoder_scipy_explicit_zeros_dropped():
     np.testing.assert_array_equal(res_explicit.result, res_dense.result)
 
 
+def test_get_decoder_scipy_duplicate_unsorted_indices():
+    """Duplicate/unsorted scipy indices are canonicalized to match the dense
+    matrix, and the caller's matrix is left unmodified."""
+    scipy_sparse = pytest.importorskip("scipy.sparse")
+
+    # Non-canonical CSR built directly from raw arrays (scipy does not sort or
+    # merge on construction):
+    #   row 0: cols [2, 1, 1] -> unsorted, with a duplicate at col 1
+    #   row 1: cols [0]
+    # The equivalent dense matrix sums the duplicate, so its nonzero pattern is
+    # [[0, 1, 1], [1, 0, 0]].
+    data = np.array([1, 1, 1, 1], dtype=np.uint8)
+    indices = np.array([2, 1, 1, 0])
+    indptr = np.array([0, 3, 4])
+    H_noncanon = scipy_sparse.csr_matrix((data, indices, indptr), shape=(2, 3))
+    assert not H_noncanon.has_canonical_format
+
+    H_dense = (H_noncanon.toarray() != 0).astype(np.uint8)
+
+    # Snapshot the caller's buffers to confirm get_decoder does not mutate them.
+    before = (H_noncanon.data.copy(), H_noncanon.indices.copy(),
+              H_noncanon.indptr.copy())
+
+    syndrome = np.zeros(H_dense.shape[0], dtype=np.uint8)
+    dec_noncanon = qec.get_decoder("single_error_lut_example", H_noncanon)
+    dec_dense = qec.get_decoder("single_error_lut_example", H_dense)
+
+    res_noncanon = dec_noncanon.decode(syndrome)
+    res_dense = dec_dense.decode(syndrome)
+    np.testing.assert_array_equal(res_noncanon.result, res_dense.result)
+
+    # The input matrix must be untouched (canonicalization happens on a copy).
+    np.testing.assert_array_equal(H_noncanon.data, before[0])
+    np.testing.assert_array_equal(H_noncanon.indices, before[1])
+    np.testing.assert_array_equal(H_noncanon.indptr, before[2])
+    assert not H_noncanon.has_canonical_format
+
+
 def test_get_decoder_scipy_csr_csc_same_result():
     """Decoders built from scipy CSR and CSC of the same matrix produce identical results."""
     scipy_sparse = pytest.importorskip("scipy.sparse")

--- a/libs/qec/unittests/test_sparse_binary_matrix.cpp
+++ b/libs/qec/unittests/test_sparse_binary_matrix.cpp
@@ -607,9 +607,9 @@ TEST(SparseBinaryMatrix, GenerateRandomPcmSparse_RejectsOverflowingRows) {
                std::invalid_argument);
 }
 
-// Shape with rows*cols > k_max_dense_pcm_elements but nnz ~ 2e6: dense path
-// must throw, sparse path must succeed.
-TEST(SparseBinaryMatrix, GenerateRandomPcmSparse_ExceedsDenseCap) {
+// Large sparse PCM (nnz ~ 2e6): sparse path must succeed and produce a
+// well-formed CSC matrix.
+TEST(SparseBinaryMatrix, GenerateRandomPcmSparse_LargeMatrix) {
   constexpr std::size_t n_rounds = 2;
   constexpr std::size_t n_errs_per_round = 250'000;
   constexpr std::size_t n_syndromes_per_round = 1'000;
@@ -617,12 +617,6 @@ TEST(SparseBinaryMatrix, GenerateRandomPcmSparse_ExceedsDenseCap) {
 
   const std::size_t n_cols = n_rounds * n_errs_per_round;
   const std::size_t n_rows = n_rounds * n_syndromes_per_round;
-  ASSERT_GT(n_rows * n_cols, cudaq::qec::k_max_dense_pcm_elements);
-
-  EXPECT_THROW(cudaq::qec::generate_random_pcm(n_rounds, n_errs_per_round,
-                                               n_syndromes_per_round, weight,
-                                               std::mt19937_64(0xC0DEull)),
-               std::invalid_argument);
 
   auto sp = cudaq::qec::generate_random_pcm_sparse(
       n_rounds, n_errs_per_round, n_syndromes_per_round, weight,


### PR DESCRIPTION
## Description

- Remove the custom dict-based sparse H input from `get_decoder`; scipy.sparse matrices (any format) are now the sole sparse input path, detected via duck typing so scipy remains an interoperability target, not a true dependency. (Dense numpy arrays can still be used.)
- Since I want to avoid the custom dict type as a public interface, remove `generate_random_pcm_sparse` Python binding. This function was returning the custom dict type that I don't think we want to maintain going forward. Users can wrap the dense `generate_random_pcm` output in scipy.sparse themselves if they want. We will also probably want to update the interface for `generate_random_pcm` in the future, so I don't want to have a separate function for something that does the same thing. In reality, we will be moving towards more realistic PCM construction techniques anyway, so generating random ones will be less useful.
- Replace PyDecoder(dict) constructor with PyDecoder(scipy_sparse) so that BYOD decoder classes can call qec.Decoder.__init__(self, H) with a scipy sparse matrix
- Update all affected tests: remove dict-helper functions, replace dict-based sparse tests with scipy.sparse equivalents, remove duplicate-sparse test (scipy always deduplicates on tocsr())

## Runtime / performance impact

N/A

## Self-review checklist

Please confirm each item before requesting review. Check `[x]` or strike
through and explain.

### Before requesting review
- [x] I reviewed my own full diff in GitHub or my editor.
- [x] PR is in Draft if it is not yet ready for review.
- [x] Temporary / debugging changes have been removed.
- [x] Local test logs reviewed; no unexplained warnings or errors.
- [x] CI logs reviewed; no unexplained warnings or errors.
- [x] Full CI has been run.

### Scope and size
- [x] PR is under ~1000 lines, or an exception is justified in the description.
- [x] Refactoring-only changes are isolated in their own PR(s).
- [x] No existing tests were disabled or modified just to make this PR pass
      (if so, an issue has been raised). **See above**

### Tests
- [x] New functionality has new tests.
- [x] Tests fail if the new functionality is broken (including crashes), not
      just when it is missing.
- [x] Negative tests added where exceptions are expected.
- [x] Truth data added where simple `EXPECT_*` / `assert` checks are
      insufficient for algorithmic correctness.
- [x] CI runtime impact considered; team notified if significant.

### Documentation
- [x] Public-facing APIs have Doxygen docs.
- [x] User-visible behavior changes have public docs, or a follow-up is
      tracked.

### Code style
- [x] Naming follows the existing convention (`snake_case` vs `camelCase`) for
      the area being modified.

### Dependencies
- [x] No new third-party dependencies, **or** the team has been notified and
      OSRB tickets filed.
