### PR TITLE
Dem from stim text can use error decompositions

### DIFF
--- a/docs/sphinx/api/qec/cpp_api.rst
+++ b/docs/sphinx/api/qec/cpp_api.rst
@@ -33,7 +33,7 @@ Detector Error Model
 .. doxygenfunction:: cudaq::qec::dem_from_memory_circuit(const code &, operation, std::size_t, cudaq::noise_model &)
 .. doxygenfunction:: cudaq::qec::x_dem_from_memory_circuit(const code &, operation, std::size_t, cudaq::noise_model &)
 .. doxygenfunction:: cudaq::qec::z_dem_from_memory_circuit(const code &, operation, std::size_t, cudaq::noise_model &)
-.. doxygenfunction:: cudaq::qec::dem_from_stim_text(const std::string &)
+.. doxygenfunction:: cudaq::qec::dem_from_stim_text(const std::string &, bool)
 
 Decoder Interfaces
 ==================

--- a/docs/sphinx/examples/qec/cpp/stim_dem_decoder.cpp
+++ b/docs/sphinx/examples/qec/cpp/stim_dem_decoder.cpp
@@ -22,14 +22,17 @@ int main() {
   const std::string dem_text = R"(error(0.1) D0 L0
 error(0.1) D1 L0
 error(0.05) D0 D1
+error(0.02) D0 ^ D1
 )";
 
   auto decoder = cudaq::qec::get_decoder("single_error_lut", dem_text);
   auto dem = cudaq::qec::dem_from_stim_text(dem_text);
+  auto dem_decomposed = cudaq::qec::dem_from_stim_text(dem_text, /*decompose_errors=*/true);
 
   std::cout << "detectors: " << dem.num_detectors() << "\n";
   std::cout << "error mechanisms: " << dem.num_error_mechanisms() << "\n";
   std::cout << "observables: " << dem.num_observables() << "\n";
+  std::cout << "error mechanisms (decomposed): " << dem_decomposed.num_error_mechanisms() << "\n";
 
   const std::vector<std::vector<cudaq::qec::float_t>> syndromes = {
       {0.0, 0.0}, {1.0, 0.0}, {0.0, 1.0}, {1.0, 1.0}};

--- a/docs/sphinx/examples/qec/cpp/stim_dem_decoder.cpp
+++ b/docs/sphinx/examples/qec/cpp/stim_dem_decoder.cpp
@@ -27,12 +27,14 @@ error(0.02) D0 ^ D1
 
   auto decoder = cudaq::qec::get_decoder("single_error_lut", dem_text);
   auto dem = cudaq::qec::dem_from_stim_text(dem_text);
-  auto dem_decomposed = cudaq::qec::dem_from_stim_text(dem_text, /*decompose_errors=*/true);
+  auto dem_decomposed =
+      cudaq::qec::dem_from_stim_text(dem_text, /*decompose_errors=*/true);
 
   std::cout << "detectors: " << dem.num_detectors() << "\n";
   std::cout << "error mechanisms: " << dem.num_error_mechanisms() << "\n";
   std::cout << "observables: " << dem.num_observables() << "\n";
-  std::cout << "error mechanisms (decomposed): " << dem_decomposed.num_error_mechanisms() << "\n";
+  std::cout << "error mechanisms (decomposed): "
+            << dem_decomposed.num_error_mechanisms() << "\n";
 
   const std::vector<std::vector<cudaq::qec::float_t>> syndromes = {
       {0.0, 0.0}, {1.0, 0.0}, {0.0, 1.0}, {1.0, 1.0}};

--- a/docs/sphinx/examples/qec/cpp/stim_dem_decoder.cpp
+++ b/docs/sphinx/examples/qec/cpp/stim_dem_decoder.cpp
@@ -25,15 +25,22 @@ error(0.05) D0 D1
 error(0.02) D0 ^ D1
 )";
 
+  // Decoder construction uses default parsing (use_decomp_suggestions=false):
+  // '^' hints in the DEM text are ignored.
   auto decoder = cudaq::qec::get_decoder("single_error_lut", dem_text);
   auto dem = cudaq::qec::dem_from_stim_text(dem_text);
-  auto dem_decomposed =
-      cudaq::qec::dem_from_stim_text(dem_text, /*decompose_errors=*/true);
 
   std::cout << "detectors: " << dem.num_detectors() << "\n";
-  std::cout << "error mechanisms: " << dem.num_error_mechanisms() << "\n";
+  std::cout << "error mechanisms (used by decoder): "
+            << dem.num_error_mechanisms() << "\n";
   std::cout << "observables: " << dem.num_observables() << "\n";
