### PR TITLE
fix: To fix input/output dtype mixing

### DIFF
--- a/libs/qec/lib/decoders/plugins/trt_decoder/trt_decoder.cpp
+++ b/libs/qec/lib/decoders/plugins/trt_decoder/trt_decoder.cpp
@@ -440,9 +440,9 @@ public:
 private:
   void check_cuda();
 
-  /// Typed decode_batch: IoType matches the engine's I/O dtype
-  /// (currently float or uint8_t).
-  template <typename IoType>
+  /// Typed decode_batch: input and output dtypes are selected independently
+  /// from the TensorRT engine metadata (currently float or uint8_t).
+  template <typename InputType, typename OutputType>
   std::vector<decoder_result>
   decode_batch_impl(const std::vector<std::vector<float_t>> &syndromes) const;
 };
@@ -894,13 +894,18 @@ trt_decoder::decode_batch(const std::vector<std::vector<float_t>> &syndromes) {
     return results;
   }
 
-  // Dispatch on the actual engine input dtype (uint8 or float).
-  if (impl_->input_dtype == nvinfer1::DataType::kUINT8)
-    return decode_batch_impl<uint8_t>(syndromes);
-  return decode_batch_impl<float>(syndromes);
+  // Dispatch on the actual engine I/O dtypes independently.
+  if (impl_->input_dtype == nvinfer1::DataType::kUINT8) {
+    if (impl_->output_dtype == nvinfer1::DataType::kUINT8)
+      return decode_batch_impl<uint8_t, uint8_t>(syndromes);
+    return decode_batch_impl<uint8_t, float>(syndromes);
+  }
+  if (impl_->output_dtype == nvinfer1::DataType::kUINT8)
+    return decode_batch_impl<float, uint8_t>(syndromes);
+  return decode_batch_impl<float, float>(syndromes);
 }
 
