### PR TITLE
Wheel cache cleanup

### DIFF
--- a/.github/actions/get-cudaq-wheels/action.yaml
+++ b/.github/actions/get-cudaq-wheels/action.yaml
@@ -12,8 +12,8 @@ inputs:
     description: 'CUDAQ repository access token.'
     default: ''
     required: false
-  pr-number:
-    description: 'Unique pull request identifier.'
+  cache-key-suffix:
+    description: 'Unique identifier to append to cache keys.'
     default: ''
     required: false
   save-build:
@@ -53,8 +53,9 @@ runs:
       run: |
         hash=${{ hashFiles(format('{0}', env.to_hash)) }}
         echo "main=cudaq-wheels-${{ inputs.platform }}-cu${{ inputs.cuda_version }}-${{ inputs.ref }}-$hash" >> $GITHUB_OUTPUT
-        if [[ -n "${{ inputs.pr-number }}" ]]; then
-          echo "pr=-pr${{ inputs.pr-number }}" >> $GITHUB_OUTPUT
+        suffix="${{ inputs.cache-key-suffix }}"
+        if [[ -n "$suffix" ]]; then
+          echo "suffix=-$suffix" >> $GITHUB_OUTPUT
         fi
         sudo mkdir /cudaq-wheels && sudo chmod 777 /cudaq-wheels
       shell: bash --noprofile --norc -euo pipefail {0}
@@ -65,7 +66,7 @@ runs:
       with:
         fail-on-cache-miss: false
         path: /cudaq-wheels
-        key: ${{ steps.cudaq-wheels-key.outputs.main }}${{ steps.cudaq-wheels-key.outputs.pr }}
+        key: ${{ steps.cudaq-wheels-key.outputs.main }}${{ steps.cudaq-wheels-key.outputs.suffix }}
         restore-keys: ${{ steps.cudaq-wheels-key.outputs.main }}
         lookup-only: ${{ inputs.lookup-only }}
 
@@ -155,4 +156,4 @@ runs:
       uses: actions/cache/save@v4
       with:
         path: /cudaq-wheels
-        key: ${{ steps.cudaq-wheels-key.outputs.main }}${{ steps.cudaq-wheels-key.outputs.pr }}
+        key: ${{ steps.cudaq-wheels-key.outputs.main }}${{ steps.cudaq-wheels-key.outputs.suffix }}

--- a/.github/workflows/build_wheels.yaml
+++ b/.github/workflows/build_wheels.yaml
@@ -36,6 +36,10 @@ on:
         type: string
         description: Optional argument to take artifacts from a prior run of this workflow; facilitates rerunning a failed workflow without re-building the artifacts.
         required: false
+      cache_key_suffix:
+        type: string
+        description: Optional suffix to append to CUDA-Q wheel cache keys.
+        required: false
   workflow_call:
     inputs:
       build_type:
@@ -58,6 +62,10 @@ on:
         default: ''
         required: false
       artifacts_from_run:
+        type: string
+        default: ''
+        required: false
+      cache_key_suffix:
         type: string
         default: ''
         required: false
@@ -283,6 +291,7 @@ jobs:
           repo: ${{ steps.get-cudaq-version.outputs.repo }}
           ref: ${{ steps.get-cudaq-version.outputs.ref }}
           token: ${{ secrets.CUDAQ_ACCESS_TOKEN }}
+          cache-key-suffix: ${{ inputs.cache_key_suffix }}
           save-build: true
           platform: ${{ matrix.platform }}
 

--- a/.github/workflows/nightly_tests.yaml
+++ b/.github/workflows/nightly_tests.yaml
@@ -140,7 +140,7 @@ jobs:
 
           for key in $cache_keys
           do
-            if [[ $key =~ (^|-)nightly$ ]]; then
+            if [[ $key =~ -nightly$ ]]; then
               gh cache delete $key --repo ${{ github.repository }}
               echo "Deleted cache entry: $key"
             fi

--- a/.github/workflows/nightly_tests.yaml
+++ b/.github/workflows/nightly_tests.yaml
@@ -12,6 +12,7 @@ jobs:
     with:
       build_type: Release
       cudaq_wheels: Custom
+      cache_key_suffix: nightly
     secrets: inherit
 
   resolve-cudaq-main:
@@ -68,7 +69,7 @@ jobs:
           repo: ${{ needs.resolve-cudaq-main.outputs.repo }}
           ref: ${{ needs.resolve-cudaq-main.outputs.ref }}
           token: ${{ secrets.CUDAQ_ACCESS_TOKEN }}
-          cache-key-suffix: nightly-cudaq-main
+          cache-key-suffix: nightly
           save-build: true
           save-ccache: false
           platform: ${{ matrix.platform }}-cu${{ steps.config.outputs.cuda_major }}
@@ -80,7 +81,7 @@ jobs:
     with:
       cudaq_repo: ${{ needs.resolve-cudaq-main.outputs.repo }}
       cudaq_ref: ${{ needs.resolve-cudaq-main.outputs.ref }}
