### PR TITLE
Add YAML and Python config support for Chromobius TRT global decoder

### DIFF
--- a/libs/qec/include/cudaq/qec/realtime/decoding_config.h
+++ b/libs/qec/include/cudaq/qec/realtime/decoding_config.h
@@ -181,7 +181,7 @@ struct decoder_config {
   std::vector<std::int64_t> D_sparse;
   std::variant<single_error_lut_config, multi_error_lut_config,
                nv_qldpc_decoder_config, sliding_window_config,
-               trt_decoder_config, pymatching_config, chromobius_config>
+               trt_decoder_config, pymatching_config>
       decoder_custom_args;
 
   bool operator==(const decoder_config &) const = default;
@@ -210,9 +210,6 @@ struct decoder_config {
     } else if (std::holds_alternative<pymatching_config>(decoder_custom_args)) {
       return std::get<pymatching_config>(decoder_custom_args)
           .to_heterogeneous_map();
-    } else if (std::holds_alternative<chromobius_config>(decoder_custom_args)) {
-      return std::get<chromobius_config>(decoder_custom_args)
-          .to_heterogeneous_map();
     }
     return cudaqx::heterogeneous_map();
   }
@@ -234,8 +231,6 @@ struct decoder_config {
       decoder_custom_args = trt_decoder_config::from_heterogeneous_map(map);
     } else if (type == "pymatching") {
       decoder_custom_args = pymatching_config::from_heterogeneous_map(map);
-    } else if (type == "chromobius") {
-      decoder_custom_args = chromobius_config::from_heterogeneous_map(map);
     }
   }
 

--- a/libs/qec/include/cudaq/qec/realtime/decoding_config.h
+++ b/libs/qec/include/cudaq/qec/realtime/decoding_config.h
@@ -107,11 +107,24 @@ struct pymatching_config {
   from_heterogeneous_map(const cudaqx::heterogeneous_map &map);
 };
 
-// The realtime trt_decoder config currently models only PyMatching as a global
-// decoder. Other global decoder plugins may be constructed through lower-level
-// APIs when their parameters are supplied directly, but they are not serialized
-// by this config variant yet.
-using global_decoder_config = std::variant<std::monostate, pymatching_config>;
+struct chromobius_config {
+  std::optional<bool> drop_mobius_errors_involving_remnant_errors;
+  std::optional<bool> ignore_decomposition_failures;
+  std::optional<bool> include_coords_in_mobius_dem;
+  std::optional<bool> return_weight;
+  std::optional<bool> write_mobius_match_to_stderr;
+
+  bool operator==(const chromobius_config &) const = default;
+
+  __attribute__((visibility("default"))) cudaqx::heterogeneous_map
+  to_heterogeneous_map() const;
+
+  __attribute__((visibility("default"))) static chromobius_config
+  from_heterogeneous_map(const cudaqx::heterogeneous_map &map);
+};
+
+using global_decoder_config =
+    std::variant<std::monostate, pymatching_config, chromobius_config>;
 
 struct trt_decoder_config {
   std::optional<std::string> onnx_load_path;
@@ -168,7 +181,7 @@ struct decoder_config {
   std::vector<std::int64_t> D_sparse;
   std::variant<single_error_lut_config, multi_error_lut_config,
                nv_qldpc_decoder_config, sliding_window_config,
-               trt_decoder_config, pymatching_config>
+               trt_decoder_config, pymatching_config, chromobius_config>
       decoder_custom_args;
 
   bool operator==(const decoder_config &) const = default;
@@ -197,6 +210,9 @@ struct decoder_config {
     } else if (std::holds_alternative<pymatching_config>(decoder_custom_args)) {
       return std::get<pymatching_config>(decoder_custom_args)
           .to_heterogeneous_map();
+    } else if (std::holds_alternative<chromobius_config>(decoder_custom_args)) {
+      return std::get<chromobius_config>(decoder_custom_args)
+          .to_heterogeneous_map();
     }
     return cudaqx::heterogeneous_map();
   }
@@ -218,6 +234,8 @@ struct decoder_config {
       decoder_custom_args = trt_decoder_config::from_heterogeneous_map(map);
     } else if (type == "pymatching") {
       decoder_custom_args = pymatching_config::from_heterogeneous_map(map);
+    } else if (type == "chromobius") {
+      decoder_custom_args = chromobius_config::from_heterogeneous_map(map);
     }
   }
 

--- a/libs/qec/lib/realtime/config.cpp
+++ b/libs/qec/lib/realtime/config.cpp
@@ -256,26 +256,25 @@ global_decoder_config global_decoder_config_from_value(
     return *global_cfg;
   }
 
-  if (global_decoder.value() == "pymatching") {
-    if (auto *pymatching_cfg = std::any_cast<pymatching_config>(&val))
-      return *pymatching_cfg;
-    if (auto *nested_map = std::any_cast<cudaqx::heterogeneous_map>(&val))
-      return pymatching_config::from_heterogeneous_map(*nested_map);
-  } else if (global_decoder.value() == "chromobius") {
-    if (auto *chromobius_cfg = std::any_cast<chromobius_config>(&val))
-      return *chromobius_cfg;
-    if (auto *nested_map = std::any_cast<cudaqx::heterogeneous_map>(&val))
-      return chromobius_config::from_heterogeneous_map(*nested_map);
+  if (auto *nested_map = std::any_cast<cudaqx::heterogeneous_map>(&val)) {
+    return global_decoder_config_from_heterogeneous_map(*nested_map,
+                                                        global_decoder);
+  }
+
+  global_decoder_config parsed_params;
+  if (auto *pymatching_cfg = std::any_cast<pymatching_config>(&val)) {
+    parsed_params = *pymatching_cfg;
+  } else if (auto *chromobius_cfg = std::any_cast<chromobius_config>(&val)) {
+    parsed_params = *chromobius_cfg;
   } else {
     throw std::runtime_error(
-        "global_decoder_params does not support global_decoder '" +
+        "global_decoder_params has an unsupported value type for "
+        "global_decoder '" +
         global_decoder.value() + "'.");
   }
 
-  throw std::runtime_error(
-      "global_decoder_params has an unsupported value type for "
-      "global_decoder '" +
-      global_decoder.value() + "'.");
+  validate_global_decoder_params(parsed_params, global_decoder);
+  return parsed_params;
 }
 
 void validate_global_decoder_params(
@@ -786,9 +785,6 @@ struct MappingTraits<cudaq::qec::decoding::config::decoder_config> {
     } else if (config.type == "pymatching") {
       INIT_AND_MAP_DECODER_CUSTOM_ARGS(
           cudaq::qec::decoding::config::pymatching_config);
-    } else if (config.type == "chromobius") {
-      INIT_AND_MAP_DECODER_CUSTOM_ARGS(
-          cudaq::qec::decoding::config::chromobius_config);
     }
   }
 };

