### PR TITLE
Bump cudaq version and match observe_policy changes

### DIFF
--- a/.cudaq_version
+++ b/.cudaq_version
@@ -1,6 +1,6 @@
 {
   "cudaq": {
     "repository": "NVIDIA/cuda-quantum",
-    "ref": "5e064537617924b5f5bf7d4e6b8875704aa1253f"
+    "ref": "8713d25e81639830c59c3d0440b09e897a70cd7b"
   }
 }

--- a/libs/solvers/include/cudaq/solvers/observe_gradient.h
+++ b/libs/solvers/include/cudaq/solvers/observe_gradient.h
@@ -62,10 +62,10 @@ protected:
         "auto_gradient_kernel_calc_" + std::to_string(batchIdx);
     auto result = cudaq::detail::runObservation(
         [&]() { quantumFunction(x); }, const_cast<spin_op &>(op), platform,
-        shots, kernelName, 0, nullptr, batchIdx, numRequiredExpectations);
-    data.emplace_back(x, result.value(), observe_execution_type::gradient);
+        shots, kernelName, 0, batchIdx, numRequiredExpectations);
+    data.emplace_back(x, result, observe_execution_type::gradient);
     batchIdx++;
-    return result.value().expectation();
+    return result.expectation();
   }
 
   /// @brief Compute the gradient at the given multi-dimensional point.


### PR DESCRIPTION
## Description

Bumping cudaq version to 8713d25e81639830c59c3d0440b09e897a70cd7b which introduces the observe_policy.
cudaq-x uses the private runObservation whose signature has changed. This PR adapts to the new signature.

## Runtime / performance impact
N/A

## Self-review checklist

Please confirm each item before requesting review. Check `[x]` or strike
through and explain.

### Before requesting review
- [x] I reviewed my own full diff in GitHub or my editor.
- [ ] PR is in Draft if it is not yet ready for review.
- [x] Temporary / debugging changes have been removed.
- [x] Local test logs reviewed; no unexplained warnings or errors.
- [x] CI logs reviewed; no unexplained warnings or errors.
- [x] Full CI has been run.

### Scope and size
- [x] PR is under ~1000 lines, or an exception is justified in the description.
- [x] Refactoring-only changes are isolated in their own PR(s).
- [x] No existing tests were disabled or modified just to make this PR pass
      (if so, an issue has been raised).

### Tests
- [ ] New functionality has new tests.
- [ ] Tests fail if the new functionality is broken (including crashes), not
      just when it is missing.
- [ ] Negative tests added where exceptions are expected.
- [ ] Truth data added where simple `EXPECT_*` / `assert` checks are
      insufficient for algorithmic correctness.
- [ ] CI runtime impact considered; team notified if significant.

### Documentation
- [ ] Public-facing APIs have Doxygen docs.
- [ ] User-visible behavior changes have public docs, or a follow-up is
      tracked.

### Code style
- [x] Naming follows the existing convention (`snake_case` vs `camelCase`) for
      the area being modified.

### Dependencies
- [x] No new third-party dependencies, **or** the team has been notified and
      OSRB tickets filed.