-      cache_key_suffix: nightly-cudaq-main
+      cache_key_suffix: nightly
     secrets: inherit
 
   cudaq-main-qec:
@@ -90,7 +91,7 @@ jobs:
     with:
       cudaq_repo: ${{ needs.resolve-cudaq-main.outputs.repo }}
       cudaq_ref: ${{ needs.resolve-cudaq-main.outputs.ref }}
-      cache_key_suffix: nightly-cudaq-main
+      cache_key_suffix: nightly
     secrets: inherit
 
   cudaq-main-solvers:
@@ -100,7 +101,7 @@ jobs:
     with:
       cudaq_repo: ${{ needs.resolve-cudaq-main.outputs.repo }}
       cudaq_ref: ${{ needs.resolve-cudaq-main.outputs.ref }}
-      cache_key_suffix: nightly-cudaq-main
+      cache_key_suffix: nightly
     secrets: inherit
 
   cudaq-main-docs:
@@ -110,7 +111,7 @@ jobs:
     with:
       cudaq_repo: ${{ needs.resolve-cudaq-main.outputs.repo }}
       cudaq_ref: ${{ needs.resolve-cudaq-main.outputs.ref }}
-      cache_key_suffix: nightly-cudaq-main
+      cache_key_suffix: nightly
     secrets: inherit
 
   cleanup-nightly-cache:
@@ -139,7 +140,7 @@ jobs:
 
           for key in $cache_keys
           do
-            if [[ $key =~ nightly-cudaq-main ]]; then
+            if [[ $key =~ (^|-)nightly$ ]]; then
               gh cache delete $key --repo ${{ github.repository }}
               echo "Deleted cache entry: $key"
             fi

--- a/.github/workflows/pr_cache_cleanup.yaml
+++ b/.github/workflows/pr_cache_cleanup.yaml
@@ -22,7 +22,7 @@ jobs:
 
           for key in $cache_keys
           do
-            if [[ $key =~ pr$pr_number ]]; then
+            if [[ $key =~ (^|-)pr${pr_number}$ ]]; then
               gh cache delete $key --repo ${{ github.repository }}
               echo "Deleted cache entry: $key"
             fi

--- a/.github/workflows/pr_cache_cleanup.yaml
+++ b/.github/workflows/pr_cache_cleanup.yaml
@@ -22,7 +22,7 @@ jobs:
 
           for key in $cache_keys
           do
-            if [[ $key =~ (^|-)pr${pr_number}$ ]]; then
+            if [[ $key =~ -pr${pr_number}$ ]]; then
               gh cache delete $key --repo ${{ github.repository }}
               echo "Deleted cache entry: $key"
             fi

--- a/.github/workflows/pr_workflow.yaml
+++ b/.github/workflows/pr_workflow.yaml
@@ -212,6 +212,7 @@ jobs:
     with:
       build_type: Release
       cudaq_wheels: Custom
+      cache_key_suffix: pr${{ needs.check-changes.outputs.pr-number }}
     secrets:
       CUDAQ_ACCESS_TOKEN: ${{ secrets.CUDAQ_ACCESS_TOKEN }}
 


### PR DESCRIPTION
<!--
Thanks for contributing to CUDA-Q Libraries!

Please read the full Pull Request Guidelines in Contributing.md:
https://github.com/NVIDIA/cudaqx/blob/main/Contributing.md#pull-request-guidelines
-->

## Description

<!-- What does this PR change, and why? Link related issues. -->

Expand the wheel build to accept a suffix for its cache keys, enabling its cache entries to be cleaned up.

## Runtime / performance impact

<!--
If this change affects performance, paste benchmark numbers here.
Otherwise write "N/A".
-->

## Self-review checklist

Please confirm each item before requesting review. Check `[x]` or strike
through and explain.

### Before requesting review
- [x] I reviewed my own full diff in GitHub or my editor.
- [x] PR is in Draft if it is not yet ready for review.
- [x] Temporary / debugging changes have been removed.
- [x] Local test logs reviewed; no unexplained warnings or errors.
- [x] CI logs reviewed; no unexplained warnings or errors.
- [x] Full CI has been run.

### Scope and size
- [x] PR is under ~1000 lines, or an exception is justified in the description.
- [x] Refactoring-only changes are isolated in their own PR(s).
- [x] No existing tests were disabled or modified just to make this PR pass
      (if so, an issue has been raised).

### Tests
- [x] New functionality has new tests.
- [x] Tests fail if the new functionality is broken (including crashes), not
      just when it is missing.
- [x] Negative tests added where exceptions are expected.
- [x] Truth data added where simple `EXPECT_*` / `assert` checks are
      insufficient for algorithmic correctness.
- [x] CI runtime impact considered; team notified if significant.

### Documentation
- [x] Public-facing APIs have Doxygen docs.
- [x] User-visible behavior changes have public docs, or a follow-up is
      tracked.

### Code style
- [x] Naming follows the existing convention (`snake_case` vs `camelCase`) for
      the area being modified.

### Dependencies
- [x] No new third-party dependencies, **or** the team has been notified and
      OSRB tickets filed.