--- a/libs/qec/lib/realtime/config.cpp
+++ b/libs/qec/lib/realtime/config.cpp
@@ -14,6 +14,7 @@
 #include "realtime_decoding.h"
 #include "cudaq/qec/realtime/decoding_config.h"
 #include "cudaq/runtime/logger/logger.h"
+#include <any>
 #include <filesystem>
 #include <fstream>
 #include <type_traits>
@@ -192,27 +193,115 @@ single_error_lut_config single_error_lut_config::from_heterogeneous_map(
 
 cudaqx::heterogeneous_map global_decoder_config_to_heterogeneous_map(
     const global_decoder_config &global_decoder_params) {
-  if (std::holds_alternative<std::monostate>(global_decoder_params)) {
-    return cudaqx::heterogeneous_map();
-  }
-
-  if (std::holds_alternative<pymatching_config>(global_decoder_params)) {
-    return std::get<pymatching_config>(global_decoder_params)
-        .to_heterogeneous_map();
-  }
-
-  throw std::runtime_error("Unsupported global decoder parameters.");
+  return std::visit(
+      [](const auto &params) -> cudaqx::heterogeneous_map {
+        using config_t = std::decay_t<decltype(params)>;
+        if constexpr (std::is_same_v<config_t, std::monostate>) {
+          return cudaqx::heterogeneous_map();
+        } else {
+          return params.to_heterogeneous_map();
+        }
+      },
+      global_decoder_params);
 }
 
 global_decoder_config global_decoder_config_from_heterogeneous_map(
     const cudaqx::heterogeneous_map &map,
     const std::optional<std::string> &global_decoder) {
-  if (global_decoder.has_value() && global_decoder.value() != "pymatching") {
+  if (!global_decoder.has_value()) {
     throw std::runtime_error(
-        "global_decoder_params currently supports only pymatching.");
+        "global_decoder_params present but global_decoder is not set.");
   }
 
-  return pymatching_config::from_heterogeneous_map(map);
+  if (global_decoder.value() == "pymatching") {
+    return pymatching_config::from_heterogeneous_map(map);
+  }
+
+  if (global_decoder.value() == "chromobius") {
+    return chromobius_config::from_heterogeneous_map(map);
+  }
+
+  throw std::runtime_error(
+      "global_decoder_params does not support global_decoder '" +
+      global_decoder.value() + "'.");
+}
+
+global_decoder_config default_global_decoder_params(
+    const std::optional<std::string> &global_decoder) {
+  if (!global_decoder.has_value())
+    return std::monostate{};
+
+  if (global_decoder.value() == "pymatching")
+    return pymatching_config{};
+
+  if (global_decoder.value() == "chromobius")
+    return chromobius_config{};
+
+  return std::monostate{};
+}
+
+void validate_global_decoder_params(
+    const global_decoder_config &global_decoder_params,
+    const std::optional<std::string> &global_decoder);
+
+global_decoder_config global_decoder_config_from_value(
+    const std::any &val, const std::optional<std::string> &global_decoder) {
+  if (!global_decoder.has_value()) {
+    throw std::runtime_error(
+        "global_decoder_params present but global_decoder is not set.");
+  }
+
+  if (auto *global_cfg = std::any_cast<global_decoder_config>(&val)) {
+    validate_global_decoder_params(*global_cfg, global_decoder);
+    return *global_cfg;
+  }
+
+  if (global_decoder.value() == "pymatching") {
+    if (auto *pymatching_cfg = std::any_cast<pymatching_config>(&val))
+      return *pymatching_cfg;
+    if (auto *nested_map = std::any_cast<cudaqx::heterogeneous_map>(&val))
+      return pymatching_config::from_heterogeneous_map(*nested_map);
+  } else if (global_decoder.value() == "chromobius") {
+    if (auto *chromobius_cfg = std::any_cast<chromobius_config>(&val))
+      return *chromobius_cfg;
+    if (auto *nested_map = std::any_cast<cudaqx::heterogeneous_map>(&val))
+      return chromobius_config::from_heterogeneous_map(*nested_map);
+  } else {
+    throw std::runtime_error(
+        "global_decoder_params does not support global_decoder '" +
+        global_decoder.value() + "'.");
+  }
+
+  throw std::runtime_error(
+      "global_decoder_params has an unsupported value type for "
+      "global_decoder '" +
+      global_decoder.value() + "'.");
+}
+
+void validate_global_decoder_params(
+    const global_decoder_config &global_decoder_params,
+    const std::optional<std::string> &global_decoder) {
+  if (std::holds_alternative<std::monostate>(global_decoder_params))
+    return;
+
+  if (!global_decoder.has_value()) {
+    throw std::runtime_error(
+        "global_decoder_params present but global_decoder is not set.");
+  }
+
+  if (global_decoder.value() == "pymatching" &&
+      std::holds_alternative<pymatching_config>(global_decoder_params)) {
+    return;
+  }
+
+  if (global_decoder.value() == "chromobius" &&
+      std::holds_alternative<chromobius_config>(global_decoder_params)) {
+    return;
+  }
+
+  throw std::runtime_error(
+      "global_decoder_params type does not match global_decoder '" +
+      global_decoder.value() + "'.");
 }
 
 // ------ pymatching_config ------
@@ -233,6 +322,30 @@ pymatching_config pymatching_config::from_heterogeneous_map(
   return config;
 }
 
+// ------ chromobius_config ------
+cudaqx::heterogeneous_map chromobius_config::to_heterogeneous_map() const {
+  cudaqx::heterogeneous_map config_map;
+
+  INSERT_ARG(drop_mobius_errors_involving_remnant_errors);
+  INSERT_ARG(ignore_decomposition_failures);
+  INSERT_ARG(include_coords_in_mobius_dem);
+  INSERT_ARG(return_weight);
+  INSERT_ARG(write_mobius_match_to_stderr);
+
+  return config_map;
+}
+
+chromobius_config chromobius_config::from_heterogeneous_map(
+    const cudaqx::heterogeneous_map &map) {
+  chromobius_config config;
+  GET_ARG(drop_mobius_errors_involving_remnant_errors);
+  GET_ARG(ignore_decomposition_failures);
+  GET_ARG(include_coords_in_mobius_dem);
+  GET_ARG(return_weight);
+  GET_ARG(write_mobius_match_to_stderr);
+  return config;
+}
+
 // ------ trt_decoder_config ------
 cudaqx::heterogeneous_map trt_decoder_config::to_heterogeneous_map() const {
   cudaqx::heterogeneous_map config_map;
@@ -245,24 +358,18 @@ cudaqx::heterogeneous_map trt_decoder_config::to_heterogeneous_map() const {
   INSERT_ARG(batch_size);
   INSERT_ARG(use_cuda_graph);
   INSERT_ARG(global_decoder);
-  if (!std::holds_alternative<std::monostate>(global_decoder_params)) {
-    if (!global_decoder.has_value()) {
-      throw std::runtime_error(
-          "global_decoder_params present but global_decoder is not set.");
-    }
-    if (global_decoder.value() != "pymatching") {
-      throw std::runtime_error(
-          "global_decoder_params currently supports only pymatching.");
-    }
-    config_map.insert(
-        "global_decoder_params",
-        global_decoder_config_to_heterogeneous_map(global_decoder_params));
+  auto effective_global_decoder_params = global_decoder_params;
+  if (std::holds_alternative<std::monostate>(effective_global_decoder_params))
+    effective_global_decoder_params =
+        default_global_decoder_params(global_decoder);
+  if (!std::holds_alternative<std::monostate>(
+          effective_global_decoder_params)) {
+    validate_global_decoder_params(effective_global_decoder_params,
+                                   global_decoder);
+    config_map.insert("global_decoder_params",
+                      global_decoder_config_to_heterogeneous_map(
+                          effective_global_decoder_params));
   }
-  // Note: when global_decoder_params is monostate we intentionally emit
-  // nothing, even if global_decoder is set. Inventing an empty params map here
-  // would round-trip back as a default pymatching_config, mutating the config.
-  // Any runtime need for an empty params map is handled in
-  // prepare_decoder_params (realtime_decoding.cpp), not in serialization.
 
   return config_map;
 }
@@ -279,27 +386,16 @@ trt_decoder_config trt_decoder_config::from_heterogeneous_map(
   GET_ARG(use_cuda_graph);
   GET_ARG(global_decoder);
   if (map.contains("global_decoder_params")) {
-    if (!config.global_decoder.has_value())
-      throw std::runtime_error(
-          "global_decoder_params present but global_decoder is not set.");
-    if (config.global_decoder.value() != "pymatching")
-      throw std::runtime_error(
-          "global_decoder_params currently supports only pymatching.");
-    try {
-      config.global_decoder_params =
-          map.get<global_decoder_config>("global_decoder_params");
-    } catch (...) {
-      try {
+    for (const auto &[key, val] : map) {
+      if (key == "global_decoder_params") {
         config.global_decoder_params =
-            map.get<pymatching_config>("global_decoder_params");
-      } catch (...) {
-        auto nested_map =
-            map.get<cudaqx::heterogeneous_map>("global_decoder_params");
-        config.global_decoder_params =
-            global_decoder_config_from_heterogeneous_map(nested_map,
-                                                         config.global_decoder);
+            global_decoder_config_from_value(val, config.global_decoder);
+        break;
       }
     }
+  } else {
+    config.global_decoder_params =
+        default_global_decoder_params(config.global_decoder);
   }
 
   return config;
@@ -446,16 +542,32 @@ struct MappingTraits<cudaq::qec::decoding::config::global_decoder_config> {
         return;
       }
 
-      auto &params = std::get<pymatching_config>(config);
-      io.mapOptional("merge_strategy", params.merge_strategy);
-      io.mapOptional("error_rate_vec", params.error_rate_vec);
+      if (std::holds_alternative<pymatching_config>(config)) {
+        auto &params = std::get<pymatching_config>(config);
+        io.mapOptional("merge_strategy", params.merge_strategy);
+        io.mapOptional("error_rate_vec", params.error_rate_vec);
+        return;
+      }
+
+      auto &params = std::get<chromobius_config>(config);
+      io.mapOptional("drop_mobius_errors_involving_remnant_errors",
+                     params.drop_mobius_errors_involving_remnant_errors);
+      io.mapOptional("ignore_decomposition_failures",
+                     params.ignore_decomposition_failures);
+      io.mapOptional("include_coords_in_mobius_dem",
+                     params.include_coords_in_mobius_dem);
+      io.mapOptional("return_weight", params.return_weight);
+      io.mapOptional("write_mobius_match_to_stderr",
+                     params.write_mobius_match_to_stderr);
       return;
     }
 
-    pymatching_config params;
-    io.mapOptional("merge_strategy", params.merge_strategy);
-    io.mapOptional("error_rate_vec", params.error_rate_vec);
-    config = std::move(params);
+    // Input cannot be decoded safely here because the variant type depends on
+    // the parent trt_decoder_config.global_decoder value. The TRT mapping
+    // below dispatches with that context.
+    throw std::runtime_error(
+        "global_decoder_config YAML input requires trt_decoder_config "
+        "global_decoder context.");
   }
 };
 
@@ -465,6 +577,22 @@ struct MappingTraits<cudaq::qec::decoding::config::pymatching_config> {
                       cudaq::qec::decoding::config::pymatching_config &config) {
     io.mapOptional("error_rate_vec", config.error_rate_vec);
     io.mapOptional("merge_strategy", config.merge_strategy);
+  }
+};
+
+template <>
+struct MappingTraits<cudaq::qec::decoding::config::chromobius_config> {
+  static void mapping(IO &io,
+                      cudaq::qec::decoding::config::chromobius_config &config) {
+    io.mapOptional("drop_mobius_errors_involving_remnant_errors",
+                   config.drop_mobius_errors_involving_remnant_errors);
+    io.mapOptional("ignore_decomposition_failures",
+                   config.ignore_decomposition_failures);
+    io.mapOptional("include_coords_in_mobius_dem",
+                   config.include_coords_in_mobius_dem);
+    io.mapOptional("return_weight", config.return_weight);
+    io.mapOptional("write_mobius_match_to_stderr",
+                   config.write_mobius_match_to_stderr);
   }
 };
 
@@ -480,22 +608,70 @@ struct MappingTraits<cudaq::qec::decoding::config::trt_decoder_config> {
     io.mapOptional("batch_size", config.batch_size);
     io.mapOptional("use_cuda_graph", config.use_cuda_graph);
     io.mapOptional("global_decoder", config.global_decoder);
-    // Emit global_decoder_params only when it actually holds params. Mapping it
-    // unconditionally on output writes an empty `global_decoder_params: {}` for
-    // the monostate case, which deserializes back into a default
-    // pymatching_config -- mutating a monostate config across a YAML
-    // round-trip. On input we always map it: an absent key leaves the variant
-    // at its monostate default (mapOptional skips the nested mapping), and a
-    // present key is parsed into pymatching_config.
-    if (!io.outputting() ||
-        !std::holds_alternative<std::monostate>(config.global_decoder_params))
-      io.mapOptional("global_decoder_params", config.global_decoder_params);
 
-    if (!std::holds_alternative<std::monostate>(config.global_decoder_params) &&
-        config.global_decoder.has_value() &&
-        config.global_decoder.value() != "pymatching") {
-      throw std::runtime_error(
-          "global_decoder_params currently supports only pymatching.");
+    if (io.outputting()) {
+      auto global_decoder_params = config.global_decoder_params;
+      if (std::holds_alternative<std::monostate>(global_decoder_params)) {
+        global_decoder_params =
+            cudaq::qec::decoding::config::default_global_decoder_params(
+                config.global_decoder);
+      }
+      if (std::holds_alternative<std::monostate>(global_decoder_params)) {
+        return;
+      }
+
+      cudaq::qec::decoding::config::validate_global_decoder_params(
+          global_decoder_params, config.global_decoder);
+      if (config.global_decoder.value() == "pymatching") {
+        io.mapOptional(
+            "global_decoder_params",
+            std::get<cudaq::qec::decoding::config::pymatching_config>(
+                global_decoder_params));
+      } else if (config.global_decoder.value() == "chromobius") {
+        io.mapOptional(
+            "global_decoder_params",
+            std::get<cudaq::qec::decoding::config::chromobius_config>(
+                global_decoder_params));
+      }
+      return;
+    }
+
+    if (config.global_decoder.has_value() &&
+        config.global_decoder.value() == "pymatching") {
+      std::optional<cudaq::qec::decoding::config::pymatching_config> params;
+      io.mapOptional("global_decoder_params", params);
+      if (params.has_value())
+        config.global_decoder_params = std::move(params.value());
+      else
+        config.global_decoder_params =
+            cudaq::qec::decoding::config::default_global_decoder_params(
+                config.global_decoder);
+    } else if (config.global_decoder.has_value() &&
+               config.global_decoder.value() == "chromobius") {
+      std::optional<cudaq::qec::decoding::config::chromobius_config> params;
+      io.mapOptional("global_decoder_params", params);
+      if (params.has_value())
+        config.global_decoder_params = std::move(params.value());
+      else
+        config.global_decoder_params =
+            cudaq::qec::decoding::config::default_global_decoder_params(
+                config.global_decoder);
+    } else {
+      // Use a throwaway value only to detect whether the key was present. Do
+      // not assign it to config.global_decoder_params: without a supported
+      // global_decoder name, there is no safe variant type to parse into.
+      std::optional<cudaq::qec::decoding::config::pymatching_config> params;
+      io.mapOptional("global_decoder_params", params);
+      if (params.has_value()) {
+        if (config.global_decoder.has_value()) {
+          throw std::runtime_error(
+              "global_decoder_params does not support global_decoder '" +
+              config.global_decoder.value() + "'.");
+        } else {
+          throw std::runtime_error(
+              "global_decoder_params present but global_decoder is not set.");
+        }
+      }
     }
   }
 };
@@ -610,6 +786,9 @@ struct MappingTraits<cudaq::qec::decoding::config::decoder_config> {
     } else if (config.type == "pymatching") {
       INIT_AND_MAP_DECODER_CUSTOM_ARGS(
           cudaq::qec::decoding::config::pymatching_config);
+    } else if (config.type == "chromobius") {
+      INIT_AND_MAP_DECODER_CUSTOM_ARGS(
+          cudaq::qec::decoding::config::chromobius_config);
     }
   }
 };

