### PR TITLE
Add docs and example for decoder construction from Stim DEM strings

### DIFF
--- a/docs/sphinx/api/qec/cpp_api.rst
+++ b/docs/sphinx/api/qec/cpp_api.rst
@@ -33,6 +33,7 @@ Detector Error Model
 .. doxygenfunction:: cudaq::qec::dem_from_memory_circuit(const code &, operation, std::size_t, cudaq::noise_model &)
 .. doxygenfunction:: cudaq::qec::x_dem_from_memory_circuit(const code &, operation, std::size_t, cudaq::noise_model &)
 .. doxygenfunction:: cudaq::qec::z_dem_from_memory_circuit(const code &, operation, std::size_t, cudaq::noise_model &)
+.. doxygenfunction:: cudaq::qec::dem_from_stim_text(const std::string &)
 
 Decoder Interfaces
 ==================

--- a/docs/sphinx/api/qec/python_api.rst
+++ b/docs/sphinx/api/qec/python_api.rst
@@ -32,6 +32,7 @@ Detector Error Model
 .. autofunction:: cudaq_qec.dem_from_memory_circuit
 .. autofunction:: cudaq_qec.x_dem_from_memory_circuit
 .. autofunction:: cudaq_qec.z_dem_from_memory_circuit
+.. autofunction:: cudaq_qec.dem_from_stim_text
 
 Decoder Interfaces
 ==================

