### PR TITLE
Make canonicalization a member of sparse_binary_matrix

### DIFF
--- a/libs/qec/include/cudaq/qec/pcm_utils.h
+++ b/libs/qec/include/cudaq/qec/pcm_utils.h
@@ -180,7 +180,8 @@ get_pcm_for_rounds(const cudaqx::tensor<uint8_t> &pcm,
 /// the dense overload.
 ///
 /// @param pcm_is_canonical If true, the caller asserts \p pcm has
-/// sorted-unique per-group indices (i.e. is the output of `canonicalize_pcm`
+/// sorted-unique per-group indices (i.e. is the output of
+/// `sparse_binary_matrix::canonicalize`
 /// or was constructed canonically). In that case the per-call
 /// canonicalization step is skipped — useful for callers like
 /// `sliding_window` that canonicalize once at construction and then call
@@ -229,18 +230,6 @@ sparse_binary_matrix
 generate_random_pcm_sparse(std::size_t n_rounds, std::size_t n_errs_per_round,
                            std::size_t n_syndromes_per_round, int weight,
                            std::mt19937_64 &&rng);
-
-/// @brief Return a GF(2)-canonical copy of \p pcm: each column (CSC) or row
-/// (CSR) has its indices sorted ascending, and duplicate indices are XOR-
-/// merged — an index that appears \p k times is kept iff \p k is odd. The
-/// output has the same layout as the input and is idempotent under further
-/// `canonicalize_pcm` calls.
-///
-/// Use this when a PCM source, such as a DEM decomposition, may legitimately
-/// emit duplicate indices within a column/row and the caller wants to apply
-/// GF(2) duplicate-collapse semantics before passing the matrix to consumers
-/// that require at-most-one entry per row per column.
-sparse_binary_matrix canonicalize_pcm(const sparse_binary_matrix &pcm);
 
 /// @brief Randomly permute the columns of a PCM.
 /// @param pcm The PCM to permute.

--- a/libs/qec/include/cudaq/qec/sparse_binary_matrix.h
+++ b/libs/qec/include/cudaq/qec/sparse_binary_matrix.h
@@ -98,6 +98,11 @@ public:
   /// indices sorted ascending, and duplicate indices are XOR-merged. An index
   /// that appears k times is kept iff k is odd. The output has the same layout
   /// as the input and is idempotent under further `canonicalize` calls.
+  ///
+  /// Use this when a PCM source, such as a DEM decomposition, may emit
+  /// duplicate indices within a compressed group and the caller wants GF(2)
+  /// duplicate-collapse semantics before passing the matrix to consumers that
+  /// require at most one entry per row/column.
   sparse_binary_matrix canonicalize() const;
 
   /// @brief Return a copy of this matrix in CSC layout. No-op if already CSC.

--- a/libs/qec/include/cudaq/qec/sparse_binary_matrix.h
+++ b/libs/qec/include/cudaq/qec/sparse_binary_matrix.h
@@ -23,7 +23,7 @@ enum class sparse_binary_matrix_layout { csc, csr };
 /// Input index lists are stored as given: not required to be sorted or
 /// GF(2)-unique. Consumers that require cuSPARSE-style compressed groups can
 /// call `validate_sorted_unique_indices`; consumers that need GF(2)-collapsed
-/// per-group indices can call `cudaq::qec::canonicalize_pcm` on entry.
+/// per-group indices can call `canonicalize` on entry.
 ///
 /// `index_type` is `uint32_t`, so each dimension and `nnz` must fit in
 /// `~4×10^9`.
@@ -93,6 +93,12 @@ public:
   /// increasing indices. This rejects duplicate entries in the stored layout.
   void validate_sorted_unique_indices(
       const char *context = "sparse_binary_matrix") const;
+
+  /// @brief Return a GF(2)-canonical copy: each compressed column/row has its
+  /// indices sorted ascending, and duplicate indices are XOR-merged. An index
+  /// that appears k times is kept iff k is odd. The output has the same layout
+  /// as the input and is idempotent under further `canonicalize` calls.
+  sparse_binary_matrix canonicalize() const;
 
   /// @brief Return a copy of this matrix in CSC layout. No-op if already CSC.
   sparse_binary_matrix to_csc() const;

--- a/libs/qec/lib/decoders/lut.cpp
+++ b/libs/qec/lib/decoders/lut.cpp
@@ -117,7 +117,7 @@ public:
       }
     }
 