-  std::cout << "error mechanisms (decomposed): "
+
+  // Inspection only: show how many columns the matrix would have if
+  // '^' hints were honored. This does not affect the decoder above.
+  auto dem_decomposed =
+      cudaq::qec::dem_from_stim_text(dem_text, /*use_decomp_suggestions=*/true);
+
+  std::cout << "error mechanisms (if ^ hints honored): "
             << dem_decomposed.num_error_mechanisms() << "\n";
 
   const std::vector<std::vector<cudaq::qec::float_t>> syndromes = {

--- a/docs/sphinx/examples/qec/python/stim_dem_decoder.py
+++ b/docs/sphinx/examples/qec/python/stim_dem_decoder.py
@@ -13,14 +13,17 @@ dem_text = """\
 error(0.1) D0 L0
 error(0.1) D1 L0
 error(0.05) D0 D1
+error(0.02) D0 ^ D1
 """
 
 decoder = qec.get_decoder("single_error_lut", dem_text)
 dem = qec.dem_from_stim_text(dem_text)
+dem_decomposed = qec.dem_from_stim_text(dem_text, decompose_errors=True)
 
 print("detectors:", dem.num_detectors())
 print("error mechanisms:", dem.num_error_mechanisms())
 print("observables:", dem.num_observables())
+print("error mechanisms (decomposed):", dem_decomposed.num_error_mechanisms())
 
 syndromes = np.array([[0, 0], [1, 0], [0, 1], [1, 1]], dtype=np.uint8)
 results = decoder.decode_batch(syndromes)

--- a/docs/sphinx/examples/qec/python/stim_dem_decoder.py
+++ b/docs/sphinx/examples/qec/python/stim_dem_decoder.py
@@ -16,14 +16,21 @@ error(0.05) D0 D1
 error(0.02) D0 ^ D1
 """
 
+# Decoder construction uses default parsing (use_decomp_suggestions=False):
+# '^' hints in the DEM text are ignored.
 decoder = qec.get_decoder("single_error_lut", dem_text)
 dem = qec.dem_from_stim_text(dem_text)
-dem_decomposed = qec.dem_from_stim_text(dem_text, decompose_errors=True)
 
 print("detectors:", dem.num_detectors())
-print("error mechanisms:", dem.num_error_mechanisms())
+print("error mechanisms (used by decoder):", dem.num_error_mechanisms())
 print("observables:", dem.num_observables())
-print("error mechanisms (decomposed):", dem_decomposed.num_error_mechanisms())
+
+# Inspection only: show how many columns the matrix would have if '^'
+# hints were honored. This does not affect the decoder above.
+dem_decomposed = qec.dem_from_stim_text(dem_text, use_decomp_suggestions=True)
+
+print("error mechanisms (if ^ hints honored):",
+      dem_decomposed.num_error_mechanisms())
 
 syndromes = np.array([[0, 0], [1, 0], [0, 1], [1, 1]], dtype=np.uint8)
 results = decoder.decode_batch(syndromes)

--- a/docs/sphinx/examples_rst/qec/stim_dem_decoder.rst
+++ b/docs/sphinx/examples_rst/qec/stim_dem_decoder.rst
@@ -11,6 +11,17 @@ matrix and supplies DEM-derived ``O`` and ``error_rate_vec`` defaults when the
 user does not provide them. C++ decoder plugins that need full Stim DEM
 metadata can consume the raw DEM string from the decoder construction input.
 
+By default, ``get_decoder(..., dem_text)`` and ``dem_from_stim_text(dem_text)``
+parse with ``use_decomp_suggestions=False``. Stim ``^`` decomposition hints are
+ignored and each ``error(...)`` instruction becomes one matrix column. The
+example below constructs a decoder this way and uses the matching parsed matrix
+for observable predictions.
+
+``dem_from_stim_text`` also accepts ``use_decomp_suggestions=True`` to split
+``^``-separated components into separate columns. That call is shown for
+inspection only; it does not change how ``get_decoder`` parses the same DEM
+text string.
+
 .. tab:: Python
 
    .. literalinclude:: ../../examples/qec/python/stim_dem_decoder.py

--- a/libs/qec/include/cudaq/qec/detector_error_model.h
+++ b/libs/qec/include/cudaq/qec/detector_error_model.h
@@ -23,8 +23,10 @@ namespace cudaq::qec {
 ///
 /// Shared size parameters among the matrix types.
 /// - `detector_error_matrix`: num_detectors x num_error_mechanisms [d, e]
-/// - `error_rates`: num_error_mechanisms
 /// - `observables_flips_matrix`: num_observables x num_error_mechanisms [k, e]
+/// - `error_rates`: num_physical_error_mechanisms (≤ num_error_mechanisms)
+/// - `error_ids` (optional): num_error_mechanisms — maps column i to its
+///   corresponding physical error mechanismin `error_rates`
 ///
 /// @note The C++ API for this class may change in the future. The Python API is
 /// more likely to be backwards compatible.
@@ -35,9 +37,10 @@ struct detector_error_model {
   /// i is triggered by error mechanism j, and 0 otherwise.
   cudaqx::tensor<uint8_t> detector_error_matrix;
 
-  /// The list of weights has length equal to the number of columns of
-  /// `detector_error_matrix`, which assigns a likelihood to each error
-  /// mechanism.
+  /// One entry per distinct physical error mechanism. When `error_ids` is not
+  /// set, this equals one entry per column of `detector_error_matrix`. When
+  /// `error_ids` is set, this equals one entry per distinct physical error
+  /// mechanism. Use `error_rates[error_ids[i]]` for the rate of column i.
   std::vector<double> error_rates;
 
   /// The observables flips matrix is a specific kind of circuit-level parity-
@@ -82,13 +85,16 @@ struct detector_error_model {
                                bool remove_zero_syndrome_errors = false);
 };
 
-/// Parse Stim DEM text into detector/observable flip matrices and error rates.
-/// DEM-native decoders should consume raw DEM text instead.
-/// If @p decompose_errors is true, error mechanisms that carry an explicit
-/// graphlike decomposition (components separated by '^' in the DEM text) are
-/// expanded into one column per component; otherwise the '^' separators are
-/// ignored and each error instruction produces a single column.
+/// Parse the Stim DEM string @p dem_text into detector/observable flip
+/// matrices and error rates. DEM-native decoders should consume raw DEM text
+/// instead. By default (@p use_decomp_suggestions = false) the '^' separators
+/// are ignored and each error instruction produces a single column. If
+/// @p use_decomp_suggestions is true, error mechanisms that carry an explicit
+/// graphlike decomposition (components separated by '^') are expanded into one
+/// column per component; @p error_ids is then populated so that columns sharing
+/// an ID originate from the same instruction and carry correlated (not
+/// independent) error rates.
 detector_error_model dem_from_stim_text(const std::string &dem_text,
-                                        bool decompose_errors = false);
+                                        bool use_decomp_suggestions = false);
 
 } // namespace cudaq::qec

--- a/libs/qec/include/cudaq/qec/detector_error_model.h
+++ b/libs/qec/include/cudaq/qec/detector_error_model.h
@@ -84,6 +84,11 @@ struct detector_error_model {
 
 /// Parse Stim DEM text into detector/observable flip matrices and error rates.
 /// DEM-native decoders should consume raw DEM text instead.
-detector_error_model dem_from_stim_text(const std::string &dem_text);
+/// If @p decompose_errors is true, error mechanisms that carry an explicit
+/// graphlike decomposition (components separated by '^' in the DEM text) are
+/// expanded into one column per component; otherwise the '^' separators are
+/// ignored and each error instruction produces a single column.
+detector_error_model dem_from_stim_text(const std::string &dem_text,
+                                        bool decompose_errors = false);
 
 } // namespace cudaq::qec

--- a/libs/qec/include/cudaq/qec/detector_error_model.h
+++ b/libs/qec/include/cudaq/qec/detector_error_model.h
@@ -23,10 +23,8 @@ namespace cudaq::qec {
 ///
 /// Shared size parameters among the matrix types.
 /// - `detector_error_matrix`: num_detectors x num_error_mechanisms [d, e]
+/// - `error_rates`: num_error_mechanisms
 /// - `observables_flips_matrix`: num_observables x num_error_mechanisms [k, e]
-/// - `error_rates`: num_physical_error_mechanisms (≤ num_error_mechanisms)
-/// - `error_ids` (optional): num_error_mechanisms — maps column i to its
-///   corresponding physical error mechanismin `error_rates`
 ///
 /// @note The C++ API for this class may change in the future. The Python API is
 /// more likely to be backwards compatible.
@@ -37,10 +35,9 @@ struct detector_error_model {
   /// i is triggered by error mechanism j, and 0 otherwise.
   cudaqx::tensor<uint8_t> detector_error_matrix;
 
-  /// One entry per distinct physical error mechanism. When `error_ids` is not
-  /// set, this equals one entry per column of `detector_error_matrix`. When
-  /// `error_ids` is set, this equals one entry per distinct physical error
-  /// mechanism. Use `error_rates[error_ids[i]]` for the rate of column i.
+  /// The list of weights has length equal to the number of columns of
+  /// `detector_error_matrix`, which assigns a likelihood to each error
+  /// mechanism.
   std::vector<double> error_rates;
 
   /// The observables flips matrix is a specific kind of circuit-level parity-
@@ -91,9 +88,9 @@ struct detector_error_model {
 /// are ignored and each error instruction produces a single column. If
 /// @p use_decomp_suggestions is true, error mechanisms that carry an explicit
 /// graphlike decomposition (components separated by '^') are expanded into one
-/// column per component; @p error_ids is then populated so that columns sharing
-/// an ID originate from the same instruction and carry correlated (not
-/// independent) error rates.
+/// column per component, each inheriting the probability of the parent
+/// instruction. @p error_ids is always left as nullopt. Note that this is a
+/// lossy approximation of the original DEM.
 detector_error_model dem_from_stim_text(const std::string &dem_text,
                                         bool use_decomp_suggestions = false);
 

--- a/libs/qec/lib/detector_error_model.cpp
+++ b/libs/qec/lib/detector_error_model.cpp
@@ -21,7 +21,8 @@
 
 namespace cudaq::qec {
 
-detector_error_model dem_from_stim_text(const std::string &dem_text) {
+detector_error_model dem_from_stim_text(const std::string &dem_text,
+                                        bool decompose_errors) {
   auto dem = [&dem_text]() {
     try {
       return stim::DetectorErrorModel(dem_text);
@@ -51,11 +52,10 @@ detector_error_model dem_from_stim_text(const std::string &dem_text) {
                                std::to_string(prob) +
                                " out of range [0, 1] at instruction index " +
                                std::to_string(instruction_index));
+
     std::vector<std::size_t> dets;
     std::vector<std::size_t> obs;
-    for (const auto &target : inst.target_data) {
-      if (target.is_separator())
-        continue;
+    auto push_target = [&](const stim::DemTarget &target) {
       if (target.is_relative_detector_id()) {
         dets.push_back(static_cast<std::size_t>(target.val()));
       } else if (target.is_observable_id()) {
@@ -67,10 +67,38 @@ detector_error_model dem_from_stim_text(const std::string &dem_text) {
             ") contains an unsupported target kind; only D* (detector) and "
             "L* (observable) targets are supported by the fallback parser");
       }
+    };
+
+    if (decompose_errors) {
+      // Each segment delimited by '^' in the DEM text becomes its own column.
+      auto flush = [&]() {
+        if (!dets.empty() || !obs.empty()) {
+          detector_hits.push_back(dets);
+          observable_hits.push_back(obs);
+          rates.push_back(prob);
+          dets.clear();
+          obs.clear();
+        }
+      };
+      for (const auto &target : inst.target_data) {
+        if (target.is_separator()) {
+          flush();
+        } else {
+          push_target(target);
+        }
+      }
+      flush();
+    } else {
+      // Ignore '^' separators; all targets become a single column.
+      for (const auto &target : inst.target_data) {
+        if (target.is_separator())
+          continue;
+        push_target(target);
+      }
+      detector_hits.push_back(std::move(dets));
+      observable_hits.push_back(std::move(obs));
+      rates.push_back(prob);
     }
-    detector_hits.push_back(std::move(dets));
-    observable_hits.push_back(std::move(obs));
-    rates.push_back(prob);
     ++instruction_index;
   });
 

--- a/libs/qec/lib/detector_error_model.cpp
+++ b/libs/qec/lib/detector_error_model.cpp
@@ -39,7 +39,6 @@ detector_error_model dem_from_stim_text(const std::string &dem_text,
   std::vector<std::vector<std::size_t>> detector_hits;
   std::vector<std::vector<std::size_t>> observable_hits;
   std::vector<double> error_rates;
-  std::vector<std::size_t> error_ids;
   std::size_t instruction_index = 0;
 
   dem.iter_flatten_error_instructions([&](const stim::DemInstruction &inst) {
@@ -56,8 +55,6 @@ detector_error_model dem_from_stim_text(const std::string &dem_text,
 
     std::set<std::size_t> dets_parity;
     std::set<std::size_t> obs_parity;
-    bool new_col =
-        true; // true until this instruction produces its first column
 
     auto toggle = [](std::set<std::size_t> &s, std::size_t v) {
       if (!s.erase(v)) {
@@ -83,11 +80,7 @@ detector_error_model dem_from_stim_text(const std::string &dem_text,
       if (!dets_parity.empty() || !obs_parity.empty()) {
         detector_hits.push_back({dets_parity.begin(), dets_parity.end()});
         observable_hits.push_back({obs_parity.begin(), obs_parity.end()});
-        if (new_col) {
-          error_rates.push_back(prob);
-          new_col = false;
-        }
-        error_ids.push_back(error_rates.size() - 1);
+        error_rates.push_back(prob);
         dets_parity.clear();
         obs_parity.clear();
       }
@@ -116,9 +109,6 @@ detector_error_model dem_from_stim_text(const std::string &dem_text,
   result.observables_flips_matrix =
       cudaqx::tensor<uint8_t>({num_observables, num_cols});
   result.error_rates = std::move(error_rates);
-  if (use_decomp_suggestions) {
-    result.error_ids = std::move(error_ids);
-  }
 
   for (std::size_t err = 0; err < num_cols; ++err) {
     for (auto det : detector_hits[err]) {

--- a/libs/qec/lib/detector_error_model.cpp
+++ b/libs/qec/lib/detector_error_model.cpp
@@ -22,7 +22,7 @@
 namespace cudaq::qec {
 
 detector_error_model dem_from_stim_text(const std::string &dem_text,
-                                        bool decompose_errors) {
+                                        bool use_decomp_suggestions) {
   auto dem = [&dem_text]() {
     try {
       return stim::DetectorErrorModel(dem_text);
@@ -38,7 +38,8 @@ detector_error_model dem_from_stim_text(const std::string &dem_text,
 
   std::vector<std::vector<std::size_t>> detector_hits;
   std::vector<std::vector<std::size_t>> observable_hits;
-  std::vector<double> rates;
+  std::vector<double> error_rates;
+  std::vector<std::size_t> error_ids;
   std::size_t instruction_index = 0;
 
   dem.iter_flatten_error_instructions([&](const stim::DemInstruction &inst) {
@@ -53,13 +54,22 @@ detector_error_model dem_from_stim_text(const std::string &dem_text,
                                " out of range [0, 1] at instruction index " +
                                std::to_string(instruction_index));
 
-    std::vector<std::size_t> dets;
-    std::vector<std::size_t> obs;
+    std::set<std::size_t> dets_parity;
+    std::set<std::size_t> obs_parity;
+    bool new_col =
+        true; // true until this instruction produces its first column
+
+    auto toggle = [](std::set<std::size_t> &s, std::size_t v) {
+      if (!s.erase(v)) {
+        s.insert(v);
+      }
+    };
+
     auto push_target = [&](const stim::DemTarget &target) {
       if (target.is_relative_detector_id()) {
-        dets.push_back(static_cast<std::size_t>(target.val()));
+        toggle(dets_parity, static_cast<std::size_t>(target.val()));
       } else if (target.is_observable_id()) {
-        obs.push_back(static_cast<std::size_t>(target.val()));
+        toggle(obs_parity, static_cast<std::size_t>(target.val()));
       } else {
         throw std::runtime_error(
             "Stim DEM error instruction (index " +
@@ -69,51 +79,48 @@ detector_error_model dem_from_stim_text(const std::string &dem_text,
       }
     };
 
-    if (decompose_errors) {
-      // Each segment delimited by '^' in the DEM text becomes its own column.
-      auto flush = [&]() {
-        if (!dets.empty() || !obs.empty()) {
-          detector_hits.push_back(dets);
-          observable_hits.push_back(obs);
-          rates.push_back(prob);
-          dets.clear();
-          obs.clear();
+    auto flush = [&]() {
+      if (!dets_parity.empty() || !obs_parity.empty()) {
+        detector_hits.push_back({dets_parity.begin(), dets_parity.end()});
+        observable_hits.push_back({obs_parity.begin(), obs_parity.end()});
+        if (new_col) {
+          error_rates.push_back(prob);
+          new_col = false;
         }
-      };
-      for (const auto &target : inst.target_data) {
-        if (target.is_separator()) {
+        error_ids.push_back(error_rates.size() - 1);
+        dets_parity.clear();
+        obs_parity.clear();
+      }
+    };
+
+    for (const auto &target : inst.target_data) {
+      if (target.is_separator()) {
+        if (use_decomp_suggestions) {
           flush();
-        } else {
-          push_target(target);
         }
+        continue;
       }
-      flush();
-    } else {
-      // Ignore '^' separators; all targets become a single column.
-      for (const auto &target : inst.target_data) {
-        if (target.is_separator())
-          continue;
-        push_target(target);
-      }
-      detector_hits.push_back(std::move(dets));
-      observable_hits.push_back(std::move(obs));
-      rates.push_back(prob);
+      push_target(target);
     }
+    flush();
     ++instruction_index;
   });
 
-  const std::size_t num_errors = rates.size();
-  if (num_errors == 0)
+  const std::size_t num_cols = detector_hits.size();
+  if (num_cols == 0)
     throw std::runtime_error(
         "Stim DEM contains no error mechanisms after flattening");
   detector_error_model result;
   result.detector_error_matrix =
-      cudaqx::tensor<uint8_t>({num_detectors, num_errors});
+      cudaqx::tensor<uint8_t>({num_detectors, num_cols});
   result.observables_flips_matrix =
-      cudaqx::tensor<uint8_t>({num_observables, num_errors});
-  result.error_rates = std::move(rates);
+      cudaqx::tensor<uint8_t>({num_observables, num_cols});
+  result.error_rates = std::move(error_rates);
+  if (use_decomp_suggestions) {
+    result.error_ids = std::move(error_ids);
+  }
 
-  for (std::size_t err = 0; err < num_errors; ++err) {
+  for (std::size_t err = 0; err < num_cols; ++err) {
     for (auto det : detector_hits[err]) {
       if (det >= num_detectors)
         throw std::runtime_error(

--- a/libs/qec/python/bindings/py_decoder.cpp
+++ b/libs/qec/python/bindings/py_decoder.cpp
@@ -816,8 +816,14 @@ void bindDecoder(nb::module_ &mod) {
 
   qecmod.def(
       "dem_from_stim_text", &dem_from_stim_text,
-      "Parse a Stim detector error model string into a DetectorErrorModel.",
-      nb::arg("dem_text"));
+      R"pbdoc(
+        Parse a Stim detector error model string into a DetectorErrorModel.
+
+        Args:
+            dem_text: A Stim detector error model string.
+            decompose_errors: If error mechanism separated by ``^`` are decomposed
+      )pbdoc",
+      nb::arg("dem_text"), nb::arg("decompose_errors") = false);
 
   // Expose decorator function that handles inheritance
   qecmod.def("decoder", [&](const std::string &name) {

--- a/libs/qec/python/bindings/py_decoder.cpp
+++ b/libs/qec/python/bindings/py_decoder.cpp
@@ -814,16 +814,15 @@ void bindDecoder(nb::module_ &mod) {
            nb::arg("num_syndromes_per_round"),
            nb::arg("remove_zero_syndrome_errors") = false);
 
-  qecmod.def(
-      "dem_from_stim_text", &dem_from_stim_text,
-      R"pbdoc(
+  qecmod.def("dem_from_stim_text", &dem_from_stim_text,
+             R"pbdoc(
         Parse a Stim detector error model string into a DetectorErrorModel.
 
         Args:
             dem_text: A Stim detector error model string.
             decompose_errors: If error mechanism separated by ``^`` are decomposed
       )pbdoc",
-      nb::arg("dem_text"), nb::arg("decompose_errors") = false);
+             nb::arg("dem_text"), nb::arg("decompose_errors") = false);
 
   // Expose decorator function that handles inheritance
   qecmod.def("decoder", [&](const std::string &name) {

--- a/libs/qec/python/bindings/py_decoder.cpp
+++ b/libs/qec/python/bindings/py_decoder.cpp
@@ -746,8 +746,10 @@ void bindDecoder(nb::module_ &mod) {
           )pbdoc")
       .def_rw("error_rates", &detector_error_model::error_rates,
               R"pbdoc(
-      The list of weights has length equal to the number of columns of the
-      detector error matrix, which assigns a likelihood to each error mechanism.
+      One entry per distinct physical error mechanism. When ``error_ids`` 
+      is not set, this equals one entry per column of ``detector_error_matrix``. When ``error_ids`` is set,
+      this equals one entry per distinct physical error mechanism. Use
+      ``error_rates[error_ids[i]]`` for the rate of column i.
     )pbdoc")
       .def_rw("error_ids", &detector_error_model::error_ids, R"pbdoc(
        Error mechanism ID. From a probability perspective, each error mechanism
@@ -820,9 +822,9 @@ void bindDecoder(nb::module_ &mod) {
 
         Args:
             dem_text: A Stim detector error model string.
-            decompose_errors: If error mechanism separated by ``^`` are decomposed
+            use_decomp_suggestions: If error mechanism separated by ``^`` are decomposed
       )pbdoc",
-             nb::arg("dem_text"), nb::arg("decompose_errors") = false);
+             nb::arg("dem_text"), nb::arg("use_decomp_suggestions") = false);
 
   // Expose decorator function that handles inheritance
   qecmod.def("decoder", [&](const std::string &name) {

--- a/libs/qec/python/bindings/py_decoder.cpp
+++ b/libs/qec/python/bindings/py_decoder.cpp
@@ -746,10 +746,8 @@ void bindDecoder(nb::module_ &mod) {
           )pbdoc")
       .def_rw("error_rates", &detector_error_model::error_rates,
               R"pbdoc(
-      One entry per distinct physical error mechanism. When ``error_ids`` 
-      is not set, this equals one entry per column of ``detector_error_matrix``. When ``error_ids`` is set,
-      this equals one entry per distinct physical error mechanism. Use
-      ``error_rates[error_ids[i]]`` for the rate of column i.
+      The list of weights has length equal to the number of columns of the
+      detector error matrix, which assigns a likelihood to each error mechanism.
     )pbdoc")
       .def_rw("error_ids", &detector_error_model::error_ids, R"pbdoc(
        Error mechanism ID. From a probability perspective, each error mechanism

--- a/libs/qec/python/tests/test_decoder.py
+++ b/libs/qec/python/tests/test_decoder.py
@@ -913,13 +913,13 @@ def test_dem_from_stim_text_explicit_parse_then_get_decoder():
     assert decoder.get_block_size() == 3
 
 
-def test_dem_from_stim_text_decompose_errors():
+def test_dem_from_stim_text_use_decomp_suggestions():
     dem_text = ("error(0.05) D0 D1 L0\n"
                 "error(0.03) D2 L1\n"
                 "error(0.1) D0 D2 ^ D1 D3\n")
 
-    # ── decompose_errors=False
-    dem_no = qec.dem_from_stim_text(dem_text, decompose_errors=False)
+    # ── use_decomp_suggestions=False
+    dem_no = qec.dem_from_stim_text(dem_text, use_decomp_suggestions=False)
     assert dem_no.num_detectors() == 4
     assert dem_no.num_observables() == 2
     assert dem_no.num_error_mechanisms() == 3
@@ -939,8 +939,8 @@ def test_dem_from_stim_text_decompose_errors():
     np.testing.assert_allclose(dem_no.error_rates, [0.05, 0.03, 0.1],
                                atol=1e-12)
 
-    # ── decompose_errors=True
-    dem_yes = qec.dem_from_stim_text(dem_text, decompose_errors=True)
+    # ── use_decomp_suggestions=True
+    dem_yes = qec.dem_from_stim_text(dem_text, use_decomp_suggestions=True)
     assert dem_yes.num_detectors() == 4
     assert dem_yes.num_observables() == 2
     assert dem_yes.num_error_mechanisms() == 4  # instruction 3 splits into 2
@@ -955,17 +955,19 @@ def test_dem_from_stim_text_decompose_errors():
     np.testing.assert_array_equal(
         np.array(dem_yes.observables_flips_matrix, dtype=np.uint8),
         explicit_O_yes)
-    np.testing.assert_allclose(dem_yes.error_rates, [0.05, 0.03, 0.1, 0.1],
+    # error_rates: one entry per source instruction (physical error rate).
+    # Use error_rates[error_ids[i]] to get the rate for column i.
+    np.testing.assert_allclose(dem_yes.error_rates, [0.05, 0.03, 0.1],
                                atol=1e-12)
 
 
-def test_dem_from_stim_text_decompose_errors_edge_cases():
+def test_dem_from_stim_text_use_decomp_suggestions_edge_cases():
     A = lambda d: np.array(d, dtype=np.uint8)
 
-    # 1. No '^' in DEM — decompose_errors=True must be a no-op.
+    # 1. No '^' in DEM — use_decomp_suggestions=True must be a no-op.
     dem_text = "error(0.1) D0 D1 L0\nerror(0.2) D1 D2\n"
-    no = qec.dem_from_stim_text(dem_text, decompose_errors=False)
-    yes = qec.dem_from_stim_text(dem_text, decompose_errors=True)
+    no = qec.dem_from_stim_text(dem_text, use_decomp_suggestions=False)
+    yes = qec.dem_from_stim_text(dem_text, use_decomp_suggestions=True)
     np.testing.assert_array_equal(A(no.detector_error_matrix),
                                   A(yes.detector_error_matrix))
     np.testing.assert_array_equal(A(no.observables_flips_matrix),
@@ -975,7 +977,7 @@ def test_dem_from_stim_text_decompose_errors_edge_cases():
     # 2. Observable flips split across components — each L stays with its '^' segment.
     # error(0.1) D0 L0 ^ D1 L1  →  col0: D0+L0, col1: D1+L1
     dem_text = "error(0.1) D0 L0 ^ D1 L1\n"
-    dem = qec.dem_from_stim_text(dem_text, decompose_errors=True)
+    dem = qec.dem_from_stim_text(dem_text, use_decomp_suggestions=True)
     assert dem.num_error_mechanisms() == 2
     np.testing.assert_array_equal(A(dem.detector_error_matrix),
                                   A([[1, 0], [0, 1]]))
@@ -983,12 +985,31 @@ def test_dem_from_stim_text_decompose_errors_edge_cases():
                                   A([[1, 0], [0, 1]]))
 
     # 3. Repeated detector within one component XOR-cancels to 0.
-    # error(0.1) D0 D0 ^ D1  →  col0: D0 appears twice → cancels; col1: D1
+    # error(0.1) D0 D0 ^ D1  →  component 0 has no net detectors after
+    # cancellation so it is dropped entirely; only D1 remains as one column.
     dem_text = "error(0.1) D0 D0 ^ D1\n"
-    dem = qec.dem_from_stim_text(dem_text, decompose_errors=True)
-    assert dem.num_error_mechanisms() == 2
-    np.testing.assert_array_equal(A(dem.detector_error_matrix),
-                                  A([[0, 0], [0, 1]]))
+    dem = qec.dem_from_stim_text(dem_text, use_decomp_suggestions=True)
+    assert dem.num_error_mechanisms() == 1
+    np.testing.assert_array_equal(A(dem.detector_error_matrix), A([[0], [1]]))
+
+
+def test_dem_from_stim_text_error_ids():
+    dem_text = ("error(0.05) D0 D1 L0\n"
+                "error(0.03) D2 L1\n"
+                "error(0.1) D0 D2 ^ D1 D3\n")
+
+    dem_no = qec.dem_from_stim_text(dem_text, use_decomp_suggestions=False)
+    assert dem_no.error_ids is None, \
+        "error_ids should not be set when use_decomp_suggestions=False"
+
+    dem_yes = qec.dem_from_stim_text(dem_text, use_decomp_suggestions=True)
+    assert dem_yes.error_ids is not None, \
+        "error_ids should be set when use_decomp_suggestions=True"
+    assert list(dem_yes.error_ids) == [0, 1, 2, 2], \
+        "columns from the same instruction must share an error_id"
+    # error_rates: one per source instruction; use error_rates[error_ids[i]] for column i.
+    np.testing.assert_allclose(dem_yes.error_rates, [0.05, 0.03, 0.1],
+                               atol=1e-12)
 
 
 def test_get_decoder_rejects_malformed_stim_dem_text():

--- a/libs/qec/python/tests/test_decoder.py
+++ b/libs/qec/python/tests/test_decoder.py
@@ -913,6 +913,82 @@ def test_dem_from_stim_text_explicit_parse_then_get_decoder():
     assert decoder.get_block_size() == 3
 
 
+def test_dem_from_stim_text_decompose_errors():
+    dem_text = ("error(0.05) D0 D1 L0\n"
+                "error(0.03) D2 L1\n"
+                "error(0.1) D0 D2 ^ D1 D3\n")
+
+    # ── decompose_errors=False
+    dem_no = qec.dem_from_stim_text(dem_text, decompose_errors=False)
+    assert dem_no.num_detectors() == 4
+    assert dem_no.num_observables() == 2
+    assert dem_no.num_error_mechanisms() == 3
+
+    # Also confirm that the default matches explicit False.
+    assert qec.dem_from_stim_text(dem_text).num_error_mechanisms() == 3
+
+    explicit_H_no = np.array([[1, 0, 1],
+                          [1, 0, 1],
+                          [0, 1, 1],
+                          [0, 0, 1]], dtype=np.uint8)
+    explicit_O_no = np.array([[1, 0, 0],
+                          [0, 1, 0]], dtype=np.uint8)
+
+    np.testing.assert_array_equal(
+        np.array(dem_no.detector_error_matrix, dtype=np.uint8), explicit_H_no)
+    np.testing.assert_array_equal(
+        np.array(dem_no.observables_flips_matrix, dtype=np.uint8), explicit_O_no)
+    np.testing.assert_allclose(dem_no.error_rates, [0.05, 0.03, 0.1], atol=1e-12)
+
+    # ── decompose_errors=True
+    dem_yes = qec.dem_from_stim_text(dem_text, decompose_errors=True)
+    assert dem_yes.num_detectors() == 4
+    assert dem_yes.num_observables() == 2
+    assert dem_yes.num_error_mechanisms() == 4  # instruction 3 splits into 2
+
+    explicit_H_yes = np.array([[1, 0, 1, 0],
+                           [1, 0, 0, 1],
+                           [0, 1, 1, 0],
+                           [0, 0, 0, 1]], dtype=np.uint8)
+    explicit_O_yes = np.array([[1, 0, 0, 0],
+                           [0, 1, 0, 0]], dtype=np.uint8)
+
+    np.testing.assert_array_equal(
+        np.array(dem_yes.detector_error_matrix, dtype=np.uint8), explicit_H_yes)
+    np.testing.assert_array_equal(
+        np.array(dem_yes.observables_flips_matrix, dtype=np.uint8), explicit_O_yes)
+    np.testing.assert_allclose(dem_yes.error_rates, [0.05, 0.03, 0.1, 0.1], atol=1e-12)
+
+
+def test_dem_from_stim_text_decompose_errors_edge_cases():
+    A = lambda d: np.array(d, dtype=np.uint8)
+
+    # 1. No '^' in DEM — decompose_errors=True must be a no-op.
+    dem_text = "error(0.1) D0 D1 L0\nerror(0.2) D1 D2\n"
+    no  = qec.dem_from_stim_text(dem_text, decompose_errors=False)
+    yes = qec.dem_from_stim_text(dem_text, decompose_errors=True)
+    np.testing.assert_array_equal(
+        A(no.detector_error_matrix), A(yes.detector_error_matrix))
+    np.testing.assert_array_equal(
+        A(no.observables_flips_matrix), A(yes.observables_flips_matrix))
+    np.testing.assert_allclose(no.error_rates, yes.error_rates, atol=1e-12)
+
+    # 2. Observable flips split across components — each L stays with its '^' segment.
+    # error(0.1) D0 L0 ^ D1 L1  →  col0: D0+L0, col1: D1+L1
+    dem_text = "error(0.1) D0 L0 ^ D1 L1\n"
+    dem = qec.dem_from_stim_text(dem_text, decompose_errors=True)
+    assert dem.num_error_mechanisms() == 2
+    np.testing.assert_array_equal(A(dem.detector_error_matrix),      A([[1, 0], [0, 1]]))
+    np.testing.assert_array_equal(A(dem.observables_flips_matrix),   A([[1, 0], [0, 1]]))
+
+    # 3. Repeated detector within one component XOR-cancels to 0.
+    # error(0.1) D0 D0 ^ D1  →  col0: D0 appears twice → cancels; col1: D1
+    dem_text = "error(0.1) D0 D0 ^ D1\n"
+    dem = qec.dem_from_stim_text(dem_text, decompose_errors=True)
+    assert dem.num_error_mechanisms() == 2
+    np.testing.assert_array_equal(A(dem.detector_error_matrix), A([[0, 0], [0, 1]]))
+
+
 def test_get_decoder_rejects_malformed_stim_dem_text():
     with pytest.raises(RuntimeError):
         qec.get_decoder("single_error_lut", "not a valid DEM")

--- a/libs/qec/python/tests/test_decoder.py
+++ b/libs/qec/python/tests/test_decoder.py
@@ -955,9 +955,8 @@ def test_dem_from_stim_text_use_decomp_suggestions():
     np.testing.assert_array_equal(
         np.array(dem_yes.observables_flips_matrix, dtype=np.uint8),
         explicit_O_yes)
-    # error_rates: one entry per source instruction (physical error rate).
-    # Use error_rates[error_ids[i]] to get the rate for column i.
-    np.testing.assert_allclose(dem_yes.error_rates, [0.05, 0.03, 0.1],
+    # Each decomposed component inherits the parent instruction's probability.
+    np.testing.assert_allclose(dem_yes.error_rates, [0.05, 0.03, 0.1, 0.1],
                                atol=1e-12)
 
 
@@ -991,25 +990,6 @@ def test_dem_from_stim_text_use_decomp_suggestions_edge_cases():
     dem = qec.dem_from_stim_text(dem_text, use_decomp_suggestions=True)
     assert dem.num_error_mechanisms() == 1
     np.testing.assert_array_equal(A(dem.detector_error_matrix), A([[0], [1]]))
-
-
-def test_dem_from_stim_text_error_ids():
-    dem_text = ("error(0.05) D0 D1 L0\n"
-                "error(0.03) D2 L1\n"
-                "error(0.1) D0 D2 ^ D1 D3\n")
-
-    dem_no = qec.dem_from_stim_text(dem_text, use_decomp_suggestions=False)
-    assert dem_no.error_ids is None, \
-        "error_ids should not be set when use_decomp_suggestions=False"
-
-    dem_yes = qec.dem_from_stim_text(dem_text, use_decomp_suggestions=True)
-    assert dem_yes.error_ids is not None, \
-        "error_ids should be set when use_decomp_suggestions=True"
-    assert list(dem_yes.error_ids) == [0, 1, 2, 2], \
-        "columns from the same instruction must share an error_id"
-    # error_rates: one per source instruction; use error_rates[error_ids[i]] for column i.
-    np.testing.assert_allclose(dem_yes.error_rates, [0.05, 0.03, 0.1],
-                               atol=1e-12)
 
 
 def test_get_decoder_rejects_malformed_stim_dem_text():

--- a/libs/qec/python/tests/test_decoder.py
+++ b/libs/qec/python/tests/test_decoder.py
@@ -927,18 +927,17 @@ def test_dem_from_stim_text_decompose_errors():
     # Also confirm that the default matches explicit False.
     assert qec.dem_from_stim_text(dem_text).num_error_mechanisms() == 3
 
-    explicit_H_no = np.array([[1, 0, 1],
-                          [1, 0, 1],
-                          [0, 1, 1],
-                          [0, 0, 1]], dtype=np.uint8)
-    explicit_O_no = np.array([[1, 0, 0],
-                          [0, 1, 0]], dtype=np.uint8)
+    explicit_H_no = np.array([[1, 0, 1], [1, 0, 1], [0, 1, 1], [0, 0, 1]],
+                             dtype=np.uint8)
+    explicit_O_no = np.array([[1, 0, 0], [0, 1, 0]], dtype=np.uint8)
 
     np.testing.assert_array_equal(
         np.array(dem_no.detector_error_matrix, dtype=np.uint8), explicit_H_no)
     np.testing.assert_array_equal(
-        np.array(dem_no.observables_flips_matrix, dtype=np.uint8), explicit_O_no)
-    np.testing.assert_allclose(dem_no.error_rates, [0.05, 0.03, 0.1], atol=1e-12)
+        np.array(dem_no.observables_flips_matrix, dtype=np.uint8),
+        explicit_O_no)
+    np.testing.assert_allclose(dem_no.error_rates, [0.05, 0.03, 0.1],
+                               atol=1e-12)
 
     # ── decompose_errors=True
     dem_yes = qec.dem_from_stim_text(dem_text, decompose_errors=True)
@@ -946,18 +945,18 @@ def test_dem_from_stim_text_decompose_errors():
     assert dem_yes.num_observables() == 2
     assert dem_yes.num_error_mechanisms() == 4  # instruction 3 splits into 2
 
-    explicit_H_yes = np.array([[1, 0, 1, 0],
-                           [1, 0, 0, 1],
-                           [0, 1, 1, 0],
-                           [0, 0, 0, 1]], dtype=np.uint8)
-    explicit_O_yes = np.array([[1, 0, 0, 0],
-                           [0, 1, 0, 0]], dtype=np.uint8)
+    explicit_H_yes = np.array(
+        [[1, 0, 1, 0], [1, 0, 0, 1], [0, 1, 1, 0], [0, 0, 0, 1]],
+        dtype=np.uint8)
+    explicit_O_yes = np.array([[1, 0, 0, 0], [0, 1, 0, 0]], dtype=np.uint8)
 
     np.testing.assert_array_equal(
         np.array(dem_yes.detector_error_matrix, dtype=np.uint8), explicit_H_yes)
     np.testing.assert_array_equal(
-        np.array(dem_yes.observables_flips_matrix, dtype=np.uint8), explicit_O_yes)
-    np.testing.assert_allclose(dem_yes.error_rates, [0.05, 0.03, 0.1, 0.1], atol=1e-12)
+        np.array(dem_yes.observables_flips_matrix, dtype=np.uint8),
+        explicit_O_yes)
+    np.testing.assert_allclose(dem_yes.error_rates, [0.05, 0.03, 0.1, 0.1],
+                               atol=1e-12)
 
 
 def test_dem_from_stim_text_decompose_errors_edge_cases():
@@ -965,12 +964,12 @@ def test_dem_from_stim_text_decompose_errors_edge_cases():
 
     # 1. No '^' in DEM — decompose_errors=True must be a no-op.
     dem_text = "error(0.1) D0 D1 L0\nerror(0.2) D1 D2\n"
-    no  = qec.dem_from_stim_text(dem_text, decompose_errors=False)
+    no = qec.dem_from_stim_text(dem_text, decompose_errors=False)
     yes = qec.dem_from_stim_text(dem_text, decompose_errors=True)
-    np.testing.assert_array_equal(
-        A(no.detector_error_matrix), A(yes.detector_error_matrix))
-    np.testing.assert_array_equal(
-        A(no.observables_flips_matrix), A(yes.observables_flips_matrix))
+    np.testing.assert_array_equal(A(no.detector_error_matrix),
+                                  A(yes.detector_error_matrix))
+    np.testing.assert_array_equal(A(no.observables_flips_matrix),
+                                  A(yes.observables_flips_matrix))
     np.testing.assert_allclose(no.error_rates, yes.error_rates, atol=1e-12)
 
     # 2. Observable flips split across components — each L stays with its '^' segment.
@@ -978,15 +977,18 @@ def test_dem_from_stim_text_decompose_errors_edge_cases():
     dem_text = "error(0.1) D0 L0 ^ D1 L1\n"
     dem = qec.dem_from_stim_text(dem_text, decompose_errors=True)
     assert dem.num_error_mechanisms() == 2
-    np.testing.assert_array_equal(A(dem.detector_error_matrix),      A([[1, 0], [0, 1]]))
-    np.testing.assert_array_equal(A(dem.observables_flips_matrix),   A([[1, 0], [0, 1]]))
+    np.testing.assert_array_equal(A(dem.detector_error_matrix),
+                                  A([[1, 0], [0, 1]]))
+    np.testing.assert_array_equal(A(dem.observables_flips_matrix),
+                                  A([[1, 0], [0, 1]]))
 
     # 3. Repeated detector within one component XOR-cancels to 0.
     # error(0.1) D0 D0 ^ D1  →  col0: D0 appears twice → cancels; col1: D1
     dem_text = "error(0.1) D0 D0 ^ D1\n"
     dem = qec.dem_from_stim_text(dem_text, decompose_errors=True)
     assert dem.num_error_mechanisms() == 2
-    np.testing.assert_array_equal(A(dem.detector_error_matrix), A([[0, 0], [0, 1]]))
+    np.testing.assert_array_equal(A(dem.detector_error_matrix),
+                                  A([[0, 0], [0, 1]]))
 
 
 def test_get_decoder_rejects_malformed_stim_dem_text():

--- a/libs/qec/unittests/test_decoders.cpp
+++ b/libs/qec/unittests/test_decoders.cpp
@@ -1036,20 +1036,16 @@ TEST(StimDemGetDecoder, DemFromStimTextErrorIds) {
 
   auto dem_yes =
       cudaq::qec::dem_from_stim_text(dem_text, /*use_decomp_suggestions=*/true);
-  ASSERT_TRUE(dem_yes.error_ids.has_value());
-  ASSERT_EQ(dem_yes.error_ids->size(), 4u);
-  EXPECT_EQ((*dem_yes.error_ids)[0], 0u);
-  EXPECT_EQ((*dem_yes.error_ids)[1], 1u);
-  EXPECT_EQ((*dem_yes.error_ids)[2], 2u);
-  EXPECT_EQ((*dem_yes.error_ids)[3], 2u);
-  ASSERT_EQ(dem_yes.error_rates.size(), 3u);
+  EXPECT_FALSE(dem_yes.error_ids.has_value());
+  ASSERT_EQ(dem_yes.error_rates.size(), 4u);
   EXPECT_DOUBLE_EQ(dem_yes.error_rates[0], 0.05);
   EXPECT_DOUBLE_EQ(dem_yes.error_rates[1], 0.03);
   EXPECT_DOUBLE_EQ(dem_yes.error_rates[2], 0.1);
+  EXPECT_DOUBLE_EQ(dem_yes.error_rates[3], 0.1);
 }
 
-// Verify true: each ^ component becomes a separate column; observables and
-// error_ids follow the split.
+// Verify true: each ^ component becomes a separate column; each component
+// inherits the parent instruction's probability; error_ids is nullopt.
 TEST(StimDemGetDecoder, DecomposeErrorsTrueSplitsCaretComponents) {
   auto dem = cudaq::qec::dem_from_stim_text("error(0.1) D0 L0 ^ D1\n",
                                             /*use_decomp_suggestions=*/true);
@@ -1069,10 +1065,11 @@ TEST(StimDemGetDecoder, DecomposeErrorsTrueSplitsCaretComponents) {
   EXPECT_EQ(dem.observables_flips_matrix.at({0u, 0u}), 1u);
   EXPECT_EQ(dem.observables_flips_matrix.at({0u, 1u}), 0u);
 
-  // error_ids maps both columns back to error mechanism 0.
-  ASSERT_TRUE(dem.error_ids.has_value());
-  EXPECT_EQ((*dem.error_ids)[0], 0u);
-  EXPECT_EQ((*dem.error_ids)[1], 0u);
+  // Each component gets the parent probability; error_ids is always nullopt.
+  EXPECT_FALSE(dem.error_ids.has_value());
+  ASSERT_EQ(dem.error_rates.size(), 2u);
+  EXPECT_DOUBLE_EQ(dem.error_rates[0], 0.1);
+  EXPECT_DOUBLE_EQ(dem.error_rates[1], 0.1);
 }
 
 TEST(StimDemGetDecoder, DecomposeErrorsXorCancelled) {
@@ -1193,4 +1190,3 @@ TEST(SlidingWindowDecoder, BaseStreamingCopiesFirstRoundDetectors) {
       << "First-round detector copy runs, but the sliding window is not full "
          "yet so no final correction is committed.";
 }
-

--- a/libs/qec/unittests/test_decoders.cpp
+++ b/libs/qec/unittests/test_decoders.cpp
@@ -924,18 +924,20 @@ TEST(StimDemGetDecoder, StillAcceptsParityCheckMatrix) {
 }
 
 TEST(StimDemGetDecoder, RepeatedDetectorOrObservableTargetsXorFold) {
-  const std::string dem_text = R"(error(0.1) D0 D0
-error(0.1) L0 L0
+  const std::string dem_text = R"(error(0.1) D0 D0 D1
+error(0.1) L0 L0 D2
 )";
 
   auto dem = cudaq::qec::dem_from_stim_text(dem_text);
-  ASSERT_EQ(dem.num_detectors(), 1u);
+  ASSERT_EQ(dem.num_detectors(), 3u);
   ASSERT_EQ(dem.num_observables(), 1u);
   ASSERT_EQ(dem.num_error_mechanisms(), 2u);
   EXPECT_EQ(dem.detector_error_matrix.at({0u, 0u}), 0u)
       << "duplicate D0 in error 0 should XOR-cancel to 0";
+  EXPECT_EQ(dem.detector_error_matrix.at({1u, 0u}), 1u) << "D1 survives";
   EXPECT_EQ(dem.observables_flips_matrix.at({0u, 1u}), 0u)
       << "duplicate L0 in error 1 should XOR-cancel to 0";
+  EXPECT_EQ(dem.detector_error_matrix.at({2u, 1u}), 1u) << "D2 survives";
 }
 
 TEST(StimDemGetDecoder, DemWithoutObservablesDoesNotAddODefault) {
@@ -997,6 +999,89 @@ error(0.05) D0 D1
   opts.insert("error_rate_vec", std::vector<double>{0.5});
   EXPECT_THROW(cudaq::qec::get_decoder("single_error_lut", dem_text, opts),
                std::runtime_error);
+}
+
+TEST(StimDemGetDecoder, SeparatorTargetsAreIgnoredByFallbackParser) {
+  // The fallback parser must skip Stim's '^' separator while retaining both
+  // detector targets and the observable target in the same error mechanism.
+  const std::string dem_text = "error(0.25) D0 ^ D1 L0\n";
+  auto dem = cudaq::qec::dem_from_stim_text(dem_text);
+  ASSERT_EQ(dem.num_error_mechanisms(), 1u);
+  ASSERT_EQ(dem.num_detectors(), 2u);
+  ASSERT_EQ(dem.num_observables(), 1u);
+  EXPECT_EQ(dem.detector_error_matrix.at({0, 0}), 1u);
+  EXPECT_EQ(dem.detector_error_matrix.at({1, 0}), 1u);
+  EXPECT_EQ(dem.observables_flips_matrix.at({0, 0}), 1u);
+}
+
+TEST(StimDemGetDecoder, DecomposeErrorsFalseIgnoresCaret) {
+  auto dem = cudaq::qec::dem_from_stim_text(
+      "error(0.1) D0 D2 ^ D1 D3\nerror(0.2) D0 D2 D1 D3\n");
+  ASSERT_EQ(dem.num_error_mechanisms(), 2u);
+  std::size_t expected_num_detectors = 4u;
+  for (std::size_t r = 0; r < expected_num_detectors; ++r) {
+    EXPECT_EQ(dem.detector_error_matrix.at({r, 0u}), 1u) << "D" << r;
+    EXPECT_EQ(dem.detector_error_matrix.at({r, 1u}), 1u) << "D" << r;
+  }
+  EXPECT_FALSE(dem.error_ids.has_value());
+}
+
+TEST(StimDemGetDecoder, DemFromStimTextErrorIds) {
+  const std::string dem_text = "error(0.05) D0 D1 L0\n"
+                               "error(0.03) D2 L1\n"
+                               "error(0.1) D0 D2 ^ D1 D3\n";
+
+  auto dem_no = cudaq::qec::dem_from_stim_text(dem_text);
+  EXPECT_FALSE(dem_no.error_ids.has_value());
+
+  auto dem_yes =
+      cudaq::qec::dem_from_stim_text(dem_text, /*use_decomp_suggestions=*/true);
+  ASSERT_TRUE(dem_yes.error_ids.has_value());
+  ASSERT_EQ(dem_yes.error_ids->size(), 4u);
+  EXPECT_EQ((*dem_yes.error_ids)[0], 0u);
+  EXPECT_EQ((*dem_yes.error_ids)[1], 1u);
+  EXPECT_EQ((*dem_yes.error_ids)[2], 2u);
+  EXPECT_EQ((*dem_yes.error_ids)[3], 2u);
+  ASSERT_EQ(dem_yes.error_rates.size(), 3u);
+  EXPECT_DOUBLE_EQ(dem_yes.error_rates[0], 0.05);
+  EXPECT_DOUBLE_EQ(dem_yes.error_rates[1], 0.03);
+  EXPECT_DOUBLE_EQ(dem_yes.error_rates[2], 0.1);
+}
+
+// Verify true: each ^ component becomes a separate column; observables and
+// error_ids follow the split.
+TEST(StimDemGetDecoder, DecomposeErrorsTrueSplitsCaretComponents) {
+  auto dem = cudaq::qec::dem_from_stim_text("error(0.1) D0 L0 ^ D1\n",
+                                            /*use_decomp_suggestions=*/true);
+  ASSERT_EQ(dem.num_error_mechanisms(), 2u);
+  ASSERT_EQ(dem.num_detectors(), 2u);
+  ASSERT_EQ(dem.num_observables(), 1u);
+
+  // Expected result:
+  //      E0 E1
+  // D0 [[1, 0],
+  // D1  [0, 1]]
+  // L0 [[1, 0]]
+  EXPECT_EQ(dem.detector_error_matrix.at({0u, 0u}), 1u);
+  EXPECT_EQ(dem.detector_error_matrix.at({0u, 1u}), 0u);
+  EXPECT_EQ(dem.detector_error_matrix.at({1u, 0u}), 0u);
+  EXPECT_EQ(dem.detector_error_matrix.at({1u, 1u}), 1u);
+  EXPECT_EQ(dem.observables_flips_matrix.at({0u, 0u}), 1u);
+  EXPECT_EQ(dem.observables_flips_matrix.at({0u, 1u}), 0u);
+
+  // error_ids maps both columns back to error mechanism 0.
+  ASSERT_TRUE(dem.error_ids.has_value());
+  EXPECT_EQ((*dem.error_ids)[0], 0u);
+  EXPECT_EQ((*dem.error_ids)[1], 0u);
+}
+
+TEST(StimDemGetDecoder, DecomposeErrorsXorCancelled) {
+  auto dem = cudaq::qec::dem_from_stim_text("error(0.1) D0 D0 ^ D1\n",
+                                            /*use_decomp_suggestions=*/true);
+  ASSERT_EQ(dem.num_error_mechanisms(), 1u)
+      << "empty component after XOR cancellation must be dropped";
+  EXPECT_EQ(dem.detector_error_matrix.at({0u, 0u}), 0u) << "D0 cancelled";
+  EXPECT_EQ(dem.detector_error_matrix.at({1u, 0u}), 1u) << "D1 survives";
 }
 
 // ---------------------------------------------------------------------------
@@ -1079,19 +1164,6 @@ TEST(EnqueueSyndrome, ObsFrameSizeMismatchThrows) {
                std::runtime_error);
 }
 
-TEST(StimDemGetDecoder, SeparatorTargetsAreIgnoredByFallbackParser) {
-  // The fallback parser must skip Stim's '^' separator while retaining both
-  // detector targets and the observable target in the same error mechanism.
-  const std::string dem_text = "error(0.25) D0 ^ D1 L0\n";
-  auto dem = cudaq::qec::dem_from_stim_text(dem_text);
-  ASSERT_EQ(dem.num_error_mechanisms(), 1u);
-  ASSERT_EQ(dem.num_detectors(), 2u);
-  ASSERT_EQ(dem.num_observables(), 1u);
-  EXPECT_EQ(dem.detector_error_matrix.at({0, 0}), 1u);
-  EXPECT_EQ(dem.detector_error_matrix.at({1, 0}), 1u);
-  EXPECT_EQ(dem.observables_flips_matrix.at({0, 0}), 1u);
-}
-
 TEST(SlidingWindowDecoder, BaseStreamingCopiesFirstRoundDetectors) {
   // A first-round detector matrix starts with single-syndrome rows; the base
   // enqueue path should decode after one streamed round using a direct copy.
@@ -1121,3 +1193,4 @@ TEST(SlidingWindowDecoder, BaseStreamingCopiesFirstRoundDetectors) {
       << "First-round detector copy runs, but the sliding window is not full "
          "yet so no final correction is committed.";
 }
+


### PR DESCRIPTION
<!--
Thanks for contributing to CUDA-Q Libraries!

Please read the full Pull Request Guidelines in Contributing.md:
https://github.com/NVIDIA/cudaqx/blob/main/Contributing.md#pull-request-guidelines
-->

## Description
In the current implementation of `dem_from_stim_text`, the suggested error decomposition `^` characters are ignored, but it is sometimes useful to output graphlike edge check matrices. For example,

```
import numpy as np
import stim
import cudaq_qec as qec
import beliefmatching

dem_text = "error(0.1) D0 ^ D1\n"

check_matrices = beliefmatching.detector_error_model_to_check_matrices(stim.DetectorErrorModel(dem_text))

# Current behavior: D0 and D1 merged into one column
dem_old = qec.dem_from_stim_text(dem_text)
print("dem_from_stim_text:")
print(np.array(dem_old.detector_error_matrix))          # [[1], [1]]

# Sometimes desirable: accept the error decomposition indicated by ^ and split into two columns
print("beliefmatching's edge_check_matrix:")
print(check_matrices.edge_check_matrix.toarray())                   # [[1, 0], [0, 1]
```

<!-- What does this PR change, and why? Link related issues. -->
This PR adds a flag to `dem_from_stim_text` which allows users to toggle if the `^` characters should be ignored (default) or should be used to generate an error-decomposed DEM. This is useful if the DEM will eventually be used for, i.e., pymatching. 

This change does not perform error decomposition; it only modifies the parsing behavior or `dem_from_stim_text` to optionally accept suggested error decompositions from `stim`.

## Runtime / performance impact
N/A
<!--
If this change affects performance, paste benchmark numbers here.
Otherwise write "N/A".
-->

## Self-review checklist

Please confirm each item before requesting review. Check `[x]` or strike
through and explain.

### Before requesting review
- [x] I reviewed my own full diff in GitHub or my editor.
- [x] PR is in Draft if it is not yet ready for review.
- [x] Temporary / debugging changes have been removed.
- [x] Local test logs reviewed; no unexplained warnings or errors.
- [x] CI logs reviewed; no unexplained warnings or errors.
- [x] Full CI has been run.

### Scope and size
- [x] PR is under ~1000 lines, or an exception is justified in the description.
- [x] Refactoring-only changes are isolated in their own PR(s).
- [x] No existing tests were disabled or modified just to make this PR pass
      (if so, an issue has been raised).

### Tests
- [x] New functionality has new tests.
- [x] Tests fail if the new functionality is broken (including crashes), not
      just when it is missing.
- [x] Negative tests added where exceptions are expected.
- [x] Truth data added where simple `EXPECT_*` / `assert` checks are
      insufficient for algorithmic correctness.
- [x] CI runtime impact considered; team notified if significant.

### Documentation
- [x] Public-facing APIs have Doxygen docs.
- [x] User-visible behavior changes have public docs, or a follow-up is
      tracked.

### Code style
- [x] Naming follows the existing convention (`snake_case` vs `camelCase`) for
      the area being modified.

### Dependencies
- [x] No new third-party dependencies, **or** the team has been notified and
      OSRB tickets filed.