-template <typename IoType>
+template <typename InputType, typename OutputType>
 std::vector<decoder_result> trt_decoder::decode_batch_impl(
     const std::vector<std::vector<float_t>> &syndromes) const {
   std::vector<decoder_result> results;
@@ -925,18 +930,18 @@ std::vector<decoder_result> trt_decoder::decode_batch_impl(
 
       // Prepare input batch. For float input we preserve soft (raw) values;
       // for uint8 we binarize to 0/1.
-      std::vector<IoType> input_host(impl_->input_size);
+      std::vector<InputType> input_host(impl_->input_size);
       for (size_t batch_idx = 0; batch_idx < actual_batch; ++batch_idx) {
         const auto &syndrome = syndromes[batch_start + batch_idx];
-        if constexpr (std::is_same_v<IoType, float>) {
+        if constexpr (std::is_same_v<InputType, float>) {
           for (size_t i = 0; i < syndrome_size_per_sample_; ++i) {
             input_host[batch_idx * syndrome_size_per_sample_ + i] =
-                static_cast<IoType>(syndrome[i]);
+                static_cast<InputType>(syndrome[i]);
           }
         } else {
           for (size_t i = 0; i < syndrome_size_per_sample_; ++i) {
             input_host[batch_idx * syndrome_size_per_sample_ + i] =
-                static_cast<IoType>(
+                static_cast<InputType>(
                     cudaq::qec::convert_soft_to_hard(syndrome[i]));
           }
         }
@@ -944,14 +949,14 @@ std::vector<decoder_result> trt_decoder::decode_batch_impl(
 
       HANDLE_CUDA_ERROR(cudaMemcpy(
           impl_->buffers[impl_->input_index], input_host.data(),
-          impl_->input_size * sizeof(IoType), cudaMemcpyHostToDevice));
+          impl_->input_size * sizeof(InputType), cudaMemcpyHostToDevice));
 
       impl_->execute_inference(actual_batch);
 
-      std::vector<IoType> output_host(impl_->output_size);
+      std::vector<OutputType> output_host(impl_->output_size);
       HANDLE_CUDA_ERROR(cudaMemcpy(
           output_host.data(), impl_->buffers[impl_->output_index],
-          impl_->output_size * sizeof(IoType), cudaMemcpyDeviceToHost));
+          impl_->output_size * sizeof(OutputType), cudaMemcpyDeviceToHost));
 
       if (log_residual_counts) {
         const size_t input_elems = actual_batch * syndrome_size_per_sample_;
@@ -960,8 +965,9 @@ std::vector<decoder_result> trt_decoder::decode_batch_impl(
             total_input_nonzero++;
         // Count non-zero entries in just the residual portion of the output.
         for (size_t batch_idx = 0; batch_idx < actual_batch; ++batch_idx) {
-          const IoType *row = output_host.data() +
-                              batch_idx * output_size_per_sample_ + pre_L_size;
+          const OutputType *row = output_host.data() +
+                                  batch_idx * output_size_per_sample_ +
+                                  pre_L_size;
           for (size_t i = 0; i < residual_size; ++i)
             if (trt_io_nonzero(row[i]))
               total_residual_nonzero++;
@@ -983,8 +989,9 @@ std::vector<decoder_result> trt_decoder::decode_batch_impl(
         std::vector<std::vector<float_t>> residual_soft(
             actual_batch, std::vector<float_t>(global_syndrome_size, 0.0f));
         for (size_t batch_idx = 0; batch_idx < actual_batch; ++batch_idx) {
-          const IoType *res = output_host.data() +
-                              batch_idx * output_size_per_sample_ + pre_L_size;
+          const OutputType *res = output_host.data() +
+                                  batch_idx * output_size_per_sample_ +
+                                  pre_L_size;
           float_t *out = residual_soft[batch_idx].data();
           for (size_t i = 0; i < global_syndrome_size; ++i)
             out[i] = trt_io_to_binary(res[i]);
@@ -999,7 +1006,7 @@ std::vector<decoder_result> trt_decoder::decode_batch_impl(
             decoder_result combined;
             combined.converged = global_results[batch_idx].converged;
             combined.result.resize(num_observables_, 0.0f);
-            const IoType *pre_L_row =
+            const OutputType *pre_L_row =
                 output_host.data() + batch_idx * output_size_per_sample_;
             const std::vector<float_t> &g = global_results[batch_idx].result;
             for (size_t k = 0; k < num_observables_; ++k) {
@@ -1022,10 +1029,10 @@ std::vector<decoder_result> trt_decoder::decode_batch_impl(
           decoder_result result;
           result.converged = true;
           result.result.resize(out_per_sample);
-          const IoType *row =
+          const OutputType *row =
               output_host.data() + batch_idx * output_size_per_sample_;
           for (size_t i = 0; i < out_per_sample; ++i) {
-            if constexpr (std::is_same_v<IoType, float>) {
+            if constexpr (std::is_same_v<OutputType, float>) {
               result.result[i] = static_cast<float_t>(row[i]);
             } else {
               result.result[i] = trt_io_to_binary(row[i]);
@@ -1054,9 +1061,17 @@ std::vector<decoder_result> trt_decoder::decode_batch_impl(
 }
 
 // Explicit instantiations for the supported single-output engine I/O dtypes.
-template std::vector<decoder_result> trt_decoder::decode_batch_impl<float>(
+template std::vector<decoder_result>
+trt_decoder::decode_batch_impl<float, float>(
     const std::vector<std::vector<float_t>> &) const;
-template std::vector<decoder_result> trt_decoder::decode_batch_impl<uint8_t>(
+template std::vector<decoder_result>
+trt_decoder::decode_batch_impl<float, uint8_t>(
+    const std::vector<std::vector<float_t>> &) const;
+template std::vector<decoder_result>
+trt_decoder::decode_batch_impl<uint8_t, float>(
+    const std::vector<std::vector<float_t>> &) const;
+template std::vector<decoder_result>
+trt_decoder::decode_batch_impl<uint8_t, uint8_t>(
     const std::vector<std::vector<float_t>> &) const;
 
 trt_decoder::~trt_decoder() = default;

--- a/libs/qec/unittests/CMakeLists.txt
+++ b/libs/qec/unittests/CMakeLists.txt
@@ -115,19 +115,27 @@ if(CUDAQ_QEC_TRT_DECODER_ENABLED AND CMAKE_SYSTEM_PROCESSOR MATCHES "(x86_64)|(A
       set(_trt_generated_onnx_dir "${CMAKE_CURRENT_BINARY_DIR}/trt_decoder_onnx")
       set(_trt_dynamic_identity_onnx "${_trt_generated_onnx_dir}/trt_dynamic_identity.onnx")
       set(_trt_uint8_identity_onnx "${_trt_generated_onnx_dir}/trt_uint8_identity.onnx")
+      set(_trt_uint8_to_float_onnx "${_trt_generated_onnx_dir}/trt_uint8_to_float.onnx")
       add_custom_command(
-        OUTPUT "${_trt_dynamic_identity_onnx}" "${_trt_uint8_identity_onnx}"
+        OUTPUT
+          "${_trt_dynamic_identity_onnx}"
+          "${_trt_uint8_identity_onnx}"
+          "${_trt_uint8_to_float_onnx}"
         COMMAND ${Python_EXECUTABLE}
           "${CMAKE_CURRENT_SOURCE_DIR}/decoders/trt_decoder/generate_trt_decoder_onnx.py"
           --out-dir "${_trt_generated_onnx_dir}"
         DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/decoders/trt_decoder/generate_trt_decoder_onnx.py"
         COMMENT "Generating TensorRT decoder ONNX test fixtures")
       add_custom_target(generate_trt_decoder_onnx
-        DEPENDS "${_trt_dynamic_identity_onnx}" "${_trt_uint8_identity_onnx}")
+        DEPENDS
+          "${_trt_dynamic_identity_onnx}"
+          "${_trt_uint8_identity_onnx}"
+          "${_trt_uint8_to_float_onnx}")
       add_dependencies(test_trt_decoder generate_trt_decoder_onnx)
       target_compile_definitions(test_trt_decoder PRIVATE
         TRT_TEST_DYNAMIC_ONNX_PATH="${_trt_dynamic_identity_onnx}"
-        TRT_TEST_UINT8_ONNX_PATH="${_trt_uint8_identity_onnx}")
+        TRT_TEST_UINT8_ONNX_PATH="${_trt_uint8_identity_onnx}"
+        TRT_TEST_UINT8_TO_FLOAT_ONNX_PATH="${_trt_uint8_to_float_onnx}")
     else()
       message(WARNING "Python package onnx not found. "
                       "Skipping generated TensorRT decoder ONNX fixtures.")

--- a/libs/qec/unittests/decoders/trt_decoder/generate_trt_decoder_onnx.py
+++ b/libs/qec/unittests/decoders/trt_decoder/generate_trt_decoder_onnx.py
@@ -26,6 +26,18 @@ def make_identity_model(output_path, name, elem_type, shape):
     onnx.save(model, output_path)
 
 
+def make_cast_model(output_path, name, input_type, output_type, shape):
+    input_info = helper.make_tensor_value_info("input", input_type, shape)
+    output_info = helper.make_tensor_value_info("output", output_type, shape)
+    cast = helper.make_node("Cast", ["input"], ["output"], to=output_type)
+    graph = helper.make_graph([cast], name, [input_info], [output_info])
+    model = helper.make_model(graph,
+                              opset_imports=[helper.make_opsetid("", 19)])
+    model.ir_version = 10
+    onnx.checker.check_model(model)
+    onnx.save(model, output_path)
+
+
 def main():
     parser = argparse.ArgumentParser(
         description="Generate small ONNX fixtures for trt_decoder tests.")
@@ -43,6 +55,13 @@ def main():
         os.path.join(args.out_dir, "trt_uint8_identity.onnx"),
         "trt_uint8_identity",
         TensorProto.UINT8,
+        [1, 3],
+    )
+    make_cast_model(
+        os.path.join(args.out_dir, "trt_uint8_to_float.onnx"),
+        "trt_uint8_to_float",
+        TensorProto.UINT8,
+        TensorProto.FLOAT,
         [1, 3],
     )
 

--- a/libs/qec/unittests/decoders/trt_decoder/test_trt_decoder.cpp
+++ b/libs/qec/unittests/decoders/trt_decoder/test_trt_decoder.cpp
@@ -59,6 +59,14 @@ std::optional<std::string> get_uint8_onnx_asset_path() {
   return std::nullopt;
 #endif
 }
+
+std::optional<std::string> get_uint8_to_float_onnx_asset_path() {
+#ifdef TRT_TEST_UINT8_TO_FLOAT_ONNX_PATH
+  return std::string(TRT_TEST_UINT8_TO_FLOAT_ONNX_PATH);
+#else
+  return std::nullopt;
+#endif
+}
 } // namespace
 
 // Path to ONNX test asset. Set by CMake (absolute path) so the test finds it
@@ -659,6 +667,39 @@ TEST_F(TRTDecoderTest, Uint8IdentityModelBinarizesInputAndOutput) {
 
   auto result = trt_decoder->decode({0.49, 0.5, 0.75});
   ASSERT_TRUE(result.converged);
+  ASSERT_EQ(result.result.size(), 3u);
+  EXPECT_FLOAT_EQ(result.result[0], 0.0);
+  EXPECT_FLOAT_EQ(result.result[1], 1.0);
+  EXPECT_FLOAT_EQ(result.result[2], 1.0);
+}
+
+TEST_F(TRTDecoderTest, MixedDtypeCopiesOutput) {
+  // Mixed UINT8 input and FLOAT output should use the engine output dtype when
+  // copying and interpreting output, not the input dtype selected for dispatch.
+  if (!gpu_available())
+    GTEST_SKIP() << "No CUDA GPU available";
+  auto onnx_path = get_uint8_to_float_onnx_asset_path();
+  if (!onnx_path || !std::filesystem::exists(*onnx_path))
+    GTEST_SKIP() << "Generated uint8-to-float ONNX fixture is unavailable";
+
+  cudaqx::heterogeneous_map params;
+  params.insert("onnx_load_path", *onnx_path);
+  params.insert("use_cuda_graph", false);
+
+  std::unique_ptr<decoder> trt_decoder;
+  try {
+    trt_decoder = decoder::get("trt_decoder", make_identity_h(3), params);
+  } catch (const std::exception &e) {
+    GTEST_SKIP() << "Failed to create uint8-to-float TRT decoder: " << e.what();
+  }
+
+  auto result = trt_decoder->decode({0.49, 0.5, 0.75});
+
+  // The Cast model should execute successfully; failure here means the mixed
+  // dtype path did not produce a usable decoder result.
+  ASSERT_TRUE(result.converged);
+  // The output has three float elements; a shorter result would show that the
+  // output buffer cardinality was not preserved.
   ASSERT_EQ(result.result.size(), 3u);
   EXPECT_FLOAT_EQ(result.result[0], 0.0);
   EXPECT_FLOAT_EQ(result.result[1], 1.0);


### PR DESCRIPTION
This PR tries to fix [[B] 6369534](https://nvbugspro.nvidia.com/bug/6369534).

There is also one exposing test "MixedDtypeCopiesOutput" added.
It uses a small ONNX model with UINT8 input and FLOAT output. It feeds soft values that binarise to {0, 1, 1} and expects float output {0, 1, 1}.
This exposes the bug because the old code dispatches on UINT8 input, copies only one byte per output element, and interprets the float output buffer incorrectly.

Thanks for looking at this PR.