--- a/libs/qec/lib/realtime/realtime_decoding.cpp
+++ b/libs/qec/lib/realtime/realtime_decoding.cpp
@@ -198,15 +198,18 @@ cudaqx::heterogeneous_map prepare_decoder_params(
         "(one syndrome is decoded per call); the extra batch slots are "
         "zero-padded and discarded. Use batch_size = 1 for realtime.");
 
-  // The trt_decoder plugin attaches a pymatching global decoder only when both
-  // "global_decoder" and "global_decoder_params" are present. Serialization no
-  // longer emits an empty params map for the monostate (no-params) case, so
-  // synthesize one here -- before the O_sparse early return -- so that a global
-  // decoder running on residual detectors without an O matrix still attaches.
-  const bool has_pymatching_global =
+  // The trt_decoder plugin attaches a global decoder only when both
+  // "global_decoder" and "global_decoder_params" are present. Most config
+  // paths materialize defaults for known global decoders, but callers can still
+  // provide a hand-built map with only "global_decoder"; synthesize params here
+  // before the O_sparse early return so that decoder still attaches.
+  const bool has_global_decoder =
       params.contains("global_decoder") &&
+      !params.get<std::string>("global_decoder").empty();
+  const bool has_pymatching_global =
+      has_global_decoder &&
       params.get<std::string>("global_decoder") == "pymatching";
