### PR TITLE
Add PyMatching HOST_CALL decoder-server RPC path

### DIFF
--- a/libs/qec/include/cudaq/qec/realtime/decoder_rpc_ids.h
+++ b/libs/qec/include/cudaq/qec/realtime/decoder_rpc_ids.h
@@ -1,0 +1,71 @@
+/****************************************************************-*- C++ -*-****
+ * Copyright (c) 2024 - 2026 NVIDIA Corporation & Affiliates.                  *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+#pragma once
+
+#include "cudaq/realtime/daemon/dispatcher/dispatch_kernel_launch.h"
+
+#include <cstddef>
+#include <cstdint>
+
+namespace cudaq::qec::decoding::rpc {
+
+constexpr std::uint32_t kEnqueueSyndromesFunctionId =
+    cudaq::realtime::fnv1a_hash("enqueue_syndromes");
+constexpr std::uint32_t kGetCorrectionsFunctionId =
+    cudaq::realtime::fnv1a_hash("get_corrections");
+constexpr std::uint32_t kResetDecoderFunctionId =
+    cudaq::realtime::fnv1a_hash("reset_decoder");
+
+static_assert(kEnqueueSyndromesFunctionId == 0x7ED8BE82u,
+              "enqueue_syndromes function_id must match "
+              "decoder_server_runtime.md");
+static_assert(kGetCorrectionsFunctionId == 0x882D5BA1u,
+              "get_corrections function_id must match "
+              "decoder_server_runtime.md");
+static_assert(kResetDecoderFunctionId == 0x977A59CFu,
+              "reset_decoder function_id must match "
+              "decoder_server_runtime.md");
+
+struct __attribute__((packed)) EnqueueRequestPayload {
+  std::int64_t decoder_id;          ///< arg0
+  std::int64_t counter;             ///< arg1
+  std::int64_t syndrome_mapping_id; ///< arg2
+  std::int64_t num_syndromes;       ///< arg3 (# syndrome bits following)
+  // Trailing: ceil(num_syndromes/8) bit-packed bytes + 0..7 zero pad.
+};
+static_assert(sizeof(EnqueueRequestPayload) == 32,
+              "EnqueueRequestPayload must be exactly 32 bytes per "
+              "decoder_server_runtime.md#enqueue_syndromes");
+
+struct __attribute__((packed)) GetCorrectionsRequestPayload {
+  std::int64_t decoder_id;  ///< arg0
+  std::int64_t return_size; ///< arg1 (# correction bits to fetch)
+  std::uint8_t reset;       ///< arg2 (0 = keep state, 1 = reset after read)
+  std::uint8_t _pad[7];     ///< zero pad to 8-byte multiple
+};
+static_assert(sizeof(GetCorrectionsRequestPayload) == 24,
+              "GetCorrectionsRequestPayload must be exactly 24 bytes per "
+              "decoder_server_runtime.md#get_corrections");
+
+struct __attribute__((packed)) ResetRequestPayload {
+  std::int64_t decoder_id; ///< arg0
+};
+static_assert(sizeof(ResetRequestPayload) == 8,
+              "ResetRequestPayload must be exactly 8 bytes per "
+              "decoder_server_runtime.md#reset_decoder");
+
+constexpr std::size_t bit_packed_bytes(std::size_t num_bits) {
+  return (num_bits + 7) / 8;
+}
+
+constexpr std::size_t align_to_8(std::size_t bytes) {
+  return (bytes + 7) & ~static_cast<std::size_t>(7);
+}
+
+} // namespace cudaq::qec::decoding::rpc

--- a/libs/qec/lib/realtime/CMakeLists.txt
+++ b/libs/qec/lib/realtime/CMakeLists.txt
@@ -53,6 +53,7 @@ if(CMAKE_CUDA_COMPILER)
     )
     if(CUDAQ_REALTIME_LIBRARY)
       message(STATUS "Found cuda-quantum realtime library at ${CUDAQ_REALTIME_LIBRARY}")
+      get_filename_component(_CUDAQ_REALTIME_LIB_DIR "${CUDAQ_REALTIME_LIBRARY}" DIRECTORY)
     endif()
     
     # Create static device library for device code
@@ -140,6 +141,13 @@ target_link_libraries(cudaq-qec-realtime-decoding
 
 set_target_properties(cudaq-qec-realtime-decoding PROPERTIES
   LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
+
+if(_CUDAQ_REALTIME_LIB_DIR)
+  set_target_properties(cudaq-qec-realtime-decoding PROPERTIES
+    BUILD_RPATH "${_CUDAQ_REALTIME_LIB_DIR};${CMAKE_BINARY_DIR}/lib"
+    INSTALL_RPATH "${_CUDAQ_REALTIME_LIB_DIR};${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}"
+  )
+endif()
 
 
 install(TARGETS cudaq-qec-realtime-decoding

--- a/libs/qec/lib/realtime/CMakeLists.txt
+++ b/libs/qec/lib/realtime/CMakeLists.txt
@@ -55,6 +55,19 @@ if(CMAKE_CUDA_COMPILER)
       message(STATUS "Found cuda-quantum realtime library at ${CUDAQ_REALTIME_LIBRARY}")
       get_filename_component(_CUDAQ_REALTIME_LIB_DIR "${CUDAQ_REALTIME_LIBRARY}" DIRECTORY)
     endif()
+
+    # The host-side dispatch loop (cudaq_host_dispatcher_loop), used by
+    # qec_realtime_session, lives in libcudaq-realtime-host-dispatch -- separate
+    # from libcudaq-realtime.  Locate it so cudaq-qec-realtime-decoding can link
+    # it (mirrors the cudaq-realtime-pipeline target below).
+    find_library(CUDAQ_REALTIME_HOST_DISPATCH_LIBRARY
+      NAMES cudaq-realtime-host-dispatch
+      PATHS ${_cudaq_realtime_prefixes}
+      PATH_SUFFIXES lib
+    )
+    if(CUDAQ_REALTIME_HOST_DISPATCH_LIBRARY)
+      message(STATUS "Found cuda-quantum realtime host dispatch library at ${CUDAQ_REALTIME_HOST_DISPATCH_LIBRARY}")
+    endif()
     
     # Create static device library for device code
     add_library(cudaq-qec-realtime-cudevice STATIC
@@ -137,6 +150,7 @@ target_link_libraries(cudaq-qec-realtime-decoding
     cudaq::cudaq-common
     LLVMSupport
     $<$<BOOL:${CUDAQ_REALTIME_LIBRARY}>:${CUDAQ_REALTIME_LIBRARY}>
+    $<$<BOOL:${CUDAQ_REALTIME_HOST_DISPATCH_LIBRARY}>:${CUDAQ_REALTIME_HOST_DISPATCH_LIBRARY}>
 )
 
 set_target_properties(cudaq-qec-realtime-decoding PROPERTIES

--- a/libs/qec/lib/realtime/CMakeLists.txt
+++ b/libs/qec/lib/realtime/CMakeLists.txt
@@ -46,6 +46,14 @@ if(CMAKE_CUDA_COMPILER)
   
   if(CUDAQ_REALTIME_INCLUDE_DIR)
     message(STATUS "Found cuda-quantum realtime headers at ${CUDAQ_REALTIME_INCLUDE_DIR}")
+    find_library(CUDAQ_REALTIME_LIBRARY
+      NAMES cudaq-realtime
+      PATHS ${_cudaq_realtime_prefixes}
+      PATH_SUFFIXES lib
+    )
+    if(CUDAQ_REALTIME_LIBRARY)
+      message(STATUS "Found cuda-quantum realtime library at ${CUDAQ_REALTIME_LIBRARY}")
+    endif()
     
     # Create static device library for device code
     add_library(cudaq-qec-realtime-cudevice STATIC
@@ -93,6 +101,8 @@ endif()
 add_library(cudaq-qec-realtime-decoding SHARED
   realtime_decoding.cpp
   config.cpp
+  qec_realtime_session.cpp
+  rpc_producer.cpp
 )
 
 target_compile_options(cudaq-qec-realtime-decoding 
@@ -104,7 +114,15 @@ target_include_directories(cudaq-qec-realtime-decoding
     $<BUILD_INTERFACE:${LLVM_INCLUDE_DIRS}>
     $<INSTALL_INTERFACE:${CUDAQ_INCLUDE_DIR}>
     $<INSTALL_INTERFACE:include>
+  PRIVATE
+    $<$<BOOL:${CUDAQ_REALTIME_INCLUDE_DIR}>:${CUDAQ_REALTIME_INCLUDE_DIR}>
+    ${CUDAToolkit_INCLUDE_DIRS}
 )
+
+if(CUDAQ_REALTIME_INCLUDE_DIR)
+  target_compile_definitions(cudaq-qec-realtime-decoding PRIVATE
+    CUDAQ_REALTIME_ROOT)
+endif()
 
 target_link_options(cudaq-qec-realtime-decoding PUBLIC
   $<$<CXX_COMPILER_ID:GNU>:-Wl,--exclude-libs,ALL>
@@ -117,6 +135,7 @@ target_link_libraries(cudaq-qec-realtime-decoding
   PRIVATE
     cudaq::cudaq-common
     LLVMSupport
+    $<$<BOOL:${CUDAQ_REALTIME_LIBRARY}>:${CUDAQ_REALTIME_LIBRARY}>
 )
 
 set_target_properties(cudaq-qec-realtime-decoding PROPERTIES

--- a/libs/qec/lib/realtime/qec_realtime_session.cpp
+++ b/libs/qec/lib/realtime/qec_realtime_session.cpp
@@ -38,11 +38,12 @@ void write_response(void *slot_host, std::int32_t status,
   auto *response = static_cast<cudaq::realtime::RPCResponse *>(slot_host);
   const std::uint32_t request_id = header->request_id;
   const std::uint64_t ptp_timestamp = header->ptp_timestamp;
-  response->magic = cudaq::realtime::RPC_MAGIC_RESPONSE;
   response->status = status;
   response->result_len = result_len;
   response->request_id = request_id;
   response->ptp_timestamp = ptp_timestamp;
+  __atomic_store_n(&response->magic, cudaq::realtime::RPC_MAGIC_RESPONSE,
+                   __ATOMIC_RELEASE);
 }
 
 std::uint8_t *response_body(void *slot_host) {
@@ -165,8 +166,8 @@ void qec_realtime_session::initialize() {
   try {
     allocate_ring_buffer();
     populate_function_table();
-    start_host_loop();
     g_active_decoders = &decoders_;
+    start_host_loop();
     initialized_ = true;
   } catch (...) {
     finalize();

--- a/libs/qec/lib/realtime/qec_realtime_session.cpp
+++ b/libs/qec/lib/realtime/qec_realtime_session.cpp
@@ -1,0 +1,284 @@
+/*******************************************************************************
+ * Copyright (c) 2024 - 2026 NVIDIA Corporation & Affiliates.                  *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+#ifdef CUDAQ_REALTIME_ROOT
+
+#include "qec_realtime_session.h"
+
+#include "cudaq/qec/realtime/decoder_rpc_ids.h"
+#include "cudaq/runtime/logger/logger.h"
+
+#include <algorithm>
+#include <cstring>
+#include <stdexcept>
+#include <string>
+
+namespace cudaq::qec::realtime {
+namespace {
+
+using Decoders = std::vector<std::unique_ptr<cudaq::qec::decoder>>;
+Decoders *g_active_decoders = nullptr;
+
+cudaq::qec::decoder *get_decoder_or_throw(std::int64_t decoder_id) {
+  if (!g_active_decoders || decoder_id < 0 ||
+      static_cast<std::size_t>(decoder_id) >= g_active_decoders->size() ||
+      !(*g_active_decoders)[static_cast<std::size_t>(decoder_id)])
+    throw std::runtime_error("invalid decoder_id " + std::to_string(decoder_id));
+  return (*g_active_decoders)[static_cast<std::size_t>(decoder_id)].get();
+}
+
+void write_response(void *slot_host, std::int32_t status,
+                    std::uint32_t result_len = 0) {
+  auto *header = static_cast<cudaq::realtime::RPCHeader *>(slot_host);
+  auto *response = static_cast<cudaq::realtime::RPCResponse *>(slot_host);
+  const std::uint32_t request_id = header->request_id;
+  const std::uint64_t ptp_timestamp = header->ptp_timestamp;
+  response->magic = cudaq::realtime::RPC_MAGIC_RESPONSE;
+  response->status = status;
+  response->result_len = result_len;
+  response->request_id = request_id;
+  response->ptp_timestamp = ptp_timestamp;
+}
+
+std::uint8_t *response_body(void *slot_host) {
+  return static_cast<std::uint8_t *>(slot_host) +
+         sizeof(cudaq::realtime::RPCResponse);
+}
+
+void enqueue_syndromes_host(void *slot_host, std::size_t slot_size) {
+  namespace rpc = cudaq::qec::decoding::rpc;
+  try {
+    auto *header = static_cast<cudaq::realtime::RPCHeader *>(slot_host);
+    if (header->arg_len < sizeof(rpc::EnqueueRequestPayload)) {
+      write_response(slot_host, -1);
+      return;
+    }
+    auto *body = reinterpret_cast<const rpc::EnqueueRequestPayload *>(
+        static_cast<std::uint8_t *>(slot_host) +
+        sizeof(cudaq::realtime::RPCHeader));
+    if (body->num_syndromes < 0 || body->syndrome_mapping_id != 0) {
+      write_response(slot_host, -4);
+      return;
+    }
+    const auto num_syndromes =
+        static_cast<std::uint64_t>(body->num_syndromes);
+    const std::size_t expected_arg_len =
+        rpc::align_to_8(sizeof(rpc::EnqueueRequestPayload) +
+                        rpc::bit_packed_bytes(num_syndromes));
+    if (header->arg_len != expected_arg_len ||
+        sizeof(cudaq::realtime::RPCHeader) + expected_arg_len > slot_size) {
+      write_response(slot_host, -4);
+      return;
+    }
+
+    auto *decoder = get_decoder_or_throw(body->decoder_id);
+    const std::uint8_t *bits =
+        reinterpret_cast<const std::uint8_t *>(body + 1);
+    std::vector<std::uint8_t> syndromes(num_syndromes, 0);
+    for (std::uint64_t bit = 0; bit < num_syndromes; ++bit)
+      syndromes[bit] = (bits[bit >> 3] >> (bit & 7)) & 0x1u;
+
+    (void)decoder->enqueue_syndrome(syndromes.data(), syndromes.size());
+    write_response(slot_host, 0);
+  } catch (...) {
+    write_response(slot_host, -2);
+  }
+}
+
+void get_corrections_host(void *slot_host, std::size_t slot_size) {
+  namespace rpc = cudaq::qec::decoding::rpc;
+  try {
+    auto *header = static_cast<cudaq::realtime::RPCHeader *>(slot_host);
+    if (header->arg_len != sizeof(rpc::GetCorrectionsRequestPayload)) {
+      write_response(slot_host, -1);
+      return;
+    }
+    auto *body = reinterpret_cast<const rpc::GetCorrectionsRequestPayload *>(
+        static_cast<std::uint8_t *>(slot_host) +
+        sizeof(cudaq::realtime::RPCHeader));
+    if (body->return_size < 0) {
+      write_response(slot_host, -4);
+      return;
+    }
+
+    auto *decoder = get_decoder_or_throw(body->decoder_id);
+    const auto return_size = static_cast<std::uint64_t>(body->return_size);
+    if (return_size > decoder->get_num_observables()) {
+      write_response(slot_host, -4);
+      return;
+    }
+    const std::size_t result_len =
+        rpc::align_to_8(rpc::bit_packed_bytes(return_size));
+    if (sizeof(cudaq::realtime::RPCResponse) + result_len > slot_size) {
+      write_response(slot_host, -5);
+      return;
+    }
+
+    std::uint8_t *out = response_body(slot_host);
+    std::memset(out, 0, result_len);
+    const std::uint8_t *corrections = decoder->get_obs_corrections();
+    for (std::uint64_t i = 0; i < return_size; ++i) {
+      if (corrections[i] & 0x1u)
+        out[i >> 3] |= static_cast<std::uint8_t>(1u << (i & 7));
+    }
+    if (body->reset != 0)
+      decoder->clear_corrections();
+    write_response(slot_host, 0, static_cast<std::uint32_t>(result_len));
+  } catch (...) {
+    write_response(slot_host, -2);
+  }
+}
+
+void reset_decoder_host(void *slot_host, std::size_t) {
+  namespace rpc = cudaq::qec::decoding::rpc;
+  try {
+    auto *header = static_cast<cudaq::realtime::RPCHeader *>(slot_host);
+    if (header->arg_len != sizeof(rpc::ResetRequestPayload)) {
+      write_response(slot_host, -1);
+      return;
+    }
+    auto *body = reinterpret_cast<const rpc::ResetRequestPayload *>(
+        static_cast<std::uint8_t *>(slot_host) +
+        sizeof(cudaq::realtime::RPCHeader));
+    get_decoder_or_throw(body->decoder_id)->reset_decoder();
+    write_response(slot_host, 0);
+  } catch (...) {
+    write_response(slot_host, -2);
+  }
+}
+
+} // namespace
+
+qec_realtime_session::qec_realtime_session(Decoders &decoders)
+    : decoders_(decoders) {}
+
+qec_realtime_session::~qec_realtime_session() { finalize(); }
+
+void qec_realtime_session::initialize() {
+  if (initialized_)
+    return;
+  try {
+    allocate_ring_buffer();
+    populate_function_table();
+    start_host_loop();
+    g_active_decoders = &decoders_;
+    initialized_ = true;
+  } catch (...) {
+    finalize();
+    throw;
+  }
+}
+
+void qec_realtime_session::finalize() {
+  const bool was_initialized = initialized_;
+  initialized_ = false;
+  stop_host_loop();
+  if (g_active_decoders == &decoders_)
+    g_active_decoders = nullptr;
+  function_table_.clear();
+  rx_flags_.clear();
+  tx_flags_.clear();
+  rx_data_.clear();
+  tx_data_.clear();
+  std::memset(&ringbuffer_, 0, sizeof(ringbuffer_));
+  std::memset(&host_ctx_, 0, sizeof(host_ctx_));
+  if (was_initialized)
+    CUDAQ_INFO("qec_realtime_session: finalized HOST_CALL session");
+}
+
+void qec_realtime_session::allocate_ring_buffer() {
+  namespace rpc = cudaq::qec::decoding::rpc;
+  std::size_t max_syndromes = 0;
+  std::size_t max_observables = 0;
+  for (auto &decoder : decoders_) {
+    if (!decoder)
+      continue;
+    max_syndromes =
+        std::max<std::size_t>(max_syndromes, decoder->get_num_msyn_per_decode());
+    max_observables =
+        std::max<std::size_t>(max_observables, decoder->get_num_observables());
+  }
+
+  const std::size_t enqueue_bytes =
+      sizeof(cudaq::realtime::RPCHeader) +
+      rpc::align_to_8(sizeof(rpc::EnqueueRequestPayload) +
+                      rpc::bit_packed_bytes(max_syndromes));
+  const std::size_t get_request_bytes =
+      sizeof(cudaq::realtime::RPCHeader) +
+      sizeof(rpc::GetCorrectionsRequestPayload);
+  const std::size_t get_response_bytes =
+      sizeof(cudaq::realtime::RPCResponse) +
+      rpc::align_to_8(rpc::bit_packed_bytes(max_observables));
+  const std::size_t reset_bytes = sizeof(cudaq::realtime::RPCHeader) +
+                                  sizeof(rpc::ResetRequestPayload);
+  slot_size_ =
+      std::max({enqueue_bytes, get_request_bytes, get_response_bytes,
+                reset_bytes, std::size_t{64}});
+
+  rx_flags_.assign(num_slots_, 0);
+  tx_flags_.assign(num_slots_, 0);
+  rx_data_.assign(num_slots_ * slot_size_, 0);
+  tx_data_.assign(num_slots_ * slot_size_, 0);
+
+  std::memset(&ringbuffer_, 0, sizeof(ringbuffer_));
+  ringbuffer_.rx_flags_host = rx_flags_.data();
+  ringbuffer_.tx_flags_host = tx_flags_.data();
+  ringbuffer_.rx_data_host = rx_data_.data();
+  ringbuffer_.tx_data_host = tx_data_.data();
+  ringbuffer_.rx_stride_sz = slot_size_;
+  ringbuffer_.tx_stride_sz = slot_size_;
+}
+
+void qec_realtime_session::populate_function_table() {
+  namespace rpc = cudaq::qec::decoding::rpc;
+  function_table_.assign(3, cudaq_function_entry_t{});
+
+  function_table_[0].handler.host_fn = enqueue_syndromes_host;
+  function_table_[0].function_id = rpc::kEnqueueSyndromesFunctionId;
+  function_table_[0].dispatch_mode = CUDAQ_DISPATCH_HOST_CALL;
+
+  function_table_[1].handler.host_fn = get_corrections_host;
+  function_table_[1].function_id = rpc::kGetCorrectionsFunctionId;
+  function_table_[1].dispatch_mode = CUDAQ_DISPATCH_HOST_CALL;
+
+  function_table_[2].handler.host_fn = reset_decoder_host;
+  function_table_[2].function_id = rpc::kResetDecoderFunctionId;
+  function_table_[2].dispatch_mode = CUDAQ_DISPATCH_HOST_CALL;
+}
+
+void qec_realtime_session::start_host_loop() {
+  shutdown_flag_ = 0;
+  std::memset(&host_ctx_, 0, sizeof(host_ctx_));
+  host_ctx_.ringbuffer = ringbuffer_;
+  host_ctx_.config.num_slots = static_cast<std::uint32_t>(num_slots_);
+  host_ctx_.config.slot_size = static_cast<std::uint32_t>(slot_size_);
+  host_ctx_.config.dispatch_path = CUDAQ_DISPATCH_PATH_HOST;
+  host_ctx_.config.dispatch_mode = CUDAQ_DISPATCH_HOST_CALL;
+  host_ctx_.config.skip_tx_markers = 1;
+  host_ctx_.function_table.entries = function_table_.data();
+  host_ctx_.function_table.count =
+      static_cast<std::uint32_t>(function_table_.size());
+  host_ctx_.shutdown_flag = &shutdown_flag_;
+  host_ctx_.stats_counter = &host_stats_counter_;
+  host_ctx_.skip_stream_sweep = true;
+
+  host_loop_thread_ =
+      std::thread([this]() { cudaq_host_dispatcher_loop(&host_ctx_); });
+}
+
+void qec_realtime_session::stop_host_loop() {
+  if (host_loop_thread_.joinable()) {
+    __atomic_store_n(&shutdown_flag_, 1, __ATOMIC_RELEASE);
+    __sync_synchronize();
+    host_loop_thread_.join();
+  }
+}
+
+} // namespace cudaq::qec::realtime
+
+#endif // CUDAQ_REALTIME_ROOT

--- a/libs/qec/lib/realtime/qec_realtime_session.cpp
+++ b/libs/qec/lib/realtime/qec_realtime_session.cpp
@@ -14,6 +14,7 @@
 #include "cudaq/runtime/logger/logger.h"
 
 #include <algorithm>
+#include <atomic>
 #include <cstring>
 #include <stdexcept>
 #include <string>
@@ -22,15 +23,22 @@ namespace cudaq::qec::realtime {
 namespace {
 
 using Decoders = std::vector<std::unique_ptr<cudaq::qec::decoder>>;
-Decoders *g_active_decoders = nullptr;
+
+// The HOST_CALL handlers below are plain C function pointers with no
+// user-context argument, so the active decoder table must be reachable from a
+// process-global.  It is published/cleared by initialize()/finalize() and read
+// concurrently by the host dispatcher thread, hence the atomic.  Only one
+// session may be live at a time (enforced in initialize()).
+std::atomic<Decoders *> g_active_decoders{nullptr};
 
 cudaq::qec::decoder *get_decoder_or_throw(std::int64_t decoder_id) {
-  if (!g_active_decoders || decoder_id < 0 ||
-      static_cast<std::size_t>(decoder_id) >= g_active_decoders->size() ||
-      !(*g_active_decoders)[static_cast<std::size_t>(decoder_id)])
+  Decoders *decoders = g_active_decoders.load(std::memory_order_acquire);
+  if (!decoders || decoder_id < 0 ||
+      static_cast<std::size_t>(decoder_id) >= decoders->size() ||
+      !(*decoders)[static_cast<std::size_t>(decoder_id)])
     throw std::runtime_error("invalid decoder_id " +
                              std::to_string(decoder_id));
-  return (*g_active_decoders)[static_cast<std::size_t>(decoder_id)].get();
+  return (*decoders)[static_cast<std::size_t>(decoder_id)].get();
 }
 
 void write_response(void *slot_host, std::int32_t status,
@@ -78,11 +86,23 @@ void enqueue_syndromes_host(void *slot_host, std::size_t slot_size) {
     }
 
     auto *decoder = get_decoder_or_throw(body->decoder_id);
+    // Reject requests larger than this decoder's per-decode window.  The slot
+    // is sized for the largest decoder in the session, so an oversized request
+    // for a smaller decoder can still fit the slot; without this guard it would
+    // overflow the decoder's accumulation buffer and be silently dropped by
+    // enqueue_syndrome (which returns false) while we ACK success.
+    if (num_syndromes > decoder->get_num_msyn_per_decode()) {
+      write_response(slot_host, -4);
+      return;
+    }
     const std::uint8_t *bits = reinterpret_cast<const std::uint8_t *>(body + 1);
     std::vector<std::uint8_t> syndromes(num_syndromes, 0);
     for (std::uint64_t bit = 0; bit < num_syndromes; ++bit)
       syndromes[bit] = (bits[bit >> 3] >> (bit & 7)) & 0x1u;
 
+    // enqueue_syndrome's bool return means "a decode was triggered", not
+    // success, so it is intentionally not treated as an error here; the
+    // oversize guard above is what rejects malformed lengths.
     (void)decoder->enqueue_syndrome(syndromes.data(), syndromes.size());
     write_response(slot_host, 0);
   } catch (...) {
@@ -162,10 +182,20 @@ qec_realtime_session::~qec_realtime_session() { finalize(); }
 void qec_realtime_session::initialize() {
   if (initialized_)
     return;
+  // Reject a second concurrent session.  With a single process-global decoder
+  // table, a second initialize() would hijack decoder-id resolution for the
+  // first session's host loop.  Claim the global atomically up front; the only
+  // alternative (threading session context through the host handler path) would
+  // require a cuda-quantum dispatcher API change.
+  Decoders *expected = nullptr;
+  if (!g_active_decoders.compare_exchange_strong(expected, &decoders_,
+                                                 std::memory_order_acq_rel))
+    throw std::runtime_error(
+        "qec_realtime_session: another HOST_CALL session is already active; "
+        "concurrent sessions are not supported");
   try {
     allocate_ring_buffer();
     populate_function_table();
-    g_active_decoders = &decoders_;
     start_host_loop();
     initialized_ = true;
   } catch (...) {
@@ -178,8 +208,11 @@ void qec_realtime_session::finalize() {
   const bool was_initialized = initialized_;
   initialized_ = false;
   stop_host_loop();
-  if (g_active_decoders == &decoders_)
-    g_active_decoders = nullptr;
+  // Release the global only if this session owns it (no-op for a session that
+  // never acquired it, e.g. one rejected because another was already active).
+  Decoders *self = &decoders_;
+  g_active_decoders.compare_exchange_strong(self, nullptr,
+                                            std::memory_order_acq_rel);
   function_table_.clear();
   rx_flags_.clear();
   tx_flags_.clear();

--- a/libs/qec/lib/realtime/qec_realtime_session.cpp
+++ b/libs/qec/lib/realtime/qec_realtime_session.cpp
@@ -28,7 +28,8 @@ cudaq::qec::decoder *get_decoder_or_throw(std::int64_t decoder_id) {
   if (!g_active_decoders || decoder_id < 0 ||
       static_cast<std::size_t>(decoder_id) >= g_active_decoders->size() ||
       !(*g_active_decoders)[static_cast<std::size_t>(decoder_id)])
-    throw std::runtime_error("invalid decoder_id " + std::to_string(decoder_id));
+    throw std::runtime_error("invalid decoder_id " +
+                             std::to_string(decoder_id));
   return (*g_active_decoders)[static_cast<std::size_t>(decoder_id)].get();
 }
 
@@ -66,8 +67,7 @@ void enqueue_syndromes_host(void *slot_host, std::size_t slot_size) {
       write_response(slot_host, -4);
       return;
     }
-    const auto num_syndromes =
-        static_cast<std::uint64_t>(body->num_syndromes);
+    const auto num_syndromes = static_cast<std::uint64_t>(body->num_syndromes);
     const std::size_t expected_arg_len =
         rpc::align_to_8(sizeof(rpc::EnqueueRequestPayload) +
                         rpc::bit_packed_bytes(num_syndromes));
@@ -78,8 +78,7 @@ void enqueue_syndromes_host(void *slot_host, std::size_t slot_size) {
     }
 
     auto *decoder = get_decoder_or_throw(body->decoder_id);
-    const std::uint8_t *bits =
-        reinterpret_cast<const std::uint8_t *>(body + 1);
+    const std::uint8_t *bits = reinterpret_cast<const std::uint8_t *>(body + 1);
     std::vector<std::uint8_t> syndromes(num_syndromes, 0);
     for (std::uint64_t bit = 0; bit < num_syndromes; ++bit)
       syndromes[bit] = (bits[bit >> 3] >> (bit & 7)) & 0x1u;
@@ -199,8 +198,8 @@ void qec_realtime_session::allocate_ring_buffer() {
   for (auto &decoder : decoders_) {
     if (!decoder)
       continue;
-    max_syndromes =
-        std::max<std::size_t>(max_syndromes, decoder->get_num_msyn_per_decode());
+    max_syndromes = std::max<std::size_t>(max_syndromes,
+                                          decoder->get_num_msyn_per_decode());
     max_observables =
         std::max<std::size_t>(max_observables, decoder->get_num_observables());
   }
@@ -215,11 +214,10 @@ void qec_realtime_session::allocate_ring_buffer() {
   const std::size_t get_response_bytes =
       sizeof(cudaq::realtime::RPCResponse) +
       rpc::align_to_8(rpc::bit_packed_bytes(max_observables));
-  const std::size_t reset_bytes = sizeof(cudaq::realtime::RPCHeader) +
-                                  sizeof(rpc::ResetRequestPayload);
-  slot_size_ =
-      std::max({enqueue_bytes, get_request_bytes, get_response_bytes,
-                reset_bytes, std::size_t{64}});
+  const std::size_t reset_bytes =
+      sizeof(cudaq::realtime::RPCHeader) + sizeof(rpc::ResetRequestPayload);
+  slot_size_ = std::max({enqueue_bytes, get_request_bytes, get_response_bytes,
+                         reset_bytes, std::size_t{64}});
 
   rx_flags_.assign(num_slots_, 0);
   tx_flags_.assign(num_slots_, 0);

--- a/libs/qec/lib/realtime/qec_realtime_session.h
+++ b/libs/qec/lib/realtime/qec_realtime_session.h
@@ -1,0 +1,69 @@
+/****************************************************************-*- C++ -*-****
+ * Copyright (c) 2024 - 2026 NVIDIA Corporation & Affiliates.                  *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+#pragma once
+
+#ifdef CUDAQ_REALTIME_ROOT
+
+#include "cudaq/qec/decoder.h"
+#include "cudaq/realtime/daemon/dispatcher/cudaq_realtime.h"
+#include "cudaq/realtime/daemon/dispatcher/host_dispatcher.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <thread>
+#include <vector>
+
+namespace cudaq::qec::realtime {
+
+class __attribute__((visibility("default"))) qec_realtime_session {
+public:
+  explicit qec_realtime_session(
+      std::vector<std::unique_ptr<cudaq::qec::decoder>> &decoders);
+  ~qec_realtime_session();
+
+  void initialize();
+  void finalize();
+  bool initialized() const { return initialized_; }
+
+  volatile std::uint64_t *rx_flags_host() { return rx_flags_.data(); }
+  volatile std::uint64_t *tx_flags_host() { return tx_flags_.data(); }
+  std::uint8_t *rx_data_host() { return rx_data_.data(); }
+  std::uint8_t *tx_data_host() { return tx_data_.data(); }
+  std::size_t num_slots() const { return num_slots_; }
+  std::size_t slot_size() const { return slot_size_; }
+
+private:
+  void allocate_ring_buffer();
+  void populate_function_table();
+  void start_host_loop();
+  void stop_host_loop();
+
+  std::vector<std::unique_ptr<cudaq::qec::decoder>> &decoders_;
+
+  bool initialized_ = false;
+  std::size_t num_slots_ = 8;
+  std::size_t slot_size_ = 0;
+
+  std::vector<std::uint64_t> rx_flags_;
+  std::vector<std::uint64_t> tx_flags_;
+  std::vector<std::uint8_t> rx_data_;
+  std::vector<std::uint8_t> tx_data_;
+  int shutdown_flag_ = 0;
+  std::uint64_t host_stats_counter_ = 0;
+
+  std::vector<cudaq_function_entry_t> function_table_;
+  cudaq_ringbuffer_t ringbuffer_{};
+  cudaq_host_dispatch_loop_ctx_t host_ctx_{};
+  std::thread host_loop_thread_;
+};
+
+} // namespace cudaq::qec::realtime
+
+#endif // CUDAQ_REALTIME_ROOT

--- a/libs/qec/lib/realtime/rpc_producer.cpp
+++ b/libs/qec/lib/realtime/rpc_producer.cpp
@@ -25,6 +25,11 @@ namespace {
 std::atomic<std::uint32_t> g_request_id_counter{1};
 std::atomic<std::uint32_t> g_next_slot_hint{0};
 
+// Producer-owned "busy" sentinel written into tx_flags while a slot is held.
+// The host loop runs with skip_tx_markers=1 and never reads/writes tx_flags, so
+// the producer repurposes it as an ownership token (any non-zero value works).
+constexpr std::uint64_t kSlotBusyMarker = ~std::uint64_t{0};
+
 std::uint32_t next_request_id() {
   return g_request_id_counter.fetch_add(1, std::memory_order_relaxed);
 }
@@ -40,7 +45,19 @@ std::uint32_t acquire_slot(cudaq::qec::realtime::qec_realtime_session &session,
     for (std::uint32_t s = 0; s < session.num_slots(); ++s) {
       const std::uint32_t slot =
           static_cast<std::uint32_t>((start + s) % session.num_slots());
-      if (rx[slot] == 0 && tx[slot] == 0) {
+      // A slot is free only when no request is in flight (rx == 0).  Claim it
+      // by atomically flipping tx_flags 0 -> BUSY: this reserves the TX
+      // response buffer for the entire acquire..release_slot window rather than
+      // only until the host loop clears rx_flags, and the CAS makes the claim
+      // safe against concurrent producers.  tx == 0 only happens after
+      // release_slot (which runs after the host loop consumed the request and
+      // cleared rx), so rx is already 0 at a successful claim.
+      if (rx[slot] != 0)
+        continue;
+      std::uint64_t expected = 0;
+      if (__atomic_compare_exchange_n(&tx[slot], &expected, kSlotBusyMarker,
+                                      false, __ATOMIC_ACQ_REL,
+                                      __ATOMIC_RELAXED)) {
         g_next_slot_hint.store(
             static_cast<std::uint32_t>((slot + 1) % session.num_slots()),
             std::memory_order_relaxed);
@@ -100,8 +117,10 @@ bool wait_for_response(cudaq::qec::realtime::qec_realtime_session &session,
 void release_slot(cudaq::qec::realtime::qec_realtime_session &session,
                   std::uint32_t slot) {
   // rx_flags[slot] is cleared by cudaq_host_dispatcher_loop after it consumes
-  // the request.  The producer only clears the TX side after reading the
-  // response, making the slot reusable when acquire_slot sees both flags zero.
+  // the request.  acquire_slot set tx_flags[slot] to the BUSY token to reserve
+  // the response buffer; clear it here (after reading the response) to return
+  // the slot to the pool.  Order the TX data wipe before the token release so a
+  // re-acquiring producer never observes stale response bytes.
   std::memset(session.tx_data_host() + slot * session.slot_size(), 0,
               session.slot_size());
   __sync_synchronize();

--- a/libs/qec/lib/realtime/rpc_producer.cpp
+++ b/libs/qec/lib/realtime/rpc_producer.cpp
@@ -88,8 +88,9 @@ bool wait_for_response(cudaq::qec::realtime::qec_realtime_session &session,
   auto *resp =
       reinterpret_cast<const cudaq::realtime::RPCResponse *>(tx_slot_host);
   for (int waited = 0; waited < timeout_ms; ++waited) {
-    __sync_synchronize();
-    if (resp->magic == cudaq::realtime::RPC_MAGIC_RESPONSE)
+    auto *magic = const_cast<std::uint32_t *>(&resp->magic);
+    if (__atomic_load_n(magic, __ATOMIC_ACQUIRE) ==
+        cudaq::realtime::RPC_MAGIC_RESPONSE)
       return true;
     usleep(200);
   }
@@ -98,6 +99,9 @@ bool wait_for_response(cudaq::qec::realtime::qec_realtime_session &session,
 
 void release_slot(cudaq::qec::realtime::qec_realtime_session &session,
                   std::uint32_t slot) {
+  // rx_flags[slot] is cleared by cudaq_host_dispatcher_loop after it consumes
+  // the request.  The producer only clears the TX side after reading the
+  // response, making the slot reusable when acquire_slot sees both flags zero.
   std::memset(session.tx_data_host() + slot * session.slot_size(), 0,
               session.slot_size());
   __sync_synchronize();
@@ -150,7 +154,7 @@ void enqueue_syndromes(cudaq::qec::realtime::qec_realtime_session &session,
       bits[i >> 3] |= static_cast<std::uint8_t>(1u << (i & 7));
   }
 
-  const std::uint32_t request_id = static_cast<std::uint32_t>(counter);
+  const std::uint32_t request_id = next_request_id();
   const std::uint32_t slot = acquire_slot(session, kAcquireSlotTimeoutMs);
   if (slot == UINT32_MAX)
     throw dispatcher_unresponsive_error(

--- a/libs/qec/lib/realtime/rpc_producer.cpp
+++ b/libs/qec/lib/realtime/rpc_producer.cpp
@@ -110,8 +110,7 @@ void release_slot(cudaq::qec::realtime::qec_realtime_session &session,
 
 const cudaq::realtime::RPCResponse *
 checked_response(cudaq::qec::realtime::qec_realtime_session &session,
-                 std::uint32_t slot, std::uint32_t request_id,
-                 const char *fn) {
+                 std::uint32_t slot, std::uint32_t request_id, const char *fn) {
   auto *resp = reinterpret_cast<const cudaq::realtime::RPCResponse *>(
       session.tx_data_host() + slot * session.slot_size());
   if (resp->request_id != request_id) {
@@ -223,9 +222,9 @@ void get_corrections(cudaq::qec::realtime::qec_realtime_session &session,
         "rpc_producer::get_corrections: malformed result_len");
   }
 
-  const std::uint8_t *bits =
-      session.tx_data_host() + slot * session.slot_size() +
-      sizeof(cudaq::realtime::RPCResponse);
+  const std::uint8_t *bits = session.tx_data_host() +
+                             slot * session.slot_size() +
+                             sizeof(cudaq::realtime::RPCResponse);
   for (std::uint64_t i = 0; i < correction_length; ++i)
     corrections[i] = (bits[i >> 3] >> (i & 7)) & 0x1u;
   release_slot(session, slot);

--- a/libs/qec/lib/realtime/rpc_producer.cpp
+++ b/libs/qec/lib/realtime/rpc_producer.cpp
@@ -88,9 +88,9 @@ bool wait_for_response(cudaq::qec::realtime::qec_realtime_session &session,
   auto *resp =
       reinterpret_cast<const cudaq::realtime::RPCResponse *>(tx_slot_host);
   for (int waited = 0; waited < timeout_ms; ++waited) {
-    auto *magic = const_cast<std::uint32_t *>(&resp->magic);
-    if (__atomic_load_n(magic, __ATOMIC_ACQUIRE) ==
-        cudaq::realtime::RPC_MAGIC_RESPONSE)
+    std::uint32_t magic = 0;
+    __atomic_load(&resp->magic, &magic, __ATOMIC_ACQUIRE);
+    if (magic == cudaq::realtime::RPC_MAGIC_RESPONSE)
       return true;
     usleep(200);
   }

--- a/libs/qec/lib/realtime/rpc_producer.cpp
+++ b/libs/qec/lib/realtime/rpc_producer.cpp
@@ -1,0 +1,267 @@
+/*******************************************************************************
+ * Copyright (c) 2024 - 2026 NVIDIA Corporation & Affiliates.                  *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+#ifdef CUDAQ_REALTIME_ROOT
+
+#include "rpc_producer.h"
+
+#include "qec_realtime_session.h"
+#include "cudaq/qec/realtime/decoder_rpc_ids.h"
+
+#include <atomic>
+#include <cstring>
+#include <sstream>
+#include <unistd.h>
+#include <vector>
+
+namespace cudaq::qec::decoding::rpc_producer {
+namespace {
+
+std::atomic<std::uint32_t> g_request_id_counter{1};
+std::atomic<std::uint32_t> g_next_slot_hint{0};
+
+std::uint32_t next_request_id() {
+  return g_request_id_counter.fetch_add(1, std::memory_order_relaxed);
+}
+
+std::uint32_t acquire_slot(cudaq::qec::realtime::qec_realtime_session &session,
+                           int timeout_ms) {
+  volatile std::uint64_t *rx = session.rx_flags_host();
+  volatile std::uint64_t *tx = session.tx_flags_host();
+  for (int waited = 0; waited < timeout_ms; ++waited) {
+    const std::uint32_t start =
+        g_next_slot_hint.load(std::memory_order_relaxed) %
+        static_cast<std::uint32_t>(session.num_slots());
+    for (std::uint32_t s = 0; s < session.num_slots(); ++s) {
+      const std::uint32_t slot =
+          static_cast<std::uint32_t>((start + s) % session.num_slots());
+      if (rx[slot] == 0 && tx[slot] == 0) {
+        g_next_slot_hint.store(
+            static_cast<std::uint32_t>((slot + 1) % session.num_slots()),
+            std::memory_order_relaxed);
+        return slot;
+      }
+    }
+    usleep(1000);
+  }
+  return UINT32_MAX;
+}
+
+void require_initialized(cudaq::qec::realtime::qec_realtime_session &session,
+                         const char *fn) {
+  if (!session.initialized()) {
+    std::ostringstream os;
+    os << "rpc_producer::" << fn
+       << ": session is not initialized; call configure_decoders first";
+    throw std::runtime_error(os.str());
+  }
+}
+
+void write_and_signal(cudaq::qec::realtime::qec_realtime_session &session,
+                      std::uint32_t slot, std::uint32_t function_id,
+                      std::uint32_t request_id, const void *payload,
+                      std::size_t payload_len) {
+  std::uint8_t *rx_slot_host =
+      session.rx_data_host() + slot * session.slot_size();
+  std::memset(rx_slot_host, 0, session.slot_size());
+  auto *header = reinterpret_cast<cudaq::realtime::RPCHeader *>(rx_slot_host);
+  header->magic = cudaq::realtime::RPC_MAGIC_REQUEST;
+  header->function_id = function_id;
+  header->arg_len = static_cast<std::uint32_t>(payload_len);
+  header->request_id = request_id;
+  header->ptp_timestamp = 0;
+  std::memcpy(rx_slot_host + sizeof(cudaq::realtime::RPCHeader), payload,
+              payload_len);
+  __sync_synchronize();
+  session.rx_flags_host()[slot] = reinterpret_cast<std::uint64_t>(rx_slot_host);
+}
+
+bool wait_for_response(cudaq::qec::realtime::qec_realtime_session &session,
+                       std::uint32_t slot, int timeout_ms) {
+  std::uint8_t *tx_slot_host =
+      session.tx_data_host() + slot * session.slot_size();
+  auto *resp =
+      reinterpret_cast<const cudaq::realtime::RPCResponse *>(tx_slot_host);
+  for (int waited = 0; waited < timeout_ms; ++waited) {
+    __sync_synchronize();
+    if (resp->magic == cudaq::realtime::RPC_MAGIC_RESPONSE)
+      return true;
+    usleep(200);
+  }
+  return false;
+}
+
+void release_slot(cudaq::qec::realtime::qec_realtime_session &session,
+                  std::uint32_t slot) {
+  std::memset(session.tx_data_host() + slot * session.slot_size(), 0,
+              session.slot_size());
+  __sync_synchronize();
+  session.tx_flags_host()[slot] = 0;
+}
+
+const cudaq::realtime::RPCResponse *
+checked_response(cudaq::qec::realtime::qec_realtime_session &session,
+                 std::uint32_t slot, std::uint32_t request_id,
+                 const char *fn) {
+  auto *resp = reinterpret_cast<const cudaq::realtime::RPCResponse *>(
+      session.tx_data_host() + slot * session.slot_size());
+  if (resp->request_id != request_id) {
+    std::ostringstream os;
+    os << "rpc_producer::" << fn << ": response request_id mismatch (got "
+       << resp->request_id << ", expected " << request_id << ")";
+    throw std::runtime_error(os.str());
+  }
+  if (resp->status != 0) {
+    std::ostringstream os;
+    os << "rpc_producer::" << fn << ": RPC status " << resp->status;
+    throw std::runtime_error(os.str());
+  }
+  return resp;
+}
+
+} // namespace
+
+void enqueue_syndromes(cudaq::qec::realtime::qec_realtime_session &session,
+                       std::size_t decoder_id, const std::uint8_t *syndromes,
+                       std::uint64_t num_syndromes, std::uint64_t counter,
+                       std::uint64_t syndrome_mapping_id) {
+  namespace rpc = cudaq::qec::decoding::rpc;
+  require_initialized(session, "enqueue_syndromes");
+  if (syndromes == nullptr && num_syndromes != 0)
+    throw std::runtime_error("rpc_producer::enqueue_syndromes: null syndromes");
+
+  const std::size_t bit_bytes = rpc::bit_packed_bytes(num_syndromes);
+  const std::size_t body_bytes =
+      rpc::align_to_8(sizeof(rpc::EnqueueRequestPayload) + bit_bytes);
+  std::vector<std::uint8_t> payload(body_bytes, 0);
+  auto *body = reinterpret_cast<rpc::EnqueueRequestPayload *>(payload.data());
+  body->decoder_id = static_cast<std::int64_t>(decoder_id);
+  body->counter = static_cast<std::int64_t>(counter);
+  body->syndrome_mapping_id = static_cast<std::int64_t>(syndrome_mapping_id);
+  body->num_syndromes = static_cast<std::int64_t>(num_syndromes);
+  auto *bits = payload.data() + sizeof(rpc::EnqueueRequestPayload);
+  for (std::uint64_t i = 0; i < num_syndromes; ++i) {
+    if (syndromes[i] & 0x1u)
+      bits[i >> 3] |= static_cast<std::uint8_t>(1u << (i & 7));
+  }
+
+  const std::uint32_t request_id = static_cast<std::uint32_t>(counter);
+  const std::uint32_t slot = acquire_slot(session, kAcquireSlotTimeoutMs);
+  if (slot == UINT32_MAX)
+    throw dispatcher_unresponsive_error(
+        "rpc_producer::enqueue_syndromes: timed out acquiring a free slot");
+
+  write_and_signal(session, slot, rpc::kEnqueueSyndromesFunctionId, request_id,
+                   payload.data(), payload.size());
+  if (!wait_for_response(session, slot, kResponseTimeoutMs)) {
+    release_slot(session, slot);
+    throw dispatcher_unresponsive_error(
+        "rpc_producer::enqueue_syndromes: timed out waiting for response");
+  }
+  const cudaq::realtime::RPCResponse *resp = nullptr;
+  try {
+    resp = checked_response(session, slot, request_id, "enqueue_syndromes");
+  } catch (...) {
+    release_slot(session, slot);
+    throw;
+  }
+  if (resp->result_len != 0) {
+    release_slot(session, slot);
+    throw std::runtime_error(
+        "rpc_producer::enqueue_syndromes: expected empty ACK response");
+  }
+  release_slot(session, slot);
+}
+
+void get_corrections(cudaq::qec::realtime::qec_realtime_session &session,
+                     std::size_t decoder_id, std::uint8_t *corrections,
+                     std::uint64_t correction_length, std::uint64_t reset) {
+  namespace rpc = cudaq::qec::decoding::rpc;
+  require_initialized(session, "get_corrections");
+  if (!corrections && correction_length != 0)
+    throw std::runtime_error("rpc_producer::get_corrections: null corrections");
+
+  rpc::GetCorrectionsRequestPayload payload{};
+  payload.decoder_id = static_cast<std::int64_t>(decoder_id);
+  payload.return_size = static_cast<std::int64_t>(correction_length);
+  payload.reset = reset ? 1 : 0;
+
+  const std::uint32_t request_id = next_request_id();
+  const std::uint32_t slot = acquire_slot(session, kAcquireSlotTimeoutMs);
+  if (slot == UINT32_MAX)
+    throw dispatcher_unresponsive_error(
+        "rpc_producer::get_corrections: timed out acquiring a free slot");
+
+  write_and_signal(session, slot, rpc::kGetCorrectionsFunctionId, request_id,
+                   &payload, sizeof(payload));
+  if (!wait_for_response(session, slot, kResponseTimeoutMs)) {
+    release_slot(session, slot);
+    throw dispatcher_unresponsive_error(
+        "rpc_producer::get_corrections: timed out waiting for response");
+  }
+  const cudaq::realtime::RPCResponse *resp = nullptr;
+  try {
+    resp = checked_response(session, slot, request_id, "get_corrections");
+  } catch (...) {
+    release_slot(session, slot);
+    throw;
+  }
+  const std::size_t expected_len =
+      rpc::align_to_8(rpc::bit_packed_bytes(correction_length));
+  if (resp->result_len != expected_len) {
+    release_slot(session, slot);
+    throw std::runtime_error(
+        "rpc_producer::get_corrections: malformed result_len");
+  }
+
+  const std::uint8_t *bits =
+      session.tx_data_host() + slot * session.slot_size() +
+      sizeof(cudaq::realtime::RPCResponse);
+  for (std::uint64_t i = 0; i < correction_length; ++i)
+    corrections[i] = (bits[i >> 3] >> (i & 7)) & 0x1u;
+  release_slot(session, slot);
+}
+
+void reset_decoder(cudaq::qec::realtime::qec_realtime_session &session,
+                   std::size_t decoder_id) {
+  namespace rpc = cudaq::qec::decoding::rpc;
+  require_initialized(session, "reset_decoder");
+  rpc::ResetRequestPayload payload{};
+  payload.decoder_id = static_cast<std::int64_t>(decoder_id);
+
+  const std::uint32_t request_id = next_request_id();
+  const std::uint32_t slot = acquire_slot(session, kAcquireSlotTimeoutMs);
+  if (slot == UINT32_MAX)
+    throw dispatcher_unresponsive_error(
+        "rpc_producer::reset_decoder: timed out acquiring a free slot");
+
+  write_and_signal(session, slot, rpc::kResetDecoderFunctionId, request_id,
+                   &payload, sizeof(payload));
+  if (!wait_for_response(session, slot, kResponseTimeoutMs)) {
+    release_slot(session, slot);
+    throw dispatcher_unresponsive_error(
+        "rpc_producer::reset_decoder: timed out waiting for response");
+  }
+  const cudaq::realtime::RPCResponse *resp = nullptr;
+  try {
+    resp = checked_response(session, slot, request_id, "reset_decoder");
+  } catch (...) {
+    release_slot(session, slot);
+    throw;
+  }
+  if (resp->result_len != 0) {
+    release_slot(session, slot);
+    throw std::runtime_error(
+        "rpc_producer::reset_decoder: expected empty ACK response");
+  }
+  release_slot(session, slot);
+}
+
+} // namespace cudaq::qec::decoding::rpc_producer
+
+#endif // CUDAQ_REALTIME_ROOT

--- a/libs/qec/lib/realtime/rpc_producer.h
+++ b/libs/qec/lib/realtime/rpc_producer.h
@@ -1,0 +1,43 @@
+/****************************************************************-*- C++ -*-****
+ * Copyright (c) 2024 - 2026 NVIDIA Corporation & Affiliates.                  *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <stdexcept>
+
+namespace cudaq::qec::realtime {
+class qec_realtime_session;
+} // namespace cudaq::qec::realtime
+
+namespace cudaq::qec::decoding::rpc_producer {
+
+struct dispatcher_unresponsive_error : std::runtime_error {
+  using std::runtime_error::runtime_error;
+};
+
+constexpr int kAcquireSlotTimeoutMs = 5000;
+constexpr int kResponseTimeoutMs = 5000;
+
+__attribute__((visibility("default"))) void
+enqueue_syndromes(cudaq::qec::realtime::qec_realtime_session &session,
+                  std::size_t decoder_id, const std::uint8_t *syndromes,
+                  std::uint64_t num_syndromes, std::uint64_t counter,
+                  std::uint64_t syndrome_mapping_id);
+
+__attribute__((visibility("default"))) void
+get_corrections(cudaq::qec::realtime::qec_realtime_session &session,
+                std::size_t decoder_id, std::uint8_t *corrections,
+                std::uint64_t correction_length, std::uint64_t reset);
+
+__attribute__((visibility("default"))) void
+reset_decoder(cudaq::qec::realtime::qec_realtime_session &session,
+              std::size_t decoder_id);
+
+} // namespace cudaq::qec::decoding::rpc_producer

--- a/libs/qec/unittests/decoders/pymatching/CMakeLists.txt
+++ b/libs/qec/unittests/decoders/pymatching/CMakeLists.txt
@@ -34,7 +34,7 @@ if(CUDAQ_REALTIME_ROOT AND CUDAQ_REALTIME_INCLUDE_DIR)
   target_include_directories(test_pymatching_realtime PRIVATE
     ${CUDAQ_REALTIME_INCLUDE_DIR}
     ${CUDAToolkit_INCLUDE_DIRS}
-    ${CMAKE_SOURCE_DIR}/libs/qec/lib/realtime
+    ${CUDAQX_QEC_SOURCE_DIR}/lib/realtime
   )
   target_compile_definitions(test_pymatching_realtime PRIVATE
     CUDAQ_REALTIME_ROOT)
@@ -47,7 +47,7 @@ if(CUDAQ_REALTIME_ROOT AND CUDAQ_REALTIME_INCLUDE_DIR)
   set_target_properties(test_pymatching_realtime PROPERTIES
     BUILD_RPATH "${CMAKE_BINARY_DIR}/lib;${CMAKE_BINARY_DIR}/lib/decoder-plugins"
   )
-  add_dependencies(CUDAQXQECUnitTests test_pymatching_realtime
-                   cudaq-qec-pymatching)
+  add_dependencies(test_pymatching_realtime cudaq-qec-pymatching)
+  add_dependencies(CUDAQXQECUnitTests test_pymatching_realtime)
   gtest_discover_tests(test_pymatching_realtime)
 endif()

--- a/libs/qec/unittests/decoders/pymatching/CMakeLists.txt
+++ b/libs/qec/unittests/decoders/pymatching/CMakeLists.txt
@@ -28,3 +28,26 @@ add_executable(test_pymatching test_pymatching.cpp)
 target_link_libraries(test_pymatching PRIVATE GTest::gtest_main cudaq-qec cudaq::cudaq)
 add_dependencies(CUDAQXQECUnitTests test_pymatching)
 gtest_discover_tests(test_pymatching)
+
+if(CUDAQ_REALTIME_ROOT AND CUDAQ_REALTIME_INCLUDE_DIR)
+  add_executable(test_pymatching_realtime test_pymatching_realtime.cpp)
+  target_include_directories(test_pymatching_realtime PRIVATE
+    ${CUDAQ_REALTIME_INCLUDE_DIR}
+    ${CUDAToolkit_INCLUDE_DIRS}
+    ${CMAKE_SOURCE_DIR}/libs/qec/lib/realtime
+  )
+  target_compile_definitions(test_pymatching_realtime PRIVATE
+    CUDAQ_REALTIME_ROOT)
+  target_link_libraries(test_pymatching_realtime PRIVATE
+    GTest::gtest_main
+    cudaq-qec
+    cudaq-qec-realtime-decoding
+    cudaq::cudaq
+  )
+  set_target_properties(test_pymatching_realtime PROPERTIES
+    BUILD_RPATH "${CMAKE_BINARY_DIR}/lib;${CMAKE_BINARY_DIR}/lib/decoder-plugins"
+  )
+  add_dependencies(CUDAQXQECUnitTests test_pymatching_realtime
+                   cudaq-qec-pymatching)
+  gtest_discover_tests(test_pymatching_realtime)
+endif()

--- a/libs/qec/unittests/decoders/pymatching/test_pymatching_realtime.cpp
+++ b/libs/qec/unittests/decoders/pymatching/test_pymatching_realtime.cpp
@@ -6,9 +6,9 @@
  * the terms of the Apache License 2.0 which accompanies this distribution.    *
  ******************************************************************************/
 