--- a/docs/sphinx/examples/qec/cpp/stim_dem_decoder.cpp
+++ b/docs/sphinx/examples/qec/cpp/stim_dem_decoder.cpp
@@ -1,0 +1,60 @@
+/*******************************************************************************
+ * Copyright (c) 2026 NVIDIA Corporation & Affiliates.                         *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+// [Begin Documentation]
+// Compile and run with:
+// nvq++ -lcudaq-qec stim_dem_decoder.cpp
+// ./a.out
+
+#include "cudaq/qec/decoder.h"
+#include "cudaq/qec/detector_error_model.h"
+
+#include <cstdint>
+#include <iostream>
+#include <string>
+#include <vector>
+
+int main() {
+  const std::string dem_text = R"(error(0.1) D0 L0
+error(0.1) D1 L0
+error(0.05) D0 D1
+)";
+
+  auto decoder = cudaq::qec::get_decoder("single_error_lut", dem_text);
+  auto dem = cudaq::qec::dem_from_stim_text(dem_text);
+
+  std::cout << "detectors: " << dem.num_detectors() << "\n";
+  std::cout << "error mechanisms: " << dem.num_error_mechanisms() << "\n";
+  std::cout << "observables: " << dem.num_observables() << "\n";
+
+  const std::vector<std::vector<cudaq::qec::float_t>> syndromes = {
+      {0.0, 0.0}, {1.0, 0.0}, {0.0, 1.0}, {1.0, 1.0}};
+
+  for (const auto &syndrome : syndromes) {
+    auto result = decoder->decode(syndrome);
+
+    std::cout << "syndrome [" << syndrome[0] << ", " << syndrome[1] << "]"
+              << " -> error [";
+    for (std::size_t i = 0; i < result.result.size(); ++i) {
+      if (i > 0)
+        std::cout << ", ";
+      std::cout << result.result[i];
+    }
+    std::cout << "] -> observable flip [";
+    for (std::size_t obs = 0; obs < dem.num_observables(); ++obs) {
+      if (obs > 0)
+        std::cout << ", ";
+      std::uint8_t flip = 0;
+      for (std::size_t error = 0; error < result.result.size(); ++error)
+        flip ^= static_cast<std::uint8_t>(
+            dem.observables_flips_matrix.at({obs, error}) &&
+            result.result[error] != 0.0);
+      std::cout << static_cast<int>(flip);
+    }
+    std::cout << "]\n";
+  }
+}

--- a/docs/sphinx/examples/qec/python/stim_dem_decoder.py
+++ b/docs/sphinx/examples/qec/python/stim_dem_decoder.py
@@ -1,0 +1,35 @@
+# ============================================================================ #
+# Copyright (c) 2026 NVIDIA Corporation & Affiliates.                          #
+# All rights reserved.                                                         #
+#                                                                              #
+# This source code and the accompanying materials are made available under     #
+# the terms of the Apache License 2.0 which accompanies this distribution.     #
+# ============================================================================ #
+# [Begin Documentation]
+import numpy as np
+import cudaq_qec as qec
+
+dem_text = """\
+error(0.1) D0 L0
+error(0.1) D1 L0
+error(0.05) D0 D1
+"""
+
+decoder = qec.get_decoder("single_error_lut", dem_text)
+dem = qec.dem_from_stim_text(dem_text)
+
+print("detectors:", dem.num_detectors())
+print("error mechanisms:", dem.num_error_mechanisms())
+print("observables:", dem.num_observables())
+
+syndromes = np.array([[0, 0], [1, 0], [0, 1], [1, 1]], dtype=np.uint8)
+results = decoder.decode_batch(syndromes)
+error_predictions = np.array([r.result for r in results], dtype=np.uint8)
+observable_predictions = (dem.observables_flips_matrix @
+                          error_predictions.T) % 2
+
+for syndrome, error, observable in zip(syndromes, error_predictions,
+                                       observable_predictions.T):
+    print(f"syndrome {syndrome.tolist()} -> "
+          f"error {error.tolist()} -> "
+          f"observable flip {observable.tolist()}")

--- a/docs/sphinx/examples/qec/python/stim_dem_decoder.py
+++ b/docs/sphinx/examples/qec/python/stim_dem_decoder.py
@@ -25,8 +25,8 @@ print("observables:", dem.num_observables())
 syndromes = np.array([[0, 0], [1, 0], [0, 1], [1, 1]], dtype=np.uint8)
 results = decoder.decode_batch(syndromes)
 error_predictions = np.array([r.result for r in results], dtype=np.uint8)
-observable_predictions = (dem.observables_flips_matrix @
-                          error_predictions.T) % 2
+observable_predictions = (
+    dem.observables_flips_matrix @ error_predictions.T) % 2
 
 for syndrome, error, observable in zip(syndromes, error_predictions,
                                        observable_predictions.T):

--- a/docs/sphinx/examples_rst/qec/decoders.rst
+++ b/docs/sphinx/examples_rst/qec/decoders.rst
@@ -19,6 +19,10 @@ canonical form that's organized by measurement rounds, making it suitable for mu
 
 For a complete example of using the surface code with DEM to generate parity check matrices and perform decoding, see the :doc:`circuit level noise example <circuit_level_noise>`.
 
+If a Stim detector error model is already available as text, the same decoder
+entry point can consume that text directly. See :doc:`Decoding From Stim DEM Text <stim_dem_decoder>`
+for a C++ and Python example.
+
 Generating a Multi-Round Parity Check Matrix
 ++++++++++++++++++++++++++++++++++++++++++++
 

--- a/docs/sphinx/examples_rst/qec/examples.rst
+++ b/docs/sphinx/examples_rst/qec/examples.rst
@@ -9,6 +9,7 @@ Examples that illustrate how to use CUDA-QX for application development are avai
 
       Code-Capacity QEC <code_capacity_noise.rst>
       Circuit-Level QEC <circuit_level_noise.rst>
+      Decoding From Stim DEM Text <stim_dem_decoder.rst>
       Decoders <decoders.rst>
       Real-Time Decoding <realtime_decoding.rst>
       AI Predecoder with CUDA-Q Realtime <realtime_predecoder_pymatching.rst>

--- a/docs/sphinx/examples_rst/qec/stim_dem_decoder.rst
+++ b/docs/sphinx/examples_rst/qec/stim_dem_decoder.rst
@@ -1,0 +1,31 @@
+Decoding From Stim DEM Text
+---------------------------
+
+CUDA-Q QEC decoders can be constructed from either a parity-check matrix or raw
+Stim detector error model (DEM) text. Passing the DEM text is useful when the
+model is already available in Stim's ``.dem`` format, such as from a saved file,
+Stim workflow, or CUDA-Q DEM generation.
+
+For PCM-based decoders, CUDA-Q QEC parses the DEM text into a detector error
+matrix and supplies DEM-derived ``O`` and ``error_rate_vec`` defaults when the
+user does not provide them. C++ decoder plugins that need full Stim DEM
+metadata can consume the raw DEM string from the decoder construction input.
+
+.. tab:: Python
+
+   .. literalinclude:: ../../examples/qec/python/stim_dem_decoder.py
+      :language: python
+      :start-after: [Begin Documentation]
+
+.. tab:: C++
+
+   .. literalinclude:: ../../examples/qec/cpp/stim_dem_decoder.cpp
+      :language: cpp
+      :start-after: [Begin Documentation]
+
+   Compile and run with
+
+   .. code-block:: bash
+
+      nvq++ -lcudaq-qec stim_dem_decoder.cpp -o stim_dem_decoder
+      ./stim_dem_decoder

--- a/libs/qec/include/cudaq/qec/detector_error_model.h
+++ b/libs/qec/include/cudaq/qec/detector_error_model.h
@@ -70,7 +70,7 @@ struct detector_error_model {
 };
 
 /// Parse Stim DEM text into detector/observable flip matrices and error rates.
-/// This is lossy; DEM-native decoders should consume raw DEM text instead.
+/// DEM-native decoders should consume raw DEM text instead.
 detector_error_model dem_from_stim_text(const std::string &dem_text);
 
 } // namespace cudaq::qec


### PR DESCRIPTION
## Description

Updates QEC docs and adds public C++ and Python examples for decoder construction from Stim DEM strings.

Closes: https://github.com/NVIDIA/cudaqx/issues/595

## Runtime / performance impact

N/A. Documentation/example-only change.

## Self-review checklist

Please confirm each item before requesting review. Check `[x]` or strike
through and explain.

### Before requesting review
- [x] I reviewed my own full diff in GitHub or my editor.
- [ ] PR is in Draft if it is not yet ready for review.
- [x] Temporary / debugging changes have been removed.
- [x] Local test logs reviewed; no unexplained warnings or errors.
- [x] CI logs reviewed; no unexplained warnings or errors.
- [x] Full CI has been run.

### Scope and size
- [x] PR is under ~1000 lines, or an exception is justified in the description.
- [ ] Refactoring-only changes are isolated in their own PR(s).
- [x] No existing tests were disabled or modified just to make this PR pass
      (if so, an issue has been raised).

### Tests
- [ ] New functionality has new tests: Docs/example-only PR; runtime functionality is covered by #571 tests.
- [ ] Tests fail if the new functionality is broken (including crashes), not
      just when it is missing: N/A, no runtime behavior added.
- [ ] Negative tests added where exceptions are expected: N/A
- [ ] Truth data added where simple `EXPECT_*` / `assert` checks are
      insufficient for algorithmic correctness: N/A
- [x] CI runtime impact considered; team notified if significant.

### Documentation
- [x] Public-facing APIs have Doxygen docs.
- [x] User-visible behavior changes have public docs, or a follow-up is
      tracked.

### Code style
- [x] Naming follows the existing convention (`snake_case` vs `camelCase`) for
      the area being modified.

### Dependencies
- [x] No new third-party dependencies, **or** the team has been notified and
      OSRB tickets filed.
