### PR TITLE
fix: To fix OOB r/w when batch failure returns empty results

### DIFF
--- a/libs/qec/lib/decoders/plugins/trt_decoder/trt_decoder.cpp
+++ b/libs/qec/lib/decoders/plugins/trt_decoder/trt_decoder.cpp
@@ -440,6 +440,10 @@ public:
 private:
   void check_cuda();
 
+  /// Size to use for failed placeholder results. This preserves the
+  /// decode_batch contract even when inference fails before producing output.
+  size_t failure_result_size() const;
+
   /// Typed decode_batch: IoType matches the engine's I/O dtype
   /// (currently float or uint8_t).
   template <typename IoType>
@@ -850,6 +854,12 @@ decoder_result trt_decoder::decode(const std::vector<float_t> &syndrome) {
     }
 
     auto results = decode_batch(padded_batch);
+    if (results.empty()) {
+      decoder_result result;
+      result.converged = false;
+      result.result.resize(failure_result_size(), 0.0f);
+      return result;
+    }
 
     // Return only the first result (the real syndrome)
     return results[0];
@@ -857,6 +867,12 @@ decoder_result trt_decoder::decode(const std::vector<float_t> &syndrome) {
 
   // For batch_size == 1, directly delegate to decode_batch
   auto results = decode_batch({syndrome});
+  if (results.empty()) {
+    decoder_result result;
+    result.converged = false;
+    result.result.resize(failure_result_size(), 0.0f);
+    return result;
+  }
   return results[0];
 }
 
@@ -898,6 +914,14 @@ trt_decoder::decode_batch(const std::vector<std::vector<float_t>> &syndromes) {
   if (impl_->input_dtype == nvinfer1::DataType::kUINT8)
     return decode_batch_impl<uint8_t>(syndromes);
   return decode_batch_impl<float>(syndromes);
+}
+
+size_t trt_decoder::failure_result_size() const {
+  if (decode_to_observables_)
+    return num_observables_;
+  if (global_decoder_)
+    return global_decoder_->get_block_size();
+  return output_size_per_sample_;
 }
 
 template <typename IoType>
@@ -1047,6 +1071,12 @@ std::vector<decoder_result> trt_decoder::decode_batch_impl(
     // Mark all results as unconverged
     for (auto &result : results) {
       result.converged = false;
+    }
+    while (results.size() < syndromes.size()) {
+      decoder_result result;
+      result.converged = false;
+      result.result.resize(failure_result_size(), 0.0f);
+      results.push_back(std::move(result));
     }
   }
 

--- a/libs/qec/unittests/decoders/trt_decoder/test_trt_decoder.cpp
+++ b/libs/qec/unittests/decoders/trt_decoder/test_trt_decoder.cpp
@@ -665,6 +665,39 @@ TEST_F(TRTDecoderTest, Uint8IdentityModelBinarizesInputAndOutput) {
   EXPECT_FLOAT_EQ(result.result[2], 1.0);
 }
 
+TEST_F(TRTDecoderTest, BatchFailureKeepsResultCount) {
+  // A post-initialisation failure in decode_batch should preserve one result
+  // per input syndrome so decode() never indexes an empty result vector.
+  if (!gpu_available())
+    GTEST_SKIP() << "No CUDA GPU available";
+  auto onnx_path = get_dynamic_onnx_asset_path();
+  if (!onnx_path || !std::filesystem::exists(*onnx_path))
+    GTEST_SKIP() << "Generated dynamic ONNX fixture is unavailable";
+
+  cudaqx::heterogeneous_map params;
+  params.insert("onnx_load_path", *onnx_path);
+  params.insert("batch_size", std::size_t{1});
+  params.insert("use_cuda_graph", false);
+  params.insert("global_decoder", std::string("single_error_lut"));
+  params.insert("global_decoder_params", cudaqx::heterogeneous_map{});
+
+  std::unique_ptr<decoder> trt_decoder;
+  try {
+    trt_decoder = decoder::get("trt_decoder", make_identity_h(2), params);
+  } catch (const std::exception &e) {
+    GTEST_SKIP() << "Failed to create mismatch TRT decoder: " << e.what();
+  }
+
+  auto results = trt_decoder->decode_batch({{1.0, 0.0, 1.0}});
+
+  // The mismatched global decoder forces an exception before any result is
+  // pushed; the fixed path must still return one placeholder for the input.
+  ASSERT_EQ(results.size(), 1u);
+  // The placeholder must be marked failed so callers can distinguish it from a
+  // successful decode without touching out-of-range elements.
+  EXPECT_FALSE(results[0].converged);
+}
+
 TEST_F(TRTDecoderTest, CompositeGlobalDecoderCombinesLogicalFrame) {
   // TRT emits [pre_L, residual syndrome]; the optional global decoder decodes
   // the residual part and XORs it with pre_L to form the final observable.


### PR DESCRIPTION
This PR tries to fix [[B] 6369627](https://nvbugspro.nvidia.com/bug/6369627).

It also adds one exposing test "BatchFailureKeepsResultCount".
It creates a valid TRT decoder, then attaches a global decoder whose expected residual syndrome size intentionally mismatches the TRT output size.
This forces an exception after inference setup but before any result is pushed.
The old code returns an empty vector; the test exposes the bug by asserting that one un-converged result is returned for the one input syndrome.

Thanks for looking at this PR.