-#include "cudaq/qec/decoder.h"
 #include "qec_realtime_session.h"
 #include "rpc_producer.h"
+#include "cudaq/qec/decoder.h"
 
 #include <gtest/gtest.h>
 
@@ -21,9 +21,9 @@ namespace {
 
 using DecoderVec = std::vector<std::unique_ptr<cudaq::qec::decoder>>;
 
-DecoderVec
-make_pymatching_decoders(const std::vector<std::uint8_t> &h_vec,
-                         std::size_t syndrome_size, std::size_t block_size) {
+DecoderVec make_pymatching_decoders(const std::vector<std::uint8_t> &h_vec,
+                                    std::size_t syndrome_size,
+                                    std::size_t block_size) {
   cudaqx::tensor<std::uint8_t> h;
   h.copy(h_vec.data(), {syndrome_size, block_size});
 
@@ -69,8 +69,8 @@ read_corrections(cudaq::qec::realtime::qec_realtime_session &session,
   return corrections;
 }
 
-void run_case(const std::vector<std::uint8_t> &h_vec,
-              std::size_t syndrome_size, std::size_t block_size,
+void run_case(const std::vector<std::uint8_t> &h_vec, std::size_t syndrome_size,
+              std::size_t block_size,
               const std::vector<std::pair<std::vector<std::uint8_t>,
                                           std::vector<std::uint8_t>>> &cases) {
   auto decoders = make_pymatching_decoders(h_vec, syndrome_size, block_size);
@@ -91,9 +91,7 @@ void run_case(const std::vector<std::uint8_t> &h_vec,
 
 TEST(PyMatchingRealtime, CheckRegularEdges) {
   run_case(/*H=*/{1, 0, 1, 1, 0, 1}, /*syndrome_size=*/3, /*block_size=*/2,
-           {{{1, 1, 0}, {1, 0}},
-            {{0, 1, 1}, {0, 1}},
-            {{1, 0, 1}, {1, 1}}});
+           {{{1, 1, 0}, {1, 0}}, {{0, 1, 1}, {0, 1}}, {{1, 0, 1}, {1, 1}}});
 }
 
 TEST(PyMatchingRealtime, CheckBoundaryEdges) {

--- a/libs/qec/unittests/decoders/pymatching/test_pymatching_realtime.cpp
+++ b/libs/qec/unittests/decoders/pymatching/test_pymatching_realtime.cpp
@@ -1,0 +1,130 @@
+/*******************************************************************************
+ * Copyright (c) 2024 - 2026 NVIDIA Corporation & Affiliates.                  *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+#include "cudaq/qec/decoder.h"
+#include "qec_realtime_session.h"
+#include "rpc_producer.h"
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <memory>
+#include <span>
+#include <vector>
+
+namespace {
+
+using DecoderVec = std::vector<std::unique_ptr<cudaq::qec::decoder>>;
+
+DecoderVec
+make_pymatching_decoders(const std::vector<std::uint8_t> &h_vec,
+                         std::size_t syndrome_size, std::size_t block_size) {
+  cudaqx::tensor<std::uint8_t> h;
+  h.copy(h_vec.data(), {syndrome_size, block_size});
+
+  DecoderVec decoders;
+  auto decoder =
+      cudaq::qec::decoder::get("pymatching", h, cudaqx::heterogeneous_map{});
+  decoder->set_decoder_id(0);
+  std::vector<std::vector<std::uint32_t>> d_sparse(syndrome_size);
+  for (std::size_t row = 0; row < syndrome_size; ++row)
+    d_sparse[row] = {static_cast<std::uint32_t>(row)};
+  decoder->set_D_sparse(d_sparse);
+  std::vector<std::vector<std::uint32_t>> o_sparse(block_size);
+  for (std::size_t row = 0; row < block_size; ++row)
+    o_sparse[row] = {static_cast<std::uint32_t>(row)};
+  decoder->set_O_sparse(o_sparse);
+  decoders.push_back(std::move(decoder));
+  return decoders;
+}
+
+void expect_corrections(cudaq::qec::realtime::qec_realtime_session &session,
+                        const std::vector<std::uint8_t> &syndrome,
+                        std::span<const std::uint8_t> expected,
+                        std::uint64_t counter, bool reset_on_read = true) {
+  cudaq::qec::decoding::rpc_producer::enqueue_syndromes(
+      session, /*decoder_id=*/0, syndrome.data(), syndrome.size(), counter,
+      /*syndrome_mapping_id=*/0);
+
+  std::vector<std::uint8_t> corrections(expected.size(), 0xCC);
+  cudaq::qec::decoding::rpc_producer::get_corrections(
+      session, /*decoder_id=*/0, corrections.data(), corrections.size(),
+      reset_on_read ? 1 : 0);
+  EXPECT_EQ(corrections,
+            std::vector<std::uint8_t>(expected.begin(), expected.end()));
+}
+
+std::vector<std::uint8_t>
+read_corrections(cudaq::qec::realtime::qec_realtime_session &session,
+                 std::size_t num_corrections) {
+  std::vector<std::uint8_t> corrections(num_corrections, 0xCC);
+  cudaq::qec::decoding::rpc_producer::get_corrections(
+      session, /*decoder_id=*/0, corrections.data(), corrections.size(),
+      /*reset=*/0);
+  return corrections;
+}
+
+void run_case(const std::vector<std::uint8_t> &h_vec,
+              std::size_t syndrome_size, std::size_t block_size,
+              const std::vector<std::pair<std::vector<std::uint8_t>,
+                                          std::vector<std::uint8_t>>> &cases) {
+  auto decoders = make_pymatching_decoders(h_vec, syndrome_size, block_size);
+  cudaq::qec::realtime::qec_realtime_session session(decoders);
+  session.initialize();
+
+  std::uint64_t counter = 1;
+  for (const auto &[syndrome, expected] : cases) {
+    expect_corrections(session, syndrome, expected, counter++);
+    EXPECT_EQ(read_corrections(session, block_size),
+              std::vector<std::uint8_t>(block_size, 0));
+  }
+
+  session.finalize();
+}
+
+} // namespace
+
+TEST(PyMatchingRealtime, CheckRegularEdges) {
+  run_case(/*H=*/{1, 0, 1, 1, 0, 1}, /*syndrome_size=*/3, /*block_size=*/2,
+           {{{1, 1, 0}, {1, 0}},
+            {{0, 1, 1}, {0, 1}},
+            {{1, 0, 1}, {1, 1}}});
+}
+
+TEST(PyMatchingRealtime, CheckBoundaryEdges) {
+  run_case(/*H=*/{1, 0, 0, 0, 1, 0, 0, 0, 1},
+           /*syndrome_size=*/3, /*block_size=*/3,
+           {{{1, 0, 0}, {1, 0, 0}},
+            {{0, 1, 0}, {0, 1, 0}},
+            {{0, 0, 1}, {0, 0, 1}},
+            {{1, 0, 0}, {1, 0, 0}}});
+}
+
+TEST(PyMatchingRealtime, PreservesCallerColumnOrderUnderNonCanonicalOrdering) {
+  run_case(/*H=*/{1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 1, 0, 0, 1, 0},
+           /*syndrome_size=*/4, /*block_size=*/4,
+           {{{0, 0, 0, 1}, {0, 0, 1, 0}},
+            {{0, 0, 1, 0}, {0, 0, 0, 1}},
+            {{1, 0, 0, 0}, {1, 0, 0, 0}}});
+}
+
+TEST(PyMatchingRealtime, ResetDecoderClearsCorrections) {
+  auto decoders =
+      make_pymatching_decoders(/*H=*/{1, 0, 1, 1, 0, 1}, /*syndrome_size=*/3,
+                               /*block_size=*/2);
+  cudaq::qec::realtime::qec_realtime_session session(decoders);
+  session.initialize();
+
+  expect_corrections(session, {1, 0, 1}, std::vector<std::uint8_t>{1, 1},
+                     /*counter=*/1, /*reset_on_read=*/false);
+  EXPECT_EQ(read_corrections(session, 2), (std::vector<std::uint8_t>{1, 1}));
+  cudaq::qec::decoding::rpc_producer::reset_decoder(session, /*decoder_id=*/0);
+  EXPECT_EQ(read_corrections(session, 2), (std::vector<std::uint8_t>{0, 0}));
+
+  session.finalize();
+}

--- a/libs/qec/unittests/decoders/pymatching/test_pymatching_realtime.cpp
+++ b/libs/qec/unittests/decoders/pymatching/test_pymatching_realtime.cpp
@@ -126,3 +126,36 @@ TEST(PyMatchingRealtime, ResetDecoderClearsCorrections) {
 
   session.finalize();
 }
+
+TEST(PyMatchingRealtime, RejectsOversizedSyndromeRequest) {
+  // Single decoder per session (the supported configuration).  The ring slot
+  // has headroom beyond the decoder's per-decode window -- it is also sized for
+  // the response payload and a 64-byte floor -- so an oversized enqueue can
+  // still fit the slot, pass the slot-size check, and reach the new per-decoder
+  // length guard.  Without that guard enqueue_syndrome would overflow the
+  // decoder's accumulation buffer, silently drop the data (it returns false),
+  // and the handler would still ACK success.
+  auto decoders = make_pymatching_decoders(/*H=*/{1, 0, 0, 0, 1, 0, 0, 0, 1},
+                                           /*syndrome_size=*/3,
+                                           /*block_size=*/3);
+  cudaq::qec::realtime::qec_realtime_session session(decoders);
+  session.initialize();
+
+  const std::uint64_t capacity = decoders[0]->get_num_msyn_per_decode();
+  const std::uint64_t oversized = capacity + 1;
+  std::vector<std::uint8_t> oversized_syndrome(oversized, 0);
+  EXPECT_THROW(cudaq::qec::decoding::rpc_producer::enqueue_syndromes(
+                   session, /*decoder_id=*/0, oversized_syndrome.data(),
+                   oversized_syndrome.size(), /*counter=*/1,
+                   /*syndrome_mapping_id=*/0),
+               std::runtime_error);
+
+  // A correctly-sized request to the same decoder is still accepted (confirms
+  // the guard rejected only the oversized one and released the slot).
+  std::vector<std::uint8_t> ok_syndrome(capacity, 0);
+  EXPECT_NO_THROW(cudaq::qec::decoding::rpc_producer::enqueue_syndromes(
+      session, /*decoder_id=*/0, ok_syndrome.data(), ok_syndrome.size(),
+      /*counter=*/2, /*syndrome_mapping_id=*/0));
+
+  session.finalize();
+}

--- a/libs/qec/unittests/decoders/pymatching/test_pymatching_realtime.cpp
+++ b/libs/qec/unittests/decoders/pymatching/test_pymatching_realtime.cpp
@@ -33,11 +33,11 @@ DecoderVec make_pymatching_decoders(const std::vector<std::uint8_t> &h_vec,
   decoder->set_decoder_id(0);
   std::vector<std::vector<std::uint32_t>> d_sparse(syndrome_size);
   for (std::size_t row = 0; row < syndrome_size; ++row)
-    d_sparse[row] = {static_cast<std::uint32_t>(row)};
+    d_sparse[row].push_back(static_cast<std::uint32_t>(row));
   decoder->set_D_sparse(d_sparse);
   std::vector<std::vector<std::uint32_t>> o_sparse(block_size);
   for (std::size_t row = 0; row < block_size; ++row)
-    o_sparse[row] = {static_cast<std::uint32_t>(row)};
+    o_sparse[row].push_back(static_cast<std::uint32_t>(row));
   decoder->set_O_sparse(o_sparse);
   decoders.push_back(std::move(decoder));
   return decoders;


### PR DESCRIPTION
## Summary
This adds a public, CPU-only reference path for the decoder-server runtime message trio using PyMatching and `CUDAQ_DISPATCH_HOST_CALL`.
The new path introduces shared QEC realtime RPC definitions, a small in-process HOST_CALL session, and an RPC producer that writes `enqueue_syndromes`, `get_corrections`, and `reset_decoder` messages through a same-process RX/TX ring. The HOST_CALL handlers reuse the existing `decoder` base accumulator methods, so PyMatching does not need decoder-specific realtime overrides.
This intentionally does not add CUDA dispatch files, surface-code integration, env-var production routing, or any private nv-qldpc pieces.
## What changed
- Adds decoder-server runtime RPC IDs and wire payload helpers.
- Adds a host-only realtime session backed by `cudaq_host_dispatcher_loop`.
- Adds an RPC producer for the three-message flow.
- Adds PyMatching realtime tests that mirror existing PyMatching behavioral cases over the RPC path and verify reset clears accumulated corrections.
## Test plan
```bash
ctest -R "PyMatchingDecoder|PyMatchingRealtime"