### PR TITLE
Patch decoders to set return type

### DIFF
--- a/libs/qec/lib/decoders/plugins/pymatching/pymatching.cpp
+++ b/libs/qec/lib/decoders/plugins/pymatching/pymatching.cpp
@@ -122,6 +122,7 @@ public:
         }
       }
       this->set_O_sparse(O_sparse);
+      this->set_result_type(decode_result_type::decode_to_obs);
       decode_to_observables = true;
       if (!merge_strategy_explicit)
         merge_strategy_enum = pm::MERGE_STRATEGY::INDEPENDENT;

--- a/libs/qec/lib/decoders/plugins/trt_decoder/trt_decoder.cpp
+++ b/libs/qec/lib/decoders/plugins/trt_decoder/trt_decoder.cpp
@@ -7,6 +7,7 @@
  ******************************************************************************/
 
 #include "cudaq/qec/decoder.h"
+#include "cudaq/qec/pcm_utils.h"
 #include "cudaq/qec/trt_decoder_internal.h"
 #include "cudaq/runtime/logger/logger.h"
 #include <algorithm>
@@ -782,6 +783,13 @@ trt_decoder::trt_decoder(const cudaq::qec::sparse_binary_matrix &H,
       }
       decode_to_observables_ = true;
       num_observables_ = O.shape()[0];
+      // Keep the base decoder's observable matrix in sync with constructor O.
+      // TRT only needs num_observables_ locally because the model emits the
+      // observable prefix directly, while realtime enqueue state and nested
+      // global decoders still carry their own O copies. This duplicate plumbing
+      // is intentional for now; a follow-up can make O ownership less
+      // redundant.
+      set_O_sparse(cudaq::qec::pcm_to_sparse_vec(O));
       set_result_type(decode_result_type::decode_to_obs);
 
       // The TRT model output must encode [pre_L (num_observables_ entries),


### PR DESCRIPTION
Description

This PR updates decoders that consume an O observable matrix and return observable-frame results to keep the base decoder metadata in sync.

Changes:

- pymatching: when constructed with O, now calls set_result_type(decode_to_obs) after setting O_sparse.
- trt_decoder: when constructed with O, now also converts O into base O_sparse before setting decode_to_obs.

This keeps direct decoder construction aligned with the realtime enqueue_syndrome() contract: decoders returning observables advertise decode_to_obs, while the base class still has the observable matrix metadata it needs for sizing/logging/realtime state.

The TRT path still has some duplicated observable plumbing: TRT keeps local observable sizing, the base decoder stores O_sparse, and nested global decoders may carry their own O. This PR keeps those paths consistent without redesigning ownership. This should be cleaned up in future follow-ups as noted in the comments in this PR. 