-    // No canonicalize_pcm: toggleSynForError XORs per row index, so duplicate
+    // No canonicalize: toggleSynForError XORs per row index, so duplicate
     // indices in a column GF(2)-cancel naturally.
     std::vector<std::vector<std::uint32_t>> H_e2d = H.to_nested_csc();
     auto toggleSynForError = [&H_e2d](std::string &err_sig, std::size_t qErr) {

--- a/libs/qec/lib/decoders/plugins/example/single_error_lut_example.cpp
+++ b/libs/qec/lib/decoders/plugins/example/single_error_lut_example.cpp
@@ -7,7 +7,6 @@
  ******************************************************************************/
 
 #include "cudaq/qec/decoder.h"
-#include "cudaq/qec/pcm_utils.h"
 #include <cassert>
 #include <map>
 #include <vector>
@@ -30,7 +29,7 @@ public:
     // The loop below sets err_sig[r] = '1' (not XOR-toggle), so canonicalize
     // to drop GF(2)-duplicate row indices first.
     std::vector<std::vector<std::uint32_t>> H_e2d =
-        cudaq::qec::canonicalize_pcm(H).to_nested_csc();
+        H.canonicalize().to_nested_csc();
 
     for (std::size_t qErr = 0; qErr < block_size; qErr++) {
       std::string err_sig(syndrome_size, '0');

--- a/libs/qec/lib/decoders/sliding_window.cpp
+++ b/libs/qec/lib/decoders/sliding_window.cpp
@@ -182,7 +182,7 @@ sliding_window::sliding_window(const cudaq::qec::sparse_binary_matrix &H,
                                const cudaqx::heterogeneous_map &params)
     // Canonical CSC is the steady-state contract for decode_window's column
     // slices and for validate_inputs's per-column .front()/.back() reads.
-    : decoder(canonicalize_pcm(H).to_csc()) {
+    : decoder(H.canonicalize().to_csc()) {
   // Fetch parameters from the params map.
   window_size = params.get<std::size_t>("window_size", window_size);
   step_size = params.get<std::size_t>("step_size", step_size);

--- a/libs/qec/lib/pcm_utils.cpp
+++ b/libs/qec/lib/pcm_utils.cpp
@@ -465,7 +465,7 @@ get_pcm_for_rounds(const sparse_binary_matrix &pcm,
   // which requires sorted-per-column input. Canonicalize unless the caller
   // opts out via \p pcm_is_canonical.
   auto row_indices = pcm_is_canonical ? pcm.to_nested_csc()
-                                      : canonicalize_pcm(pcm).to_nested_csc();
+                                      : pcm.canonicalize().to_nested_csc();
   std::vector<std::uint32_t> columns_in_range;
   std::uint32_t first_column = 0, last_column = 0;
   select_pcm_columns_for_round_range(
@@ -628,60 +628,6 @@ generate_random_pcm_sparse(std::size_t n_rounds, std::size_t n_errs_per_round,
   return sparse_binary_matrix::from_nested_csc(
       static_cast<sparse_binary_matrix::index_type>(n_rows),
       static_cast<sparse_binary_matrix::index_type>(n_cols), nested);
-}
-
-sparse_binary_matrix canonicalize_pcm(const sparse_binary_matrix &pcm) {
-  // Sort each per-group index list, then GF(2)-collapse equal-value runs
-  // (keep one iff the run length is odd).
-  using index_type = sparse_binary_matrix::index_type;
-  const auto &in_ptr = pcm.ptr();
-  const auto &in_idx = pcm.indices();
-  const bool is_csc = pcm.layout() == sparse_binary_matrix_layout::csc;
-  // num_groups from dims (not in_ptr.size()) so default-constructed pcm
-  // still produces a num_groups+1 ptr vector.
-  const std::size_t num_groups = is_csc
-                                     ? static_cast<std::size_t>(pcm.num_cols())
-                                     : static_cast<std::size_t>(pcm.num_rows());
-
-  std::vector<index_type> new_ptr(num_groups + 1, 0);
-  std::vector<index_type> new_idx;
-  new_idx.reserve(in_idx.size());
-
-  std::vector<index_type> scratch;
-  const bool ptr_is_valid = in_ptr.size() == num_groups + 1;
-  if (ptr_is_valid) {
-    std::size_t max_group_size = 0;
-    for (std::size_t g = 0; g < num_groups; ++g)
-      max_group_size =
-          std::max<std::size_t>(max_group_size, in_ptr[g + 1] - in_ptr[g]);
-    scratch.reserve(max_group_size);
-  }
-
-  for (std::size_t g = 0; g < num_groups && ptr_is_valid; ++g) {
-    const auto begin = in_ptr[g];
-    const auto end = in_ptr[g + 1];
-    scratch.assign(in_idx.begin() + begin, in_idx.begin() + end);
-    std::sort(scratch.begin(), scratch.end());
-    auto read = scratch.begin();
-    while (read != scratch.end()) {
-      const index_type val = *read;
-      auto run_end = read;
-      while (run_end != scratch.end() && *run_end == val)
-        ++run_end;
-      if (((run_end - read) & 1) != 0)
-        new_idx.push_back(val);
-      read = run_end;
-    }
-    new_ptr[g + 1] = static_cast<index_type>(new_idx.size());
-  }
-  new_idx.shrink_to_fit();
-
-  return is_csc ? sparse_binary_matrix::from_csc(pcm.num_rows(), pcm.num_cols(),
-                                                 std::move(new_ptr),
-                                                 std::move(new_idx))
-                : sparse_binary_matrix::from_csr(pcm.num_rows(), pcm.num_cols(),
-                                                 std::move(new_ptr),
-                                                 std::move(new_idx));
 }
 
 /// @brief Randomly permute the columns of a PCM.

--- a/libs/qec/lib/sparse_binary_matrix.cpp
+++ b/libs/qec/lib/sparse_binary_matrix.cpp
@@ -86,6 +86,56 @@ void sparse_binary_matrix::validate_sorted_unique_indices(
   }
 }
 
+sparse_binary_matrix sparse_binary_matrix::canonicalize() const {
+  // Sort each per-group index list, then GF(2)-collapse equal-value runs
+  // (keep one iff the run length is odd).
+  const bool is_csc = layout_ == sparse_binary_matrix_layout::csc;
+  // num_groups from dims (not ptr_.size()) so default-constructed matrices
+  // still produce a num_groups+1 ptr vector.
+  const std::size_t num_groups = is_csc ? static_cast<std::size_t>(num_cols_)
+                                        : static_cast<std::size_t>(num_rows_);
+
+  std::vector<index_type> new_ptr(num_groups + 1, 0);
+  std::vector<index_type> new_idx;
+  new_idx.reserve(indices_.size());
+
+  std::vector<index_type> scratch;
+  const bool ptr_is_valid = ptr_.size() == num_groups + 1;
+  if (ptr_is_valid) {
+    std::size_t max_group_size = 0;
+    for (std::size_t g = 0; g < num_groups; ++g)
+      max_group_size =
+          std::max<std::size_t>(max_group_size, ptr_[g + 1] - ptr_[g]);
+    scratch.reserve(max_group_size);
+  }
+
+  for (std::size_t g = 0; g < num_groups && ptr_is_valid; ++g) {
+    const auto begin = ptr_[g];
+    const auto end = ptr_[g + 1];
+    scratch.assign(indices_.begin() + begin, indices_.begin() + end);
+    std::sort(scratch.begin(), scratch.end());
+    auto read = scratch.begin();
+    while (read != scratch.end()) {
+      const index_type val = *read;
+      auto run_end = read;
+      while (run_end != scratch.end() && *run_end == val)
+        ++run_end;
+      if (((run_end - read) & 1) != 0)
+        new_idx.push_back(val);
+      read = run_end;
+    }
+    new_ptr[g + 1] = static_cast<index_type>(new_idx.size());
+  }
+  new_idx.shrink_to_fit();
+
+  return is_csc ? sparse_binary_matrix::from_csc(num_rows_, num_cols_,
+                                                 std::move(new_ptr),
+                                                 std::move(new_idx))
+                : sparse_binary_matrix::from_csr(num_rows_, num_cols_,
+                                                 std::move(new_ptr),
+                                                 std::move(new_idx));
+}
+
 sparse_binary_matrix
 sparse_binary_matrix::from_csc(index_type num_rows, index_type num_cols,
                                std::vector<index_type> col_ptrs,

--- a/libs/qec/unittests/test_sparse_binary_matrix.cpp
+++ b/libs/qec/unittests/test_sparse_binary_matrix.cpp
@@ -448,7 +448,7 @@ TEST(SparseBinaryMatrix, ValidateSortedUniqueIndicesRejectsUnsortedCsr) {
 // sparse_binary_matrix::canonicalize (GF(2) merge)
 // -----------------------------------------------------------------------------
 
-TEST(SparseBinaryMatrix, CanonicalizePcm_NoOpOnAlreadyCanonical) {
+TEST(SparseBinaryMatrix, Canonicalize_NoOpOnAlreadyCanonical) {
   // Column 0: {0,1}, column 1: {1,2}. No duplicates → output identical.
   std::vector<std::vector<index_type>> nested = {{0, 1}, {1, 2}};
   auto sp = sparse_binary_matrix::from_nested_csc(3, 2, nested);
@@ -457,7 +457,7 @@ TEST(SparseBinaryMatrix, CanonicalizePcm_NoOpOnAlreadyCanonical) {
   EXPECT_EQ(canon.num_nnz(), 4u);
 }
 
-TEST(SparseBinaryMatrix, CanonicalizePcm_EvenCountDropsEntry) {
+TEST(SparseBinaryMatrix, Canonicalize_EvenCountDropsEntry) {
   // Column 0 has row 1 listed twice; GF(2) merge → drop both.
   std::vector<std::vector<index_type>> nested = {{1, 1}, {0}};
   auto sp = sparse_binary_matrix::from_nested_csc(3, 2, nested);
@@ -468,7 +468,7 @@ TEST(SparseBinaryMatrix, CanonicalizePcm_EvenCountDropsEntry) {
   EXPECT_EQ(canon_nested[1], (std::vector<index_type>{0}));
 }
 
-TEST(SparseBinaryMatrix, CanonicalizePcm_OddCountKeepsOne) {
+TEST(SparseBinaryMatrix, Canonicalize_OddCountKeepsOne) {
   // Row 2 listed three times in column 0 → odd count → one entry survives.
   std::vector<std::vector<index_type>> nested = {{2, 2, 2}, {}};
   auto sp = sparse_binary_matrix::from_nested_csc(3, 2, nested);
@@ -477,7 +477,7 @@ TEST(SparseBinaryMatrix, CanonicalizePcm_OddCountKeepsOne) {
   EXPECT_EQ(canon_nested[0], (std::vector<index_type>{2}));
 }
 
-TEST(SparseBinaryMatrix, CanonicalizePcm_SortsAscending) {
+TEST(SparseBinaryMatrix, Canonicalize_SortsAscending) {
   // Unsorted, no duplicates → output sorted, same nnz.
   std::vector<std::vector<index_type>> nested = {{2, 0, 1}};
   auto sp = sparse_binary_matrix::from_nested_csc(3, 1, nested);
@@ -485,7 +485,7 @@ TEST(SparseBinaryMatrix, CanonicalizePcm_SortsAscending) {
   EXPECT_EQ(canon.to_nested_csc()[0], (std::vector<index_type>{0, 1, 2}));
 }
 
-TEST(SparseBinaryMatrix, CanonicalizePcm_Idempotent) {
+TEST(SparseBinaryMatrix, Canonicalize_Idempotent) {
   std::vector<std::vector<index_type>> nested = {{2, 0, 2, 1, 1, 1}};
   auto sp = sparse_binary_matrix::from_nested_csc(3, 1, nested);
   auto once = sp.canonicalize();
@@ -575,7 +575,7 @@ TEST(SparseBinaryMatrix,
   }
 }
 
-TEST(SparseBinaryMatrix, CanonicalizePcm_PreservesCsrLayout) {
+TEST(SparseBinaryMatrix, Canonicalize_PreservesCsrLayout) {
   std::vector<std::vector<index_type>> nested_csr = {{0, 0, 1}, {1, 2}};
   auto sp = sparse_binary_matrix::from_nested_csr(2, 3, nested_csr);
   auto canon = sp.canonicalize();

--- a/libs/qec/unittests/test_sparse_binary_matrix.cpp
+++ b/libs/qec/unittests/test_sparse_binary_matrix.cpp
@@ -445,14 +445,14 @@ TEST(SparseBinaryMatrix, ValidateSortedUniqueIndicesRejectsUnsortedCsr) {
 }
 
 // -----------------------------------------------------------------------------
-// canonicalize_pcm (GF(2) merge)
+// sparse_binary_matrix::canonicalize (GF(2) merge)
 // -----------------------------------------------------------------------------
 
 TEST(SparseBinaryMatrix, CanonicalizePcm_NoOpOnAlreadyCanonical) {
   // Column 0: {0,1}, column 1: {1,2}. No duplicates → output identical.
   std::vector<std::vector<index_type>> nested = {{0, 1}, {1, 2}};
   auto sp = sparse_binary_matrix::from_nested_csc(3, 2, nested);
-  auto canon = cudaq::qec::canonicalize_pcm(sp);
+  auto canon = sp.canonicalize();
   EXPECT_TRUE(dense_pcm_equal(sp.to_dense(), canon.to_dense()));
   EXPECT_EQ(canon.num_nnz(), 4u);
 }
@@ -461,7 +461,7 @@ TEST(SparseBinaryMatrix, CanonicalizePcm_EvenCountDropsEntry) {
   // Column 0 has row 1 listed twice; GF(2) merge → drop both.
   std::vector<std::vector<index_type>> nested = {{1, 1}, {0}};
   auto sp = sparse_binary_matrix::from_nested_csc(3, 2, nested);
-  auto canon = cudaq::qec::canonicalize_pcm(sp);
+  auto canon = sp.canonicalize();
   EXPECT_EQ(canon.num_nnz(), 1u);
   auto canon_nested = canon.to_nested_csc();
   EXPECT_TRUE(canon_nested[0].empty());
@@ -472,7 +472,7 @@ TEST(SparseBinaryMatrix, CanonicalizePcm_OddCountKeepsOne) {
   // Row 2 listed three times in column 0 → odd count → one entry survives.
   std::vector<std::vector<index_type>> nested = {{2, 2, 2}, {}};
   auto sp = sparse_binary_matrix::from_nested_csc(3, 2, nested);
-  auto canon = cudaq::qec::canonicalize_pcm(sp);
+  auto canon = sp.canonicalize();
   auto canon_nested = canon.to_nested_csc();
   EXPECT_EQ(canon_nested[0], (std::vector<index_type>{2}));
 }
@@ -481,15 +481,15 @@ TEST(SparseBinaryMatrix, CanonicalizePcm_SortsAscending) {
   // Unsorted, no duplicates → output sorted, same nnz.
   std::vector<std::vector<index_type>> nested = {{2, 0, 1}};
   auto sp = sparse_binary_matrix::from_nested_csc(3, 1, nested);
-  auto canon = cudaq::qec::canonicalize_pcm(sp);
+  auto canon = sp.canonicalize();
   EXPECT_EQ(canon.to_nested_csc()[0], (std::vector<index_type>{0, 1, 2}));
 }
 
 TEST(SparseBinaryMatrix, CanonicalizePcm_Idempotent) {
   std::vector<std::vector<index_type>> nested = {{2, 0, 2, 1, 1, 1}};
   auto sp = sparse_binary_matrix::from_nested_csc(3, 1, nested);
-  auto once = cudaq::qec::canonicalize_pcm(sp);
-  auto twice = cudaq::qec::canonicalize_pcm(once);
+  auto once = sp.canonicalize();
+  auto twice = once.canonicalize();
   EXPECT_TRUE(dense_pcm_equal(once.to_dense(), twice.to_dense()));
   EXPECT_EQ(once.num_nnz(), twice.num_nnz());
 }
@@ -557,8 +557,7 @@ TEST(SparseBinaryMatrix,
                                                /*weight=*/2, std::move(rng));
   auto sorted =
       cudaq::qec::sort_pcm_columns(dense, /*num_syndromes_per_round=*/3);
-  auto canonical =
-      cudaq::qec::canonicalize_pcm(sparse_binary_matrix(sorted)).to_csc();
+  auto canonical = sparse_binary_matrix(sorted).canonicalize().to_csc();
 
   constexpr std::uint32_t kSp = 3;
   for (bool straddle_start : {false, true}) {
@@ -579,7 +578,7 @@ TEST(SparseBinaryMatrix,
 TEST(SparseBinaryMatrix, CanonicalizePcm_PreservesCsrLayout) {
   std::vector<std::vector<index_type>> nested_csr = {{0, 0, 1}, {1, 2}};
   auto sp = sparse_binary_matrix::from_nested_csr(2, 3, nested_csr);
-  auto canon = cudaq::qec::canonicalize_pcm(sp);
+  auto canon = sp.canonicalize();
   EXPECT_EQ(canon.layout(), sparse_binary_matrix_layout::csr);
   EXPECT_EQ(canon.to_nested_csr()[0], (std::vector<index_type>{1}));
   EXPECT_EQ(canon.to_nested_csr()[1], (std::vector<index_type>{1, 2}));
@@ -640,8 +639,8 @@ TEST(SparseBinaryMatrix, GenerateRandomPcmSparse_LargeMatrix) {
       ASSERT_LT(idx[p], static_cast<index_type>(n_rows));
   }
 
-  // canonicalize_pcm must be a content-preserving no-op on canonical input.
-  auto canon = cudaq::qec::canonicalize_pcm(sp);
+  // canonicalize must be a content-preserving no-op on canonical input.
+  auto canon = sp.canonicalize();
   EXPECT_EQ(canon.num_rows(), sp.num_rows());
   EXPECT_EQ(canon.num_cols(), sp.num_cols());
   EXPECT_EQ(canon.num_nnz(), sp.num_nnz());


### PR DESCRIPTION
<!--
Thanks for contributing to CUDA-Q Libraries!

Please read the full Pull Request Guidelines in Contributing.md:
https://github.com/NVIDIA/cudaqx/blob/main/Contributing.md#pull-request-guidelines
-->

## Description

This PR moves sparse PCM GF(2) canonicalization from the free `canonicalize_pcm` helper to `sparse_binary_matrix::canonicalize()`.

Related: https://github.com/NVIDIA/cudaqx/issues/582

## Runtime / performance impact

N/A

## Self-review checklist

Please confirm each item before requesting review. Check `[x]` or strike
through and explain.

### Before requesting review
- [x] I reviewed my own full diff in GitHub or my editor.
- [x] PR is in Draft if it is not yet ready for review.
- [x] Temporary / debugging changes have been removed.
- [x] Local test logs reviewed; no unexplained warnings or errors.
- [x] CI logs reviewed; no unexplained warnings or errors.
- [x] Full CI has been run.

### Scope and size
- [x] PR is under ~1000 lines, or an exception is justified in the description.
- [x] Refactoring-only changes are isolated in their own PR(s).
- [x] No existing tests were disabled or modified just to make this PR pass
      (if so, an issue has been raised).

### Tests
- [x] New functionality has new tests.
- [x] Tests fail if the new functionality is broken (including crashes), not
      just when it is missing.
- [x] Negative tests added where exceptions are expected.
- [x] Truth data added where simple `EXPECT_*` / `assert` checks are
      insufficient for algorithmic correctness.
- [x] CI runtime impact considered; team notified if significant.

### Documentation
- [x] Public-facing APIs have Doxygen docs.
- [x] User-visible behavior changes have public docs, or a follow-up is
      tracked.

### Code style
- [x] Naming follows the existing convention (`snake_case` vs `camelCase`) for
      the area being modified.

### Dependencies
- [x] No new third-party dependencies, **or** the team has been notified and
      OSRB tickets filed.
