### PR TITLE
Prevent vendored dependency artifacts leakage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,10 @@ project(CUDAQX
   VERSION 0.0.0
   LANGUAGES C CXX)
 
+# Do not let vendored dependencies add their own install rules to CUDA-QX
+# packages. CUDA-QX installs only its public artifacts.
+set(FMT_INSTALL OFF CACHE BOOL "Generate the fmt install target." FORCE)
+
 set(CUDAQX_ALL_LIBS "qec;solvers")
 set(CUDAQX_ENABLE_LIBS "all" CACHE STRING
   "Semicolon-separated list of libs to build (${CUDAQX_ALL_LIBS}), or \"all\".")

--- a/libs/core/CMakeLists.txt
+++ b/libs/core/CMakeLists.txt
@@ -37,6 +37,7 @@ option(CUDAQX_CORE_INCLUDE_TESTS
 # ==============================================================================
 
 include(FetchContent)
+include(GNUInstallDirs)
 
 FetchContent_Declare(
   xtl
@@ -70,4 +71,3 @@ if (CUDAQX_CORE_INCLUDE_TESTS)
   add_custom_target(CUDAQXCoreUnitTests)
   add_subdirectory(unittests)
 endif()
-

--- a/libs/core/lib/CMakeLists.txt
+++ b/libs/core/lib/CMakeLists.txt
@@ -26,8 +26,7 @@ target_link_libraries(cudaqx-core
 )
 
 install(DIRECTORY ${CUDAQX_CORE_INCLUDE_DIR}/cuda-qx
-  DESTINATION "${CUDAQ_INCLUDE_DIR}"
+  DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
   COMPONENT cudaqx-core
   FILES_MATCHING PATTERN "*.h"
 )
-

--- a/libs/qec/lib/decoders/plugins/pymatching/CMakeLists.txt
+++ b/libs/qec/lib/decoders/plugins/pymatching/CMakeLists.txt
@@ -17,6 +17,7 @@ FetchContent_Declare(
   pymatching
   GIT_REPOSITORY https://github.com/oscarhiggott/PyMatching
   GIT_TAG e27b8c6a5f5ba10fb74d4ebb29822f2df5e12bcd # v2.3.1
+  EXCLUDE_FROM_ALL
   # Disable test targets because they cause wheel build issues and GTest issues.
   PATCH_COMMAND sed -i
     -e "/^add_executable(pymatching_tests /i if(FALSE)  # skip tests when used as FetchContent"


### PR DESCRIPTION
## Description

Cleans up CUDA-QX install/package artifacts so vendored dependency install rules do not leak into `installed_files.zip`.

This prevents third-party artifacts such as:

- `bin/pymatching`
- `lib/libpymatching.a`
- `include/pymatching/*`
- `lib/libfmt.a`
- `include/fmt/*`
- `lib/cmake/fmt/*`

from being included in the package overlay generated by `ninja zip_installed_files`.

Changes:
- Disables `fmt` install rules for the vendored `fmt` dependency.
- Marks vendored PyMatching `FetchContent` as `EXCLUDE_FROM_ALL` so its upstream install rules do not enter the top-level install manifest.
- Installs CUDA-QX core headers under the CUDA-QX install include directory instead of the CUDA-Q install include path.

This does not change runtime code or decoder behavior; it only affects install/package contents.

## Validation

Validated with:

```bash
cmake -S . -B build -DCMAKE_BUILD_TYPE=Release
ninja -C build install
ninja -C build zip_installed_files
unzip -l build/installed_files.zip | tee build/zip_contents_after.txt
```

Validated by regenerating `installed_files.zip` and checking both the install manifest and zip listing.

The leakage check now produces no output:

```bash
grep -iE 'bin/pymatching|lib/libpymatching\.a|include/pymatching|lib/libfmt\.a|include/fmt|lib/cmake/fmt|lib/pkgconfig/fmt\.pc|usr/local/cudaq' \
  build/install_manifest.txt build/zip_contents_after.txt
```

## Runtime / performance impact

N/A

## Self-review checklist

Please confirm each item before requesting review. Check `[x]` or strike
through and explain.

### Before requesting review
- [x] I reviewed my own full diff in GitHub or my editor.
- [x] PR is in Draft if it is not yet ready for review.
- [x] Temporary / debugging changes have been removed.
- [x] Local test logs reviewed; no unexplained warnings or errors.
- [x] CI logs reviewed; no unexplained warnings or errors.
- [x] Full CI has been run.

### Scope and size
- [x] PR is under ~1000 lines, or an exception is justified in the description.
- [x] Refactoring-only changes are isolated in their own PR(s).
- [x] No existing tests were disabled or modified just to make this PR pass
      (if so, an issue has been raised).

### Tests
- [x] New functionality has new tests.
      CMake/package behavior was validated by regenerating `installed_files.zip` and inspecting its contents.
- [x] Tests fail if the new functionality is broken.
      The package-content check fails if vendored artifacts remain in `installed_files.zip`.
- [x] Negative tests added where exceptions are expected.
      N/A, no exception behavior changed.
- [x] Truth data added where simple `EXPECT_*` / `assert` checks are insufficient.
      N/A, no algorithmic behavior changed.
- [x] CI runtime impact considered; team notified if significant.

### Documentation
- [x] Public-facing APIs have Doxygen docs.
      N/A, no public API changes.
- [x] User-visible behavior changes have public docs, or a follow-up is tracked.
      N/A, package cleanup only.

### Code style
- [x] Naming follows the existing convention (`snake_case` vs `camelCase`) for the area being modified.

### Dependencies
- [x] No new third-party dependencies, or the team has been notified and OSRB tickets filed.