-  if (has_pymatching_global && !params.contains("global_decoder_params"))
+  if (has_global_decoder && !params.contains("global_decoder_params"))
     params.insert("global_decoder_params", cudaqx::heterogeneous_map());
 
   if (decoder_config.O_sparse.empty())
@@ -221,6 +224,9 @@ cudaqx::heterogeneous_map prepare_decoder_params(
       decoder_config.O_sparse, num_observables, decoder_config.block_size);
   params.insert("O", O);
 
+  // PyMatching consumes the observable matrix through its params; other global
+  // decoders receive only the top-level O until they define a matching
+  // contract.
   if (has_pymatching_global) {
     auto global_decoder_params =
         params.get<cudaqx::heterogeneous_map>("global_decoder_params");

--- a/libs/qec/python/bindings/py_decoding_config.cpp
+++ b/libs/qec/python/bindings/py_decoding_config.cpp
@@ -140,21 +140,33 @@ void bindDecodingConfig(nb::module_ &mod) {
               setter_accepts_none)
       .def_prop_rw(
           "global_decoder_params",
-          [](const trt_decoder_config &self)
-              -> std::optional<pymatching_config> {
+          [](const trt_decoder_config &self) -> nb::object {
             if (std::holds_alternative<pymatching_config>(
                     self.global_decoder_params)) {
-              return std::get<pymatching_config>(self.global_decoder_params);
+              return nb::cast(
+                  std::get<pymatching_config>(self.global_decoder_params));
             }
-            return std::nullopt;
+            if (std::holds_alternative<chromobius_config>(
+                    self.global_decoder_params)) {
+              return nb::cast(
+                  std::get<chromobius_config>(self.global_decoder_params));
+            }
+            return nb::none();
           },
-          [](trt_decoder_config &self, std::optional<pymatching_config> value) {
-            if (value.has_value()) {
-              self.global_decoder_params = value.value();
-            } else {
+          [](trt_decoder_config &self, nb::object value) {
+            if (value.is_none()) {
               self.global_decoder_params = std::monostate();
+            } else if (nb::isinstance<pymatching_config>(value)) {
+              self.global_decoder_params = nb::cast<pymatching_config>(value);
+            } else if (nb::isinstance<chromobius_config>(value)) {
+              self.global_decoder_params = nb::cast<chromobius_config>(value);
+            } else {
+              throw nb::type_error(
+                  "global_decoder_params must be pymatching_config, "
+                  "chromobius_config, or None.");
             }
-          })
+          },
+          setter_accepts_none)
       .def("to_heterogeneous_map", &trt_decoder_config::to_heterogeneous_map,
            nb::rv_policy::move)
       .def_static("from_heterogeneous_map",
@@ -178,6 +190,37 @@ void bindDecodingConfig(nb::module_ &mod) {
            nb::rv_policy::move)
       .def_static("from_heterogeneous_map",
                   &pymatching_config::from_heterogeneous_map, nb::arg("map"));
+
+  // chromobius_config
+  nb::class_<config::chromobius_config>(mod_cfg, "chromobius_config",
+                                        "Chromobius decoder configuration.")
+      .def(nb::init<>())
+      .def(
+          "__init__",
+          [](config::chromobius_config &self,
+             const cudaqx::heterogeneous_map &map) {
+            new (&self) chromobius_config(
+                chromobius_config::from_heterogeneous_map(map));
+          },
+          nb::arg("map"))
+      .def_rw("drop_mobius_errors_involving_remnant_errors",
+              &chromobius_config::drop_mobius_errors_involving_remnant_errors,
+              setter_accepts_none)
+      .def_rw("ignore_decomposition_failures",
+              &chromobius_config::ignore_decomposition_failures,
+              setter_accepts_none)
+      .def_rw("include_coords_in_mobius_dem",
+              &chromobius_config::include_coords_in_mobius_dem,
+              setter_accepts_none)
+      .def_rw("return_weight", &chromobius_config::return_weight,
+              setter_accepts_none)
+      .def_rw("write_mobius_match_to_stderr",
+              &chromobius_config::write_mobius_match_to_stderr,
+              setter_accepts_none)
+      .def("to_heterogeneous_map", &chromobius_config::to_heterogeneous_map,
+           nb::rv_policy::move)
+      .def_static("from_heterogeneous_map",
+                  &chromobius_config::from_heterogeneous_map, nb::arg("map"));
 
   // single_error_lut_config
   nb::class_<config::single_error_lut_config>(

--- a/libs/qec/python/bindings/type_casters.h
+++ b/libs/qec/python/bindings/type_casters.h
@@ -201,9 +201,16 @@ struct type_caster<cudaqx::heterogeneous_map> {
             // Omit the key for monostate, matching
             // trt_decoder_config::to_heterogeneous_map(): an unset global
             // decoder serializes as absent, not as a null value.
-          } else {
+          } else if (std::holds_alternative<
+                         cudaq::qec::decoding::config::pymatching_config>(
+                         *global_cfg)) {
             result[key.c_str()] = nb::cast(
                 std::get<cudaq::qec::decoding::config::pymatching_config>(
+                    *global_cfg)
+                    .to_heterogeneous_map());
+          } else {
+            result[key.c_str()] = nb::cast(
+                std::get<cudaq::qec::decoding::config::chromobius_config>(
                     *global_cfg)
                     .to_heterogeneous_map());
           }
@@ -211,6 +218,10 @@ struct type_caster<cudaqx::heterogeneous_map> {
                        cudaq::qec::decoding::config::pymatching_config>(&val)) {
           result[key.c_str()] =
               nb::cast(pymatching_cfg->to_heterogeneous_map());
+        } else if (auto *chromobius_cfg = std::any_cast<
+                       cudaq::qec::decoding::config::chromobius_config>(&val)) {
+          result[key.c_str()] =
+              nb::cast(chromobius_cfg->to_heterogeneous_map());
         } else if (auto *sw_cfg = std::any_cast<
                        cudaq::qec::decoding::config::sliding_window_config>(
                        &val)) {

--- a/libs/qec/python/cudaq_qec/__init__.py
+++ b/libs/qec/python/cudaq_qec/__init__.py
@@ -116,6 +116,7 @@ nv_qldpc_decoder_config = qecrt.config.nv_qldpc_decoder_config
 multi_error_lut_config = qecrt.config.multi_error_lut_config
 trt_decoder_config = qecrt.config.trt_decoder_config
 pymatching_config = qecrt.config.pymatching_config
+chromobius_config = qecrt.config.chromobius_config
 configure_decoders_from_file = qecrt.config.configure_decoders_from_file
 configure_decoders_from_str = qecrt.config.configure_decoders_from_str
 finalize_decoders = qecrt.config.finalize_decoders

--- a/libs/qec/python/tests/test_decoding_config.py
+++ b/libs/qec/python/tests/test_decoding_config.py
@@ -173,6 +173,14 @@ FIELDS_PYMATCHING = {
     "merge_strategy": (str, "smallest_weight", "disallow"),
 }
 
+FIELDS_CHROMOBIUS = {
+    "drop_mobius_errors_involving_remnant_errors": (bool, True, False),
+    "ignore_decomposition_failures": (bool, True, False),
+    "include_coords_in_mobius_dem": (bool, True, False),
+    "return_weight": (bool, True, False),
+    "write_mobius_match_to_stderr": (bool, True, False),
+}
+
 # trt_decoder_config tests
 
 FIELDS_TRT_DECODER = {
@@ -196,6 +204,12 @@ def test_pymatching_config_defaults_are_none():
         assert getattr(pm, name) is None, f"Expected {name} to default to None"
 
 
+def test_chromobius_config_defaults_are_none():
+    chromobius = qec.chromobius_config()
+    for name in FIELDS_CHROMOBIUS:
+        assert getattr(chromobius, name) is None
+
+
 @pytest.mark.parametrize("name, meta", list(FIELDS_PYMATCHING.items()))
 def test_pymatching_config_set_and_get_each_optional(name, meta):
     pm = qec.pymatching_config()
@@ -215,6 +229,27 @@ def test_pymatching_config_set_and_get_each_optional(name, meta):
 
     setattr(pm, name, None)
     assert getattr(pm, name) is None
+
+
+@pytest.mark.parametrize("name, meta", list(FIELDS_CHROMOBIUS.items()))
+def test_chromobius_config_set_and_get_each_optional(name, meta):
+    chromobius = qec.chromobius_config()
+
+    py_type, sample_val, alt_val = meta
+
+    assert getattr(chromobius, name) is None
+
+    setattr(chromobius, name, sample_val)
+    got = getattr(chromobius, name)
+    assert isinstance(got, py_type)
+    assert got == sample_val
+
+    setattr(chromobius, name, alt_val)
+    got2 = getattr(chromobius, name)
+    assert got2 == alt_val
+
+    setattr(chromobius, name, None)
+    assert getattr(chromobius, name) is None
 
 
 def test_configure_valid_multi_error_lut_decoders():
@@ -307,6 +342,78 @@ def test_trt_decoder_config_yaml_roundtrip():
     assert trt2.memory_workspace == 1073741824
 
 
+def test_trt_decoder_config_chromobius_global_params_roundtrip():
+    trt = qec.trt_decoder_config()
+    chromobius = qec.chromobius_config()
+    chromobius.return_weight = True
+
+    trt.global_decoder = "chromobius"
+    trt.global_decoder_params = chromobius
+
+    got = trt.global_decoder_params
+    assert isinstance(got, qec.chromobius_config)
+    assert got.return_weight is True
+
+    as_map = trt.to_heterogeneous_map()
+    assert as_map["global_decoder"] == "chromobius"
+    assert as_map["global_decoder_params"]["return_weight"] is True
+
+    trt2 = qec.trt_decoder_config.from_heterogeneous_map(as_map)
+    got2 = trt2.global_decoder_params
+    assert isinstance(got2, qec.chromobius_config)
+    assert got2.return_weight is True
+
+    trt2.global_decoder_params = None
+    assert trt2.global_decoder_params is None
+
+
+def test_trt_decoder_config_defaults_omitted_global_params():
+    for global_decoder, config_type in (
+        ("pymatching", qec.pymatching_config),
+        ("chromobius", qec.chromobius_config),
+    ):
+        trt = qec.trt_decoder_config.from_heterogeneous_map(
+            {"global_decoder": global_decoder})
+
+        got = trt.global_decoder_params
+        assert isinstance(got, config_type)
+
+        as_map = trt.to_heterogeneous_map()
+        assert as_map["global_decoder"] == global_decoder
+        assert as_map["global_decoder_params"] == {}
+
+        trt = qec.trt_decoder_config()
+        trt.global_decoder = global_decoder
+        as_map = trt.to_heterogeneous_map()
+        assert as_map["global_decoder"] == global_decoder
+        assert as_map["global_decoder_params"] == {}
+
+
+def test_trt_decoder_config_preserves_unknown_omitted_global_params():
+    trt = qec.trt_decoder_config.from_heterogeneous_map(
+        {"global_decoder": "my_plugin"})
+
+    assert trt.global_decoder_params is None
+
+    as_map = trt.to_heterogeneous_map()
+    assert as_map["global_decoder"] == "my_plugin"
+    assert "global_decoder_params" not in as_map
+
+    trt = qec.trt_decoder_config()
+    trt.global_decoder = "my_plugin"
+    as_map = trt.to_heterogeneous_map()
+    assert as_map["global_decoder"] == "my_plugin"
+    assert "global_decoder_params" not in as_map
+
+
+def test_trt_decoder_config_rejects_unknown_global_params():
+    with pytest.raises(RuntimeError):
+        qec.trt_decoder_config.from_heterogeneous_map({
+            "global_decoder": "my_plugin",
+            "global_decoder_params": {},
+        })
+
+
 def test_pymatching_config_yaml_roundtrip():
     pm = qec.pymatching_config()
     pm.error_rate_vec = [0.1, 0.2, 0.3]
@@ -333,6 +440,34 @@ def test_pymatching_config_yaml_roundtrip():
     assert pm2 is not None
     assert pm2.error_rate_vec == [0.1, 0.2, 0.3]
     assert pm2.merge_strategy == "smallest_weight"
+
+
+def test_chromobius_config_yaml_roundtrip():
+    chromobius = qec.chromobius_config()
+    chromobius.ignore_decomposition_failures = True
+    chromobius.return_weight = False
+
+    dc = qec.decoder_config()
+    dc.id = 0
+    dc.type = "chromobius"
+    dc.block_size = 3
+    dc.syndrome_size = 3
+    dc.H_sparse = [0, -1, 1, -1, 2, -1]
+    dc.O_sparse = [0, -1, 1, -1, 2, -1]
+    dc.D_sparse = [0, -1, 1, -1, 2, -1]
+    dc.set_decoder_custom_args(chromobius)
+
+    yaml_text = dc.to_yaml_str()
+    assert isinstance(yaml_text, str) and "chromobius" in yaml_text
+
+    dc2 = qec.decoder_config.from_yaml_str(yaml_text)
+    assert dc2 is not None
+    assert dc2.type == "chromobius"
+
+    chromobius2 = dc2.decoder_custom_args
+    assert chromobius2 is not None
+    assert chromobius2.ignore_decomposition_failures is True
+    assert chromobius2.return_weight is False
 
 
 # decoder_config tests

--- a/libs/qec/python/tests/test_decoding_config.py
+++ b/libs/qec/python/tests/test_decoding_config.py
@@ -442,29 +442,37 @@ def test_pymatching_config_yaml_roundtrip():
     assert pm2.merge_strategy == "smallest_weight"
 
 
-def test_chromobius_config_yaml_roundtrip():
+def test_trt_decoder_chromobius_global_config_yaml_roundtrip():
     chromobius = qec.chromobius_config()
     chromobius.ignore_decomposition_failures = True
     chromobius.return_weight = False
 
+    trt = qec.trt_decoder_config()
+    trt.global_decoder = "chromobius"
+    trt.global_decoder_params = chromobius
+
     dc = qec.decoder_config()
     dc.id = 0
-    dc.type = "chromobius"
+    dc.type = "trt_decoder"
     dc.block_size = 3
     dc.syndrome_size = 3
     dc.H_sparse = [0, -1, 1, -1, 2, -1]
     dc.O_sparse = [0, -1, 1, -1, 2, -1]
     dc.D_sparse = [0, -1, 1, -1, 2, -1]
-    dc.set_decoder_custom_args(chromobius)
+    dc.set_decoder_custom_args(trt)
 
     yaml_text = dc.to_yaml_str()
     assert isinstance(yaml_text, str) and "chromobius" in yaml_text
 
     dc2 = qec.decoder_config.from_yaml_str(yaml_text)
     assert dc2 is not None
-    assert dc2.type == "chromobius"
+    assert dc2.type == "trt_decoder"
 
-    chromobius2 = dc2.decoder_custom_args
+    trt2 = dc2.decoder_custom_args
+    assert trt2 is not None
+    assert trt2.global_decoder == "chromobius"
+
+    chromobius2 = trt2.global_decoder_params
     assert chromobius2 is not None
     assert chromobius2.ignore_decomposition_failures is True
     assert chromobius2.return_weight is False

--- a/libs/qec/unittests/test_decoders_yaml.cpp
+++ b/libs/qec/unittests/test_decoders_yaml.cpp
@@ -313,11 +313,23 @@ TEST(DecoderYAMLTest, TrtDecoderMonostateGlobalDecoderParams) {
   trt_config.global_decoder_params = std::monostate{};
 
   auto params = config.decoder_custom_args_to_heterogeneous_map();
-  EXPECT_FALSE(params.contains("global_decoder_params"));
+  EXPECT_TRUE(params.contains("global_decoder_params"));
+  EXPECT_TRUE(
+      params.get<cudaqx::heterogeneous_map>("global_decoder_params").empty());
 
   cudaq::qec::decoding::config::multi_decoder_config multi_config;
   multi_config.decoders.push_back(config);
-  test_decoder_yaml_roundtrip(multi_config);
+  const auto yaml = multi_config.to_yaml_str(200);
+  EXPECT_NE(yaml.find("global_decoder_params"), std::string::npos);
+  auto round_tripped =
+      cudaq::qec::decoding::config::multi_decoder_config::from_yaml_str(yaml);
+  EXPECT_EQ(round_tripped.to_yaml_str(200), yaml);
+  const auto &round_tripped_trt_config =
+      std::get<cudaq::qec::decoding::config::trt_decoder_config>(
+          round_tripped.decoders[0].decoder_custom_args);
+  EXPECT_TRUE(
+      std::holds_alternative<cudaq::qec::decoding::config::pymatching_config>(
+          round_tripped_trt_config.global_decoder_params));
 
   params = cudaq::qec::decoding::host::prepare_decoder_params(config);
   EXPECT_TRUE(params.contains("global_decoder_params"));
@@ -327,6 +339,105 @@ TEST(DecoderYAMLTest, TrtDecoderMonostateGlobalDecoderParams) {
   params = cudaq::qec::decoding::host::prepare_decoder_params(config);
   EXPECT_TRUE(params.contains("global_decoder_params"));
   EXPECT_FALSE(params.contains("O"));
+}
+
+TEST(DecoderYAMLTest, TrtDecoderDefaultGlobalDecoderParams) {
+  cudaqx::heterogeneous_map map;
+  map.insert("global_decoder", std::string("chromobius"));
+
+  auto trt_config =
+      cudaq::qec::decoding::config::trt_decoder_config::from_heterogeneous_map(
+          map);
+  EXPECT_TRUE(
+      std::holds_alternative<cudaq::qec::decoding::config::chromobius_config>(
+          trt_config.global_decoder_params));
+  auto params = trt_config.to_heterogeneous_map();
+  EXPECT_TRUE(params.contains("global_decoder_params"));
+  EXPECT_TRUE(
+      params.get<cudaqx::heterogeneous_map>("global_decoder_params").empty());
+
+  const std::string yaml_without_params = R"(
+decoders:
+  - id: 0
+    type: trt_decoder
+    block_size: 1
+    syndrome_size: 1
+    H_sparse: [0, -1]
+    O_sparse: []
+    D_sparse: [0, -1]
+    decoder_custom_args:
+      global_decoder: chromobius
+)";
+  auto parsed_without_params =
+      cudaq::qec::decoding::config::multi_decoder_config::from_yaml_str(
+          yaml_without_params);
+  const auto &parsed_trt_config =
+      std::get<cudaq::qec::decoding::config::trt_decoder_config>(
+          parsed_without_params.decoders[0].decoder_custom_args);
+  EXPECT_TRUE(
+      std::holds_alternative<cudaq::qec::decoding::config::chromobius_config>(
+          parsed_trt_config.global_decoder_params));
+
+  auto config = create_test_decoder_config_trt(0);
+  auto &yaml_trt_config =
+      std::get<cudaq::qec::decoding::config::trt_decoder_config>(
+          config.decoder_custom_args);
+  yaml_trt_config.global_decoder = "chromobius";
+  yaml_trt_config.global_decoder_params = std::monostate{};
+  cudaq::qec::decoding::config::multi_decoder_config multi_config;
+  multi_config.decoders.push_back(config);
+  const auto yaml = multi_config.to_yaml_str(200);
+  EXPECT_NE(yaml.find("global_decoder_params"), std::string::npos);
+  auto round_tripped =
+      cudaq::qec::decoding::config::multi_decoder_config::from_yaml_str(yaml);
+  const auto &round_tripped_trt_config =
+      std::get<cudaq::qec::decoding::config::trt_decoder_config>(
+          round_tripped.decoders[0].decoder_custom_args);
+  EXPECT_TRUE(
+      std::holds_alternative<cudaq::qec::decoding::config::chromobius_config>(
+          round_tripped_trt_config.global_decoder_params));
+}
+
+TEST(DecoderYAMLTest, UnknownTrtGlobalDecoderParamsThrow) {
+  cudaqx::heterogeneous_map map;
+  map.insert("global_decoder", std::string("my_plugin"));
+  map.insert("global_decoder_params", cudaqx::heterogeneous_map{});
+  EXPECT_THROW(
+      cudaq::qec::decoding::config::trt_decoder_config::from_heterogeneous_map(
+          map),
+      std::runtime_error);
+
+  cudaq::qec::decoding::config::trt_decoder_config trt_config;
+  trt_config.global_decoder = "my_plugin";
+  auto params = trt_config.to_heterogeneous_map();
+  EXPECT_EQ(params.get<std::string>("global_decoder"), "my_plugin");
+  EXPECT_FALSE(params.contains("global_decoder_params"));
+
+  map = cudaqx::heterogeneous_map();
+  map.insert("global_decoder", std::string("my_plugin"));
+  trt_config =
+      cudaq::qec::decoding::config::trt_decoder_config::from_heterogeneous_map(
+          map);
+  EXPECT_TRUE(
+      std::holds_alternative<std::monostate>(trt_config.global_decoder_params));
+
+  const std::string yaml_with_unknown_params = R"(
+decoders:
+  - id: 0
+    type: trt_decoder
+    block_size: 1
+    syndrome_size: 1
+    H_sparse: [0, -1]
+    O_sparse: []
+    D_sparse: [0, -1]
+    decoder_custom_args:
+      global_decoder: my_plugin
+      global_decoder_params: {}
+)";
+  EXPECT_THROW(
+      cudaq::qec::decoding::config::multi_decoder_config::from_yaml_str(
+          yaml_with_unknown_params),
+      std::runtime_error);
 }
 
 TEST(DecoderYAMLTest, TrtDecoderParamsWithoutDecoderThrows) {


### PR DESCRIPTION
## Summary

Adds `chromobius_config` support for TRT global decoder configuration across C++ config maps, YAML serialization/deserialization, realtime parameter preparation, and Python bindings.

## Changes

- Adds `chromobius_config` with Chromobius boolean options.
- Extends `global_decoder_config` to support both `pymatching_config` and `chromobius_config`.
- Dispatches TRT `global_decoder_params` by `global_decoder` name for map and YAML paths.
- Defaults missing params for known TRT global decoders while preserving unknown decoder names as extension points when params are omitted.
- Ensures realtime TRT configs attach named global decoders even when `global_decoder_params` is omitted.
- Adds Python binding/export support for `chromobius_config`.
- Keeps Chromobius config scoped to TRT global decoder params rather than top-level decoder YAML custom args.
- Adds C++ and Python coverage for Chromobius params, defaults, unknown decoder behavior, and TRT YAML round trips.