### PR TITLE
qec: add surface code orientation support (XV/XH/ZV/ZH)

### DIFF
--- a/libs/qec/include/cudaq/qec/codes/surface_code.h
+++ b/libs/qec/include/cudaq/qec/codes/surface_code.h
@@ -36,8 +36,10 @@ enum surface_role { amx, amz, empty };
 /// row). See get_spin_op_observables() for details.
 enum class sc_orientation { XV, XH, ZV, ZH };
 
-/// @brief Parse a surface-code orientation string (XV, XH, ZV, or ZH).
-sc_orientation parse_orientation(const std::string &s);
+/// @brief Convert a surface-code orientation string to a sc_orientation enum
+/// (XV, XH, ZV, ZH, or Ising's O1-O4 aliases, where O1/O2/O3/O4 map to
+/// XV/XH/ZV/ZH).
+sc_orientation sc_orientation_from_str(const std::string &s);
 
 /// @brief describes the 2d coordinate on the stabilizer grid
 struct vec2d {
@@ -69,9 +71,8 @@ bool operator<(const vec2d &lhs, const vec2d &rhs);
 ///
 /// Each entry on the grid can be an X stabilizer, Z stabilizer,
 /// or empty, as is needed on the edges.
-/// The diagrams below show the default ZH orientation, which preserves the
-/// original fixed surface-code layout. Other orientations assign X/Z roles
-/// according to sc_orientation.
+/// The diagrams below show the default ZH orientation. Other orientations
+/// assign X/Z roles according to sc_orientation.
 /// The grid length of 4 corresponds to a distance 3 surface code, which results
 /// in:
 /// ```
@@ -122,15 +123,15 @@ public:
   /// determines the number of data qubits per dimension
   uint32_t distance = 0;
 
-  /// @brief Orientation used to assign stabilizer roles. The default ZH is the
-  /// legacy fixed surface-code layout, named per Ising's code_rotation.
-  sc_orientation orientation = sc_orientation::ZH;
-
   /// @brief length of the stabilizer grid
   /// for distance = d data qubits,
   /// the stabilizer grid has length d+1
   uint32_t grid_length = 0;
 
+private:
+  sc_orientation orientation_ = sc_orientation::ZH;
+
+public:
   /// @brief flattened vector of the stabilizer grid sites roles'
   /// grid idx -> role
   /// stored in row major order
@@ -170,6 +171,9 @@ public:
                   sc_orientation orientation = sc_orientation::ZH);
   /// @brief Empty constructor
   stabilizer_grid();
+
+  /// @brief Get the orientation used to construct this stabilizer grid.
+  sc_orientation get_orientation() const;
 
   /// @brief Print a 2d grid of stabilizer roles
   void print_stabilizer_grid() const;

--- a/libs/qec/include/cudaq/qec/codes/surface_code.h
+++ b/libs/qec/include/cudaq/qec/codes/surface_code.h
@@ -22,13 +22,11 @@ enum surface_role { amx, amz, empty };
 /// @brief Surface-code orientation: controls which Pauli type (X or Z) occupies
 /// the bulk interior and which boundaries are X-type vs Z-type.
 ///
-/// Names follow Ising's `code_rotation` convention (first character = bulk
-/// syndrome type, second character = rotated_type), so a given name denotes the
-/// SAME physical stabilizer layout in cudaqx and Ising — an Ising-trained model
-/// can be matched by name. By geometry: XV and ZH place X-type stabilizers on
-/// the left/right boundaries (Z on top/bottom); XH and ZV place X-type on
-/// top/bottom (Z on left/right). XV vs ZH (and XH vs ZV) differ in the bulk X/Z
-/// checkerboard.
+/// Geometry names follow Ising's `code_rotation` convention (first character =
+/// bulk syndrome type, second character = rotated_type). By geometry: XV and ZH
+/// place X-type stabilizers on the left/right boundaries (Z on top/bottom); XH
+/// and ZV place X-type on top/bottom (Z on left/right). XV vs ZH (and XH vs ZV)
+/// differ in the bulk X/Z checkerboard.
 ///
 /// Observable convention: get_spin_op_observables() returns the valid logical
 /// pair for the orientation. XV/ZH use X obs along the top row and Z obs along

--- a/libs/qec/include/cudaq/qec/codes/surface_code.h
+++ b/libs/qec/include/cudaq/qec/codes/surface_code.h
@@ -67,6 +67,9 @@ bool operator<(const vec2d &lhs, const vec2d &rhs);
 ///
 /// Each entry on the grid can be an X stabilizer, Z stabilizer,
 /// or empty, as is needed on the edges.
+/// The diagrams below show the default ZH orientation, which preserves the
+/// original fixed surface-code layout. Other orientations assign X/Z roles
+/// according to sc_orientation.
 /// The grid length of 4 corresponds to a distance 3 surface code, which results
 /// in:
 /// ```
@@ -188,6 +191,9 @@ public:
   std::vector<cudaq::spin_op_term> get_spin_op_stabilizers() const;
 
   /// @brief Get the observables as a vector of cudaq::spin_op_terms
+  ///
+  /// @return The X logical observable first, followed by the Z logical
+  /// observable.
   ///
   /// @note Returns the correct logical pair for the grid's orientation. For XV
   /// and ZH the X observable runs along the top row of data qubits and the Z

--- a/libs/qec/include/cudaq/qec/codes/surface_code.h
+++ b/libs/qec/include/cudaq/qec/codes/surface_code.h
@@ -9,6 +9,7 @@
 
 #include "cudaq/qec/code.h"
 #include "cudaq/qec/patch.h"
+#include <string>
 
 using namespace cudaqx;
 
@@ -17,6 +18,33 @@ namespace cudaq::qec::surface_code {
 /// @brief enumerates the role of a grid site in the surface codes stabilizer
 /// grid
 enum surface_role { amx, amz, empty };
+
+/// @brief Surface-code orientation: controls which Pauli type (X or Z) occupies
+/// the bulk interior and which boundaries are X-type vs Z-type.
+///
+/// Within cudaqx: XV and ZH put X-type stabilizers on left/right boundaries;
+/// XH and ZV put them on top/bottom.
+///
+/// WARNING — do NOT map these to Ising by name string. Ising has two naming
+/// layers: a `code_rotation` parameter (aliases O1=XV, O2=XH, O3=ZV, O4=ZH) and
+/// a derived `logical_direction` whose second character is the inverse of
+/// rotated_type. These cudaqx enum names coincide with Ising's
+/// logical_direction STRING but NOT with its physical geometry. To match an
+/// Ising-trained model, map by stabilizer geometry, never by name: Ising's
+/// pretrained d13 model uses code_rotation O1 (=XV), which corresponds to
+/// cudaqx sc_orientation::ZH — not
+/// ::XV and not ::XH. Confirm via stabilizer supports + logical-operator
+/// commutation.
+///
+/// Observable convention: get_spin_op_observables() always returns X obs along
+/// the top row and Z obs along the left column, regardless of orientation (the
+/// valid logical pair for XV/ZH). It is intentionally NOT updated to track
+/// per-orientation logical operators. See get_spin_op_observables() for
+/// details.
+enum class sc_orientation { XV, XH, ZV, ZH };
+
+/// @brief Parse a surface-code orientation string (XV, XH, ZV, or ZH).
+sc_orientation parse_orientation(const std::string &s);
 
 /// @brief describes the 2d coordinate on the stabilizer grid
 struct vec2d {
@@ -98,6 +126,9 @@ public:
   /// determines the number of data qubits per dimension
   uint32_t distance = 0;
 
+  /// @brief Orientation used to assign stabilizer roles.
+  sc_orientation orientation = sc_orientation::XV;
+
   /// @brief length of the stabilizer grid
   /// for distance = d data qubits,
   /// the stabilizer grid has length d+1
@@ -138,7 +169,8 @@ public:
   std::vector<std::vector<size_t>> z_stabilizers;
 
   /// @brief Construct the grid from the code's distance
-  stabilizer_grid(uint32_t distance);
+  stabilizer_grid(uint32_t distance,
+                  sc_orientation orientation = sc_orientation::XV);
   /// @brief Empty constructor
   stabilizer_grid();
 
@@ -164,6 +196,11 @@ public:
   std::vector<cudaq::spin_op_term> get_spin_op_stabilizers() const;
 
   /// @brief Get the observables as a vector of cudaq::spin_op_terms
+  ///
+  /// @note This is intentionally NOT updated to match Ising's per-orientation
+  /// logical operator convention. The existing X=top-row / Z=left-column
+  /// behavior is preserved as-is across all orientations. Reconciliation with
+  /// Ising's convention is deferred.
   std::vector<cudaq::spin_op_term> get_spin_op_observables() const;
 };
 

--- a/libs/qec/include/cudaq/qec/codes/surface_code.h
+++ b/libs/qec/include/cudaq/qec/codes/surface_code.h
@@ -36,11 +36,10 @@ enum surface_role { amx, amz, empty };
 /// ::XV and not ::XH. Confirm via stabilizer supports + logical-operator
 /// commutation.
 ///
-/// Observable convention: get_spin_op_observables() always returns X obs along
-/// the top row and Z obs along the left column, regardless of orientation (the
-/// valid logical pair for XV/ZH). It is intentionally NOT updated to track
-/// per-orientation logical operators. See get_spin_op_observables() for
-/// details.
+/// Observable convention: get_spin_op_observables() returns the valid logical
+/// pair for the grid's orientation. XV/ZH use X obs along the top row and Z obs
+/// along the left column; XH/ZV swap them (X along the left column, Z along the
+/// top row). See get_spin_op_observables() for details.
 enum class sc_orientation { XV, XH, ZV, ZH };
 
 /// @brief Parse a surface-code orientation string (XV, XH, ZV, or ZH).
@@ -197,10 +196,12 @@ public:
 
   /// @brief Get the observables as a vector of cudaq::spin_op_terms
   ///
-  /// @note This is intentionally NOT updated to match Ising's per-orientation
-  /// logical operator convention. The existing X=top-row / Z=left-column
-  /// behavior is preserved as-is across all orientations. Reconciliation with
-  /// Ising's convention is deferred.
+  /// @note Returns the correct logical pair for the grid's orientation. For XV
+  /// and ZH the X observable runs along the top row of data qubits and the Z
+  /// observable along the left column; for XH and ZV the assignment is swapped
+  /// (X along the left column, Z along the top row) to match their boundary
+  /// types. The returned X/Z observables commute with the stabilizers and
+  /// anticommute with each other for every orientation.
   std::vector<cudaq::spin_op_term> get_spin_op_observables() const;
 };
 

--- a/libs/qec/include/cudaq/qec/codes/surface_code.h
+++ b/libs/qec/include/cudaq/qec/codes/surface_code.h
@@ -22,24 +22,18 @@ enum surface_role { amx, amz, empty };
 /// @brief Surface-code orientation: controls which Pauli type (X or Z) occupies
 /// the bulk interior and which boundaries are X-type vs Z-type.
 ///
-/// Within cudaqx: XV and ZH put X-type stabilizers on left/right boundaries;
-/// XH and ZV put them on top/bottom.
-///
-/// WARNING — do NOT map these to Ising by name string. Ising has two naming
-/// layers: a `code_rotation` parameter (aliases O1=XV, O2=XH, O3=ZV, O4=ZH) and
-/// a derived `logical_direction` whose second character is the inverse of
-/// rotated_type. These cudaqx enum names coincide with Ising's
-/// logical_direction STRING but NOT with its physical geometry. To match an
-/// Ising-trained model, map by stabilizer geometry, never by name: Ising's
-/// pretrained d13 model uses code_rotation O1 (=XV), which corresponds to
-/// cudaqx sc_orientation::ZH — not
-/// ::XV and not ::XH. Confirm via stabilizer supports + logical-operator
-/// commutation.
+/// Names follow Ising's `code_rotation` convention (first character = bulk
+/// syndrome type, second character = rotated_type), so a given name denotes the
+/// SAME physical stabilizer layout in cudaqx and Ising — an Ising-trained model
+/// can be matched by name. By geometry: XV and ZH place X-type stabilizers on
+/// the left/right boundaries (Z on top/bottom); XH and ZV place X-type on
+/// top/bottom (Z on left/right). XV vs ZH (and XH vs ZV) differ in the bulk X/Z
+/// checkerboard.
 ///
 /// Observable convention: get_spin_op_observables() returns the valid logical
-/// pair for the grid's orientation. XV/ZH use X obs along the top row and Z obs
-/// along the left column; XH/ZV swap them (X along the left column, Z along the
-/// top row). See get_spin_op_observables() for details.
+/// pair for the orientation. XV/ZH use X obs along the top row and Z obs along
+/// the left column; XH/ZV swap them (X along the left column, Z along the top
+/// row). See get_spin_op_observables() for details.
 enum class sc_orientation { XV, XH, ZV, ZH };
 
 /// @brief Parse a surface-code orientation string (XV, XH, ZV, or ZH).
@@ -125,8 +119,9 @@ public:
   /// determines the number of data qubits per dimension
   uint32_t distance = 0;
 
-  /// @brief Orientation used to assign stabilizer roles.
-  sc_orientation orientation = sc_orientation::XV;
+  /// @brief Orientation used to assign stabilizer roles. The default ZH is the
+  /// legacy fixed surface-code layout, named per Ising's code_rotation.
+  sc_orientation orientation = sc_orientation::ZH;
 
   /// @brief length of the stabilizer grid
   /// for distance = d data qubits,
@@ -169,7 +164,7 @@ public:
 
   /// @brief Construct the grid from the code's distance
   stabilizer_grid(uint32_t distance,
-                  sc_orientation orientation = sc_orientation::XV);
+                  sc_orientation orientation = sc_orientation::ZH);
   /// @brief Empty constructor
   stabilizer_grid();
 

--- a/libs/qec/include/cudaq/qec/codes/surface_code.h
+++ b/libs/qec/include/cudaq/qec/codes/surface_code.h
@@ -22,11 +22,13 @@ enum surface_role { amx, amz, empty };
 /// @brief Surface-code orientation: controls which Pauli type (X or Z) occupies
 /// the bulk interior and which boundaries are X-type vs Z-type.
 ///
-/// Geometry names follow Ising's `code_rotation` convention (first character =
-/// bulk syndrome type, second character = rotated_type). By geometry: XV and ZH
-/// place X-type stabilizers on the left/right boundaries (Z on top/bottom); XH
-/// and ZV place X-type on top/bottom (Z on left/right). XV vs ZH (and XH vs ZV)
-/// differ in the bulk X/Z checkerboard.
+/// Geometry names follow the NVIDIA/Ising-Decoding naming convention
+/// (https://github.com/NVIDIA/Ising-Decoding): Ising's `code_rotation`
+/// convention uses first character = bulk syndrome type, second character =
+/// rotated_type. By geometry: XV and ZH place X-type stabilizers on the
+/// left/right boundaries (Z on top/bottom); XH and ZV place X-type on
+/// top/bottom (Z on left/right). XV vs ZH (and XH vs ZV) differ in the bulk
+/// X/Z checkerboard.
 ///
 /// Observable convention: get_spin_op_observables() returns the valid logical
 /// pair for the orientation. XV/ZH use X obs along the top row and Z obs along

--- a/libs/qec/lib/codes/surface_code.cpp
+++ b/libs/qec/lib/codes/surface_code.cpp
@@ -31,12 +31,14 @@ surface_role role_for_parity(sc_orientation orientation, bool odd_parity) {
   switch (orientation) {
   case sc_orientation::XV:
   case sc_orientation::XH:
-    // First bulk syndrome type X (Ising code_rotation X*): X on even
-    // stabilizer-grid parity, Z on odd.
+    // The first orientation character controls the bulk checkerboard. The H/V
+    // character controls boundary placement only, so XV and XH share this bulk
+    // assignment.
     return odd_parity ? surface_role::amz : surface_role::amx;
   case sc_orientation::ZV:
   case sc_orientation::ZH:
-    // First bulk syndrome type Z: Z on even parity, X on odd.
+    // Likewise, ZV and ZH share a bulk assignment with Z on even parity and X
+    // on odd parity.
     return odd_parity ? surface_role::amx : surface_role::amz;
   }
   throw std::runtime_error("Unhandled surface-code orientation.");
@@ -96,21 +98,28 @@ void stabilizer_grid::generate_grid_roles() {
   for (size_t row = 1; row < grid_length - 1; ++row) {
     for (size_t col = 1; col < grid_length - 1; ++col) {
       size_t idx = row * grid_length + col;
-      bool parity = (row + col) % 2;
-      roles[idx] = role_for_parity(orientation, parity);
+      const bool is_odd_parity = (row + col) % 2;
+      roles[idx] = role_for_parity(orientation, is_odd_parity);
     }
   }
 
   const bool horizontal_boundaries_use_even_parity =
       orientation == sc_orientation::XH || orientation == sc_orientation::ZH;
 
+  // Boundary sites alternate around the perimeter. The top/bottom and
+  // left/right edges therefore occupy complementary parities. Since
+  // is_odd_parity is false for even parity, the top/bottom predicate is
+  // intentionally the inverse of horizontal_boundaries_use_even_parity.
+  // The left/right predicate selects the opposite edge parity class: when
+  // top/bottom uses even parity, == selects odd sites, and vice versa.
+
   // set top/bottom boundaries for weight 2 stabs
   for (size_t row = 0; row < grid_length; row += grid_length - 1) {
     for (size_t col = 1; col < grid_length - 1; ++col) {
       size_t idx = row * grid_length + col;
-      bool parity = (row + col) % 2;
-      if (parity != horizontal_boundaries_use_even_parity)
-        roles[idx] = role_for_parity(orientation, parity);
+      const bool is_odd_parity = (row + col) % 2;
+      if (is_odd_parity != horizontal_boundaries_use_even_parity)
+        roles[idx] = role_for_parity(orientation, is_odd_parity);
     }
   }
 
@@ -118,9 +127,9 @@ void stabilizer_grid::generate_grid_roles() {
   for (size_t row = 1; row < grid_length - 1; ++row) {
     for (size_t col = 0; col < grid_length; col += grid_length - 1) {
       size_t idx = row * grid_length + col;
-      bool parity = (row + col) % 2;
-      if (parity == horizontal_boundaries_use_even_parity)
-        roles[idx] = role_for_parity(orientation, parity);
+      const bool is_odd_parity = (row + col) % 2;
+      if (is_odd_parity == horizontal_boundaries_use_even_parity)
+        roles[idx] = role_for_parity(orientation, is_odd_parity);
     }
   }
 }

--- a/libs/qec/lib/codes/surface_code.cpp
+++ b/libs/qec/lib/codes/surface_code.cpp
@@ -6,11 +6,55 @@
  * the terms of the Apache License 2.0 which accompanies this distribution.    *
  ******************************************************************************/
 #include "cudaq/qec/codes/surface_code.h"
+#include <algorithm>
+#include <cctype>
 #include <iomanip>
 
 using cudaq::qec::operation;
 
 namespace cudaq::qec::surface_code {
+namespace {
+
+std::string normalize_orientation(std::string value) {
+  auto is_not_space = [](unsigned char ch) { return !std::isspace(ch); };
+  value.erase(value.begin(),
+              std::find_if(value.begin(), value.end(), is_not_space));
+  value.erase(std::find_if(value.rbegin(), value.rend(), is_not_space).base(),
+              value.end());
+  std::transform(
+      value.begin(), value.end(), value.begin(),
+      [](unsigned char ch) { return static_cast<char>(std::toupper(ch)); });
+  return value;
+}
+
+surface_role role_for_parity(sc_orientation orientation, bool odd_parity) {
+  switch (orientation) {
+  case sc_orientation::XV:
+  case sc_orientation::XH:
+    // Legacy XV has Z on even stabilizer-grid parity and X on odd parity.
+    return odd_parity ? surface_role::amx : surface_role::amz;
+  case sc_orientation::ZV:
+  case sc_orientation::ZH:
+    return odd_parity ? surface_role::amz : surface_role::amx;
+  }
+  throw std::runtime_error("Unhandled surface-code orientation.");
+}
+
+} // namespace
+
+sc_orientation parse_orientation(const std::string &s) {
+  const auto orientation = normalize_orientation(s);
+  if (orientation == "XV")
+    return sc_orientation::XV;
+  if (orientation == "XH")
+    return sc_orientation::XH;
+  if (orientation == "ZV")
+    return sc_orientation::ZV;
+  if (orientation == "ZH")
+    return sc_orientation::ZH;
+  throw std::runtime_error("Invalid surface-code orientation '" + s +
+                           "'. Expected XV, XH, ZV, or ZH.");
+}
 
 vec2d::vec2d(int row_in, int col_in) : row(row_in), col(col_in) {}
 
@@ -51,31 +95,30 @@ void stabilizer_grid::generate_grid_roles() {
     for (size_t col = 1; col < grid_length - 1; ++col) {
       size_t idx = row * grid_length + col;
       bool parity = (row + col) % 2;
-      if (!parity) {
-        roles[idx] = surface_role::amz;
-      } else {
-        roles[idx] = surface_role::amx;
-      }
+      roles[idx] = role_for_parity(orientation, parity);
     }
   }
 
-  // set top/bottom boundaries for weight 2 z-stabs
+  const bool horizontal_boundaries_use_even_parity =
+      orientation == sc_orientation::XV || orientation == sc_orientation::ZV;
+
+  // set top/bottom boundaries for weight 2 stabs
   for (size_t row = 0; row < grid_length; row += grid_length - 1) {
     for (size_t col = 1; col < grid_length - 1; ++col) {
       size_t idx = row * grid_length + col;
       bool parity = (row + col) % 2;
-      if (!parity)
-        roles[idx] = surface_role::amz;
+      if (parity != horizontal_boundaries_use_even_parity)
+        roles[idx] = role_for_parity(orientation, parity);
     }
   }
 
-  // set left/right boundaries for weight 2 x-stabs
+  // set left/right boundaries for weight 2 stabs
   for (size_t row = 1; row < grid_length - 1; ++row) {
     for (size_t col = 0; col < grid_length; col += grid_length - 1) {
       size_t idx = row * grid_length + col;
       bool parity = (row + col) % 2;
-      if (parity)
-        roles[idx] = surface_role::amx;
+      if (parity == horizontal_boundaries_use_even_parity)
+        roles[idx] = role_for_parity(orientation, parity);
     }
   }
 }
@@ -157,8 +200,8 @@ void stabilizer_grid::generate_stabilizers() {
 
 stabilizer_grid::stabilizer_grid() {}
 
-stabilizer_grid::stabilizer_grid(uint32_t distance)
-    : distance(distance), grid_length(distance + 1),
+stabilizer_grid::stabilizer_grid(uint32_t distance, sc_orientation orientation)
+    : distance(distance), orientation(orientation), grid_length(distance + 1),
       roles(grid_length * grid_length) {
   // generate a 2d grid of roles
   generate_grid_roles();
@@ -336,14 +379,15 @@ stabilizer_grid::get_spin_op_stabilizers() const {
 std::vector<cudaq::spin_op_term>
 stabilizer_grid::get_spin_op_observables() const {
   std::vector<cudaq::spin_op_term> spin_op_obs;
-  // X obs runs along top row of data qubits
+  // Intentionally preserve the historical convention for every orientation:
+  // X obs runs along top row of data qubits.
   std::string xobs(data_coords.size(), 'I');
   for (size_t i = 0; i < distance; ++i) {
     xobs[i] = 'X';
   }
   spin_op_obs.emplace_back(cudaq::spin_op::from_word(xobs));
 
-  // Z ob runs along left col of data qubits
+  // Z obs runs along left col of data qubits.
   std::string zobs(data_coords.size(), 'I');
   for (size_t i = 0; i < data_coords.size(); i += distance) {
     zobs[i] = 'Z';
@@ -359,7 +403,8 @@ surface_code::surface_code(const heterogeneous_map &options) : code() {
         "[surface_code] distance not provided. distance must be provided via "
         "qec::get_code(..., options) options map.");
   distance = options.get<std::size_t>("distance");
-  grid = stabilizer_grid(distance);
+  grid = stabilizer_grid(distance, parse_orientation(options.get<std::string>(
+                                       "orientation", "XV")));
 
   m_stabilizers = grid.get_spin_op_stabilizers();
   m_pauli_observables = grid.get_spin_op_observables();

--- a/libs/qec/lib/codes/surface_code.cpp
+++ b/libs/qec/lib/codes/surface_code.cpp
@@ -379,20 +379,40 @@ stabilizer_grid::get_spin_op_stabilizers() const {
 std::vector<cudaq::spin_op_term>
 stabilizer_grid::get_spin_op_observables() const {
   std::vector<cudaq::spin_op_term> spin_op_obs;
-  // Intentionally preserve the historical convention for every orientation:
-  // X obs runs along top row of data qubits.
-  std::string xobs(data_coords.size(), 'I');
-  for (size_t i = 0; i < distance; ++i) {
-    xobs[i] = 'X';
-  }
-  spin_op_obs.emplace_back(cudaq::spin_op::from_word(xobs));
 
-  // Z obs runs along left col of data qubits.
-  std::string zobs(data_coords.size(), 'I');
-  for (size_t i = 0; i < data_coords.size(); i += distance) {
-    zobs[i] = 'Z';
+  // The valid logical pair depends on orientation. For XV and ZH, the X logical
+  // runs along the top row of data qubits and the Z logical along the left
+  // column. For XH and ZV the boundary types are swapped, so the assignment is
+  // exchanged: X logical along the left column, Z logical along the top row.
+  // Picking the wrong pair yields operators that do not commute with the
+  // stabilizers.
+  const bool x_logical_on_top_row =
+      orientation == sc_orientation::XV || orientation == sc_orientation::ZH;
+
+  // Support that runs along the top row of data qubits.
+  std::string top_row_obs(data_coords.size(), 'I');
+  // Support that runs along the left column of data qubits.
+  std::string left_col_obs(data_coords.size(), 'I');
+
+  if (x_logical_on_top_row) {
+    // X obs runs along top row of data qubits.
+    for (size_t i = 0; i < distance; ++i)
+      top_row_obs[i] = 'X';
+    // Z obs runs along left col of data qubits.
+    for (size_t i = 0; i < data_coords.size(); i += distance)
+      left_col_obs[i] = 'Z';
+    spin_op_obs.emplace_back(cudaq::spin_op::from_word(top_row_obs));
+    spin_op_obs.emplace_back(cudaq::spin_op::from_word(left_col_obs));
+  } else {
+    // X obs runs along left col of data qubits.
+    for (size_t i = 0; i < data_coords.size(); i += distance)
+      left_col_obs[i] = 'X';
+    // Z obs runs along top row of data qubits.
+    for (size_t i = 0; i < distance; ++i)
+      top_row_obs[i] = 'Z';
+    spin_op_obs.emplace_back(cudaq::spin_op::from_word(left_col_obs));
+    spin_op_obs.emplace_back(cudaq::spin_op::from_word(top_row_obs));
   }
-  spin_op_obs.emplace_back(cudaq::spin_op::from_word(zobs));
 
   return spin_op_obs;
 }

--- a/libs/qec/lib/codes/surface_code.cpp
+++ b/libs/qec/lib/codes/surface_code.cpp
@@ -31,11 +31,13 @@ surface_role role_for_parity(sc_orientation orientation, bool odd_parity) {
   switch (orientation) {
   case sc_orientation::XV:
   case sc_orientation::XH:
-    // Legacy XV has Z on even stabilizer-grid parity and X on odd parity.
-    return odd_parity ? surface_role::amx : surface_role::amz;
+    // First bulk syndrome type X (Ising code_rotation X*): X on even
+    // stabilizer-grid parity, Z on odd.
+    return odd_parity ? surface_role::amz : surface_role::amx;
   case sc_orientation::ZV:
   case sc_orientation::ZH:
-    return odd_parity ? surface_role::amz : surface_role::amx;
+    // First bulk syndrome type Z: Z on even parity, X on odd.
+    return odd_parity ? surface_role::amx : surface_role::amz;
   }
   throw std::runtime_error("Unhandled surface-code orientation.");
 }
@@ -100,7 +102,7 @@ void stabilizer_grid::generate_grid_roles() {
   }
 
   const bool horizontal_boundaries_use_even_parity =
-      orientation == sc_orientation::XV || orientation == sc_orientation::ZV;
+      orientation == sc_orientation::XH || orientation == sc_orientation::ZH;
 
   // set top/bottom boundaries for weight 2 stabs
   for (size_t row = 0; row < grid_length; row += grid_length - 1) {
@@ -424,7 +426,7 @@ surface_code::surface_code(const heterogeneous_map &options) : code() {
         "qec::get_code(..., options) options map.");
   distance = options.get<std::size_t>("distance");
   grid = stabilizer_grid(distance, parse_orientation(options.get<std::string>(
-                                       "orientation", "XV")));
+                                       "orientation", "ZH")));
 
   m_stabilizers = grid.get_spin_op_stabilizers();
   m_pauli_observables = grid.get_spin_op_observables();

--- a/libs/qec/lib/codes/surface_code.cpp
+++ b/libs/qec/lib/codes/surface_code.cpp
@@ -28,36 +28,33 @@ std::string normalize_orientation(std::string value) {
 }
 
 surface_role role_for_parity(sc_orientation orientation, bool odd_parity) {
-  switch (orientation) {
-  case sc_orientation::XV:
-  case sc_orientation::XH:
-    // The first orientation character controls the bulk checkerboard. The H/V
-    // character controls boundary placement only, so XV and XH share this bulk
-    // assignment.
-    return odd_parity ? surface_role::amz : surface_role::amx;
-  case sc_orientation::ZV:
-  case sc_orientation::ZH:
-    // Likewise, ZV and ZH share a bulk assignment with Z on even parity and X
-    // on odd parity.
-    return odd_parity ? surface_role::amx : surface_role::amz;
-  }
-  throw std::runtime_error("Unhandled surface-code orientation.");
+  // The first orientation character controls the bulk checkerboard. The H/V
+  // character controls boundary placement only, so XV/XH share one bulk
+  // assignment and ZV/ZH share the other.
+  const bool x_on_even_parity =
+      orientation == sc_orientation::XV || orientation == sc_orientation::XH;
+  const bool z_on_even_parity =
+      orientation == sc_orientation::ZV || orientation == sc_orientation::ZH;
+  if (!x_on_even_parity && !z_on_even_parity)
+    throw std::runtime_error("Unhandled surface-code orientation.");
+  return (x_on_even_parity != odd_parity) ? surface_role::amx
+                                          : surface_role::amz;
 }
 
 } // namespace
 
-sc_orientation parse_orientation(const std::string &s) {
+sc_orientation sc_orientation_from_str(const std::string &s) {
   const auto orientation = normalize_orientation(s);
-  if (orientation == "XV")
+  if (orientation == "XV" || orientation == "O1")
     return sc_orientation::XV;
-  if (orientation == "XH")
+  if (orientation == "XH" || orientation == "O2")
     return sc_orientation::XH;
-  if (orientation == "ZV")
+  if (orientation == "ZV" || orientation == "O3")
     return sc_orientation::ZV;
-  if (orientation == "ZH")
+  if (orientation == "ZH" || orientation == "O4")
     return sc_orientation::ZH;
   throw std::runtime_error("Invalid surface-code orientation '" + s +
-                           "'. Expected XV, XH, ZV, or ZH.");
+                           "'. Expected XV(O1), XH(O2), ZV(O3), or ZH(O4).");
 }
 
 vec2d::vec2d(int row_in, int col_in) : row(row_in), col(col_in) {}
@@ -99,12 +96,12 @@ void stabilizer_grid::generate_grid_roles() {
     for (size_t col = 1; col < grid_length - 1; ++col) {
       size_t idx = row * grid_length + col;
       const bool is_odd_parity = (row + col) % 2;
-      roles[idx] = role_for_parity(orientation, is_odd_parity);
+      roles[idx] = role_for_parity(orientation_, is_odd_parity);
     }
   }
 
   const bool horizontal_boundaries_use_even_parity =
-      orientation == sc_orientation::XH || orientation == sc_orientation::ZH;
+      orientation_ == sc_orientation::XH || orientation_ == sc_orientation::ZH;
 
   // Boundary sites alternate around the perimeter. The top/bottom and
   // left/right edges therefore occupy complementary parities. Since
@@ -119,7 +116,7 @@ void stabilizer_grid::generate_grid_roles() {
       size_t idx = row * grid_length + col;
       const bool is_odd_parity = (row + col) % 2;
       if (is_odd_parity != horizontal_boundaries_use_even_parity)
-        roles[idx] = role_for_parity(orientation, is_odd_parity);
+        roles[idx] = role_for_parity(orientation_, is_odd_parity);
     }
   }
 
@@ -129,7 +126,7 @@ void stabilizer_grid::generate_grid_roles() {
       size_t idx = row * grid_length + col;
       const bool is_odd_parity = (row + col) % 2;
       if (is_odd_parity == horizontal_boundaries_use_even_parity)
-        roles[idx] = role_for_parity(orientation, is_odd_parity);
+        roles[idx] = role_for_parity(orientation_, is_odd_parity);
     }
   }
 }
@@ -212,7 +209,7 @@ void stabilizer_grid::generate_stabilizers() {
 stabilizer_grid::stabilizer_grid() {}
 
 stabilizer_grid::stabilizer_grid(uint32_t distance, sc_orientation orientation)
-    : distance(distance), orientation(orientation), grid_length(distance + 1),
+    : distance(distance), grid_length(distance + 1), orientation_(orientation),
       roles(grid_length * grid_length) {
   // generate a 2d grid of roles
   generate_grid_roles();
@@ -221,6 +218,8 @@ stabilizer_grid::stabilizer_grid(uint32_t distance, sc_orientation orientation)
   // now use coords to set the stabilizers
   generate_stabilizers();
 }
+
+sc_orientation stabilizer_grid::get_orientation() const { return orientation_; }
 
 void stabilizer_grid::print_stabilizer_coords() const {
   int width = std::to_string(grid_length).length();
@@ -398,7 +397,7 @@ stabilizer_grid::get_spin_op_observables() const {
   // Picking the wrong pair yields operators that do not commute with the
   // stabilizers.
   const bool x_logical_on_top_row =
-      orientation == sc_orientation::XV || orientation == sc_orientation::ZH;
+      orientation_ == sc_orientation::XV || orientation_ == sc_orientation::ZH;
 
   // Support that runs along the top row of data qubits.
   std::string top_row_obs(data_coords.size(), 'I');
@@ -434,8 +433,9 @@ surface_code::surface_code(const heterogeneous_map &options) : code() {
         "[surface_code] distance not provided. distance must be provided via "
         "qec::get_code(..., options) options map.");
   distance = options.get<std::size_t>("distance");
-  grid = stabilizer_grid(distance, parse_orientation(options.get<std::string>(
-                                       "orientation", "ZH")));
+  grid = stabilizer_grid(
+      distance,
+      sc_orientation_from_str(options.get<std::string>("orientation", "ZH")));
 
   m_stabilizers = grid.get_spin_op_stabilizers();
   m_pauli_observables = grid.get_spin_op_observables();

--- a/libs/qec/python/bindings/py_surface_code.cpp
+++ b/libs/qec/python/bindings/py_surface_code.cpp
@@ -52,6 +52,15 @@ void bindSurfaceCode(nb::module_ &mod) {
       .value("empty", surface_role::empty)
       .export_values();
 
+  nb::enum_<sc_orientation>(qecmod, "sc_orientation")
+      .value("XV", sc_orientation::XV)
+      .value("XH", sc_orientation::XH)
+      .value("ZV", sc_orientation::ZV)
+      .value("ZH", sc_orientation::ZH)
+      .export_values();
+
+  qecmod.def("parse_orientation", &parse_orientation, nb::arg("orientation"));
+
   nb::class_<vec2d>(qecmod, "vec2d")
       .def(nb::init<int, int>(), nb::arg("row"), nb::arg("col"))
       .def_rw("row", &vec2d::row)
@@ -67,8 +76,18 @@ void bindSurfaceCode(nb::module_ &mod) {
 
   nb::class_<stabilizer_grid>(qecmod, "stabilizer_grid")
       .def(nb::init<>())
-      .def(nb::init<std::uint32_t>(), nb::arg("distance"))
+      .def(nb::init<std::uint32_t, sc_orientation>(), nb::arg("distance"),
+           nb::arg("orientation") = sc_orientation::XV)
+      .def(
+          "__init__",
+          [](stabilizer_grid &self, std::uint32_t distance,
+             const std::string &orientation) {
+            new (&self)
+                stabilizer_grid(distance, parse_orientation(orientation));
+          },
+          nb::arg("distance"), nb::arg("orientation"))
       .def_ro("distance", &stabilizer_grid::distance)
+      .def_ro("orientation", &stabilizer_grid::orientation)
       .def_ro("grid_length", &stabilizer_grid::grid_length)
       .def_ro("roles", &stabilizer_grid::roles)
       .def_ro("x_stab_coords", &stabilizer_grid::x_stab_coords)

--- a/libs/qec/python/bindings/py_surface_code.cpp
+++ b/libs/qec/python/bindings/py_surface_code.cpp
@@ -77,7 +77,7 @@ void bindSurfaceCode(nb::module_ &mod) {
   nb::class_<stabilizer_grid>(qecmod, "stabilizer_grid")
       .def(nb::init<>())
       .def(nb::init<std::uint32_t, sc_orientation>(), nb::arg("distance"),
-           nb::arg("orientation") = sc_orientation::XV)
+           nb::arg("orientation") = sc_orientation::ZH)
       .def(
           "__init__",
           [](stabilizer_grid &self, std::uint32_t distance,

--- a/libs/qec/python/bindings/py_surface_code.cpp
+++ b/libs/qec/python/bindings/py_surface_code.cpp
@@ -59,8 +59,6 @@ void bindSurfaceCode(nb::module_ &mod) {
       .value("ZH", sc_orientation::ZH)
       .export_values();
 
-  qecmod.def("parse_orientation", &parse_orientation, nb::arg("orientation"));
-
   nb::class_<vec2d>(qecmod, "vec2d")
       .def(nb::init<int, int>(), nb::arg("row"), nb::arg("col"))
       .def_rw("row", &vec2d::row)
@@ -83,11 +81,11 @@ void bindSurfaceCode(nb::module_ &mod) {
           [](stabilizer_grid &self, std::uint32_t distance,
              const std::string &orientation) {
             new (&self)
-                stabilizer_grid(distance, parse_orientation(orientation));
+                stabilizer_grid(distance, sc_orientation_from_str(orientation));
           },
           nb::arg("distance"), nb::arg("orientation"))
       .def_ro("distance", &stabilizer_grid::distance)
-      .def_ro("orientation", &stabilizer_grid::orientation)
+      .def_prop_ro("orientation", &stabilizer_grid::get_orientation)
       .def_ro("grid_length", &stabilizer_grid::grid_length)
       .def_ro("roles", &stabilizer_grid::roles)
       .def_ro("x_stab_coords", &stabilizer_grid::x_stab_coords)

--- a/libs/qec/python/bindings/py_surface_code.cpp
+++ b/libs/qec/python/bindings/py_surface_code.cpp
@@ -135,7 +135,8 @@ void bindSurfaceCode(nb::module_ &mod) {
       .def("get_spin_op_stabilizers", &stabilizer_grid::get_spin_op_stabilizers,
            "Return the stabilizers as a list of cudaq::spin_op_term")
       .def("get_spin_op_observables", &stabilizer_grid::get_spin_op_observables,
-           "Return the logical observables as a list of cudaq::spin_op_term");
+           "Return the logical observables as [X, Z] cudaq::spin_op_term "
+           "entries");
 
   qecmod.def("role_to_str", [](surface_role r) {
     switch (r) {

--- a/libs/qec/python/cudaq_qec/__init__.py
+++ b/libs/qec/python/cudaq_qec/__init__.py
@@ -123,6 +123,8 @@ configure_decoders = qecrt.config.configure_decoders
 
 stabilizer_grid = qecrt.stabilizer_grid
 role_to_str = qecrt.role_to_str
+sc_orientation = qecrt.sc_orientation
+parse_orientation = qecrt.parse_orientation
 
 from .dem_sampling import dem_sampling
 

--- a/libs/qec/python/cudaq_qec/__init__.py
+++ b/libs/qec/python/cudaq_qec/__init__.py
@@ -125,7 +125,6 @@ configure_decoders = qecrt.config.configure_decoders
 stabilizer_grid = qecrt.stabilizer_grid
 role_to_str = qecrt.role_to_str
 sc_orientation = qecrt.sc_orientation
-parse_orientation = qecrt.parse_orientation
 
 from .dem_sampling import dem_sampling
 

--- a/libs/qec/python/tests/test_surface_code.py
+++ b/libs/qec/python/tests/test_surface_code.py
@@ -25,6 +25,20 @@ def test_basic_construction_d3():
     assert len(g.data_coords) == 9
 
 
+def test_orientation_construction_d3():
+    assert qec.parse_orientation("XH") == qec.sc_orientation.XH
+
+    g = qec.stabilizer_grid(3, qec.sc_orientation.XH)
+    assert g.orientation == qec.sc_orientation.XH
+    assert len(g.x_stabilizers) == 4
+    assert len(g.z_stabilizers) == 4
+
+    canonical_grid = qec.stabilizer_grid(3, "ZV")
+    assert canonical_grid.orientation == qec.sc_orientation.ZV
+    assert len(canonical_grid.x_stabilizers) == 4
+    assert len(canonical_grid.z_stabilizers) == 4
+
+
 def test_roles_layout_d3():
     g = qec.stabilizer_grid(3)
     roles = g.roles

--- a/libs/qec/python/tests/test_surface_code.py
+++ b/libs/qec/python/tests/test_surface_code.py
@@ -26,17 +26,32 @@ def test_basic_construction_d3():
 
 
 def test_orientation_construction_d3():
-    assert qec.parse_orientation("XH") == qec.sc_orientation.XH
-
     g = qec.stabilizer_grid(3, qec.sc_orientation.XH)
     assert g.orientation == qec.sc_orientation.XH
     assert len(g.x_stabilizers) == 4
     assert len(g.z_stabilizers) == 4
 
-    canonical_grid = qec.stabilizer_grid(3, "ZV")
-    assert canonical_grid.orientation == qec.sc_orientation.ZV
+    alias_grid = qec.stabilizer_grid(3, "O3")
+    assert alias_grid.orientation == qec.sc_orientation.ZV
+    assert len(alias_grid.x_stabilizers) == 4
+    assert len(alias_grid.z_stabilizers) == 4
+
+    canonical_grid = qec.stabilizer_grid(3, " ZH ")
+    assert canonical_grid.orientation == qec.sc_orientation.ZH
     assert len(canonical_grid.x_stabilizers) == 4
     assert len(canonical_grid.z_stabilizers) == 4
+
+
+def test_get_code_orientation_option():
+    code = qec.get_code("surface_code", distance=3, orientation="O3")
+    assert isinstance(code, qec.Code)
+
+    np.testing.assert_array_equal(
+        code.get_observables_x(),
+        np.array([[1, 0, 0, 1, 0, 0, 1, 0, 0]], dtype=np.uint8))
+    np.testing.assert_array_equal(
+        code.get_observables_z(),
+        np.array([[1, 1, 1, 0, 0, 0, 0, 0, 0]], dtype=np.uint8))
 
 
 def test_roles_layout_d3():

--- a/libs/qec/unittests/test_qec.cpp
+++ b/libs/qec/unittests/test_qec.cpp
@@ -770,8 +770,10 @@ TEST(QECCodeTester, checkSurfaceCodeOrientationParser) {
   EXPECT_EQ(sc_orientation::XH, surface->grid.orientation);
 }
 
-TEST(QECCodeTester, checkSurfaceCodeXVPreservesLegacyLayout) {
-  stabilizer_grid grid(3, sc_orientation::XV);
+TEST(QECCodeTester, checkSurfaceCodeDefaultPreservesLegacyLayout) {
+  // The default orientation (ZH under Ising naming) is the original fixed
+  // surface-code layout.
+  stabilizer_grid grid(3);
   const auto role_at = [&grid](std::size_t row, std::size_t col) {
     return grid.roles[row * grid.grid_length + col];
   };
@@ -821,11 +823,12 @@ std::vector<std::size_t> support_of(const cudaq::spin_op_term &term) {
 } // namespace
 
 // Pin the EXACT role grid of every orientation at d=3 so permuting the
-// orientation labels (or regressing the boundary logic) fails. The grids are
-// derived by tracing generate_grid_roles()/role_for_parity(); the XV grid
-// matches checkSurfaceCodeXVPreservesLegacyLayout. Boundary summary: XV/ZH put
-// amx on left/right and amz on top/bottom; XH/ZV put amx on top/bottom and amz
-// on left/right (XV vs ZH and XH vs ZV differ in the bulk checkerboard).
+// orientation labels (or regressing the boundary logic) fails. Grids derived by
+// tracing generate_grid_roles()/role_for_parity() and cross-checked against
+// Ising's code_rotation stabilizers; the ZH grid is the legacy default layout
+// (see checkSurfaceCodeDefaultPreservesLegacyLayout). Boundary summary: XV/ZH
+// put amx on left/right and amz on top/bottom; XH/ZV put amx on top/bottom and
+// amz on left/right (XV vs ZH and XH vs ZV differ in the bulk checkerboard).
 TEST(QECCodeTester, checkSurfaceCodeAllOrientationGeometries) {
   // ---- XV ----
   {
@@ -835,23 +838,23 @@ TEST(QECCodeTester, checkSurfaceCodeAllOrientationGeometries) {
       return grid.roles[row * grid.grid_length + col];
     };
     EXPECT_EQ(surface_role::empty, role_at(0, 0));
-    EXPECT_EQ(surface_role::empty, role_at(0, 1));
-    EXPECT_EQ(surface_role::amz, role_at(0, 2));
+    EXPECT_EQ(surface_role::amz, role_at(0, 1));
+    EXPECT_EQ(surface_role::empty, role_at(0, 2));
     EXPECT_EQ(surface_role::empty, role_at(0, 3));
 
-    EXPECT_EQ(surface_role::amx, role_at(1, 0));
-    EXPECT_EQ(surface_role::amz, role_at(1, 1));
-    EXPECT_EQ(surface_role::amx, role_at(1, 2));
-    EXPECT_EQ(surface_role::empty, role_at(1, 3));
+    EXPECT_EQ(surface_role::empty, role_at(1, 0));
+    EXPECT_EQ(surface_role::amx, role_at(1, 1));
+    EXPECT_EQ(surface_role::amz, role_at(1, 2));
+    EXPECT_EQ(surface_role::amx, role_at(1, 3));
 
-    EXPECT_EQ(surface_role::empty, role_at(2, 0));
-    EXPECT_EQ(surface_role::amx, role_at(2, 1));
-    EXPECT_EQ(surface_role::amz, role_at(2, 2));
-    EXPECT_EQ(surface_role::amx, role_at(2, 3));
+    EXPECT_EQ(surface_role::amx, role_at(2, 0));
+    EXPECT_EQ(surface_role::amz, role_at(2, 1));
+    EXPECT_EQ(surface_role::amx, role_at(2, 2));
+    EXPECT_EQ(surface_role::empty, role_at(2, 3));
 
     EXPECT_EQ(surface_role::empty, role_at(3, 0));
-    EXPECT_EQ(surface_role::amz, role_at(3, 1));
-    EXPECT_EQ(surface_role::empty, role_at(3, 2));
+    EXPECT_EQ(surface_role::empty, role_at(3, 1));
+    EXPECT_EQ(surface_role::amz, role_at(3, 2));
     EXPECT_EQ(surface_role::empty, role_at(3, 3));
   }
 
@@ -859,34 +862,6 @@ TEST(QECCodeTester, checkSurfaceCodeAllOrientationGeometries) {
   {
     SCOPED_TRACE("XH");
     stabilizer_grid grid(3, sc_orientation::XH);
-    const auto role_at = [&grid](std::size_t row, std::size_t col) {
-      return grid.roles[row * grid.grid_length + col];
-    };
-    EXPECT_EQ(surface_role::empty, role_at(0, 0));
-    EXPECT_EQ(surface_role::amx, role_at(0, 1));
-    EXPECT_EQ(surface_role::empty, role_at(0, 2));
-    EXPECT_EQ(surface_role::empty, role_at(0, 3));
-
-    EXPECT_EQ(surface_role::empty, role_at(1, 0));
-    EXPECT_EQ(surface_role::amz, role_at(1, 1));
-    EXPECT_EQ(surface_role::amx, role_at(1, 2));
-    EXPECT_EQ(surface_role::amz, role_at(1, 3));
-
-    EXPECT_EQ(surface_role::amz, role_at(2, 0));
-    EXPECT_EQ(surface_role::amx, role_at(2, 1));
-    EXPECT_EQ(surface_role::amz, role_at(2, 2));
-    EXPECT_EQ(surface_role::empty, role_at(2, 3));
-
-    EXPECT_EQ(surface_role::empty, role_at(3, 0));
-    EXPECT_EQ(surface_role::empty, role_at(3, 1));
-    EXPECT_EQ(surface_role::amx, role_at(3, 2));
-    EXPECT_EQ(surface_role::empty, role_at(3, 3));
-  }
-
-  // ---- ZV ----
-  {
-    SCOPED_TRACE("ZV");
-    stabilizer_grid grid(3, sc_orientation::ZV);
     const auto role_at = [&grid](std::size_t row, std::size_t col) {
       return grid.roles[row * grid.grid_length + col];
     };
@@ -911,7 +886,35 @@ TEST(QECCodeTester, checkSurfaceCodeAllOrientationGeometries) {
     EXPECT_EQ(surface_role::empty, role_at(3, 3));
   }
 
-  // ---- ZH ----
+  // ---- ZV ----
+  {
+    SCOPED_TRACE("ZV");
+    stabilizer_grid grid(3, sc_orientation::ZV);
+    const auto role_at = [&grid](std::size_t row, std::size_t col) {
+      return grid.roles[row * grid.grid_length + col];
+    };
+    EXPECT_EQ(surface_role::empty, role_at(0, 0));
+    EXPECT_EQ(surface_role::amx, role_at(0, 1));
+    EXPECT_EQ(surface_role::empty, role_at(0, 2));
+    EXPECT_EQ(surface_role::empty, role_at(0, 3));
+
+    EXPECT_EQ(surface_role::empty, role_at(1, 0));
+    EXPECT_EQ(surface_role::amz, role_at(1, 1));
+    EXPECT_EQ(surface_role::amx, role_at(1, 2));
+    EXPECT_EQ(surface_role::amz, role_at(1, 3));
+
+    EXPECT_EQ(surface_role::amz, role_at(2, 0));
+    EXPECT_EQ(surface_role::amx, role_at(2, 1));
+    EXPECT_EQ(surface_role::amz, role_at(2, 2));
+    EXPECT_EQ(surface_role::empty, role_at(2, 3));
+
+    EXPECT_EQ(surface_role::empty, role_at(3, 0));
+    EXPECT_EQ(surface_role::empty, role_at(3, 1));
+    EXPECT_EQ(surface_role::amx, role_at(3, 2));
+    EXPECT_EQ(surface_role::empty, role_at(3, 3));
+  }
+
+  // ---- ZH (legacy default layout) ----
   {
     SCOPED_TRACE("ZH");
     stabilizer_grid grid(3, sc_orientation::ZH);
@@ -919,23 +922,23 @@ TEST(QECCodeTester, checkSurfaceCodeAllOrientationGeometries) {
       return grid.roles[row * grid.grid_length + col];
     };
     EXPECT_EQ(surface_role::empty, role_at(0, 0));
-    EXPECT_EQ(surface_role::amz, role_at(0, 1));
-    EXPECT_EQ(surface_role::empty, role_at(0, 2));
+    EXPECT_EQ(surface_role::empty, role_at(0, 1));
+    EXPECT_EQ(surface_role::amz, role_at(0, 2));
     EXPECT_EQ(surface_role::empty, role_at(0, 3));
 
-    EXPECT_EQ(surface_role::empty, role_at(1, 0));
-    EXPECT_EQ(surface_role::amx, role_at(1, 1));
-    EXPECT_EQ(surface_role::amz, role_at(1, 2));
-    EXPECT_EQ(surface_role::amx, role_at(1, 3));
+    EXPECT_EQ(surface_role::amx, role_at(1, 0));
+    EXPECT_EQ(surface_role::amz, role_at(1, 1));
+    EXPECT_EQ(surface_role::amx, role_at(1, 2));
+    EXPECT_EQ(surface_role::empty, role_at(1, 3));
 
-    EXPECT_EQ(surface_role::amx, role_at(2, 0));
-    EXPECT_EQ(surface_role::amz, role_at(2, 1));
-    EXPECT_EQ(surface_role::amx, role_at(2, 2));
-    EXPECT_EQ(surface_role::empty, role_at(2, 3));
+    EXPECT_EQ(surface_role::empty, role_at(2, 0));
+    EXPECT_EQ(surface_role::amx, role_at(2, 1));
+    EXPECT_EQ(surface_role::amz, role_at(2, 2));
+    EXPECT_EQ(surface_role::amx, role_at(2, 3));
 
     EXPECT_EQ(surface_role::empty, role_at(3, 0));
-    EXPECT_EQ(surface_role::empty, role_at(3, 1));
-    EXPECT_EQ(surface_role::amz, role_at(3, 2));
+    EXPECT_EQ(surface_role::amz, role_at(3, 1));
+    EXPECT_EQ(surface_role::empty, role_at(3, 2));
     EXPECT_EQ(surface_role::empty, role_at(3, 3));
   }
 }

--- a/libs/qec/unittests/test_qec.cpp
+++ b/libs/qec/unittests/test_qec.cpp
@@ -59,6 +59,17 @@ std::vector<std::size_t> left_column_support(std::uint32_t distance) {
   return support;
 }
 
+// Recover the integer support (indices of non-identity Paulis) of a single
+// spin_op_term pauli word, e.g. "XIXII" -> {0, 2}.
+std::vector<std::size_t> support_of(const cudaq::spin_op_term &term) {
+  std::vector<std::size_t> support;
+  const std::string word = term.get_pauli_word();
+  for (std::size_t i = 0; i < word.size(); ++i)
+    if (word[i] != 'I')
+      support.push_back(i);
+  return support;
+}
+
 bool uses_horizontal_x_logical(sc_orientation orientation) {
   return orientation == sc_orientation::XV || orientation == sc_orientation::ZH;
 }
@@ -72,10 +83,17 @@ void expect_surface_code_algebra(sc_orientation orientation) {
 
   const auto top_row = top_row_support(distance);
   const auto left_column = left_column_support(distance);
-  const auto logical_x =
+  const auto expected_logical_x =
       uses_horizontal_x_logical(orientation) ? top_row : left_column;
-  const auto logical_z =
+  const auto expected_logical_z =
       uses_horizontal_x_logical(orientation) ? left_column : top_row;
+  const auto observables = grid.get_spin_op_observables();
+  ASSERT_EQ(2u, observables.size());
+  // get_spin_op_observables() emits the X observable first, then Z.
+  const auto logical_x = support_of(observables[0]);
+  const auto logical_z = support_of(observables[1]);
+  EXPECT_EQ(expected_logical_x, logical_x);
+  EXPECT_EQ(expected_logical_z, logical_z);
   EXPECT_EQ(1, overlap_parity(logical_x, logical_z));
 
   for (const auto &x_stabilizer : grid.x_stabilizers) {
@@ -86,17 +104,6 @@ void expect_surface_code_algebra(sc_orientation orientation) {
 
   for (const auto &z_stabilizer : grid.z_stabilizers)
     EXPECT_EQ(0, overlap_parity(z_stabilizer, logical_x));
-}
-
-// Recover the integer support (indices of non-identity Paulis) of a single
-// spin_op_term pauli word, e.g. "XIXII" -> {0, 2}.
-std::vector<std::size_t> support_of(const cudaq::spin_op_term &term) {
-  std::vector<std::size_t> support;
-  const std::string word = term.get_pauli_word();
-  for (std::size_t i = 0; i < word.size(); ++i)
-    if (word[i] != 'I')
-      support.push_back(i);
-  return support;
 }
 
 } // namespace
@@ -763,27 +770,30 @@ TEST(QECNoiseModelTester, ConstructsTwoQubitBitflipChannel) {
   EXPECT_NO_THROW({ cudaq::qec::two_qubit_bitflip channel(0.05); });
 }
 
-TEST(QECCodeTester, checkSurfaceCodeOrientationParser) {
-  using cudaq::qec::surface_code::parse_orientation;
+TEST(QECCodeTester, checkSurfaceCodeOrientationFromString) {
+  using cudaq::qec::surface_code::sc_orientation_from_str;
 
-  EXPECT_EQ(sc_orientation::XV, parse_orientation("XV"));
-  EXPECT_EQ(sc_orientation::XH, parse_orientation(" xh "));
-  EXPECT_EQ(sc_orientation::ZV, parse_orientation("ZV"));
-  EXPECT_EQ(sc_orientation::ZH, parse_orientation("zh"));
-  EXPECT_THROW(parse_orientation("north"), std::runtime_error);
+  EXPECT_EQ(sc_orientation::XV, sc_orientation_from_str("XV"));
+  EXPECT_EQ(sc_orientation::XV, sc_orientation_from_str("o1"));
+  EXPECT_EQ(sc_orientation::XH, sc_orientation_from_str(" xh "));
+  EXPECT_EQ(sc_orientation::XH, sc_orientation_from_str("O2"));
+  EXPECT_EQ(sc_orientation::ZV, sc_orientation_from_str("ZV"));
+  EXPECT_EQ(sc_orientation::ZV, sc_orientation_from_str(" o3 "));
+  EXPECT_EQ(sc_orientation::ZH, sc_orientation_from_str("zh"));
+  EXPECT_EQ(sc_orientation::ZH, sc_orientation_from_str("O4"));
+  EXPECT_THROW(sc_orientation_from_str("north"), std::runtime_error);
 
   auto surf_code = cudaq::qec::get_code(
       "surface_code",
-      cudaqx::heterogeneous_map{{"distance", 3}, {"orientation", "XH"}});
+      cudaqx::heterogeneous_map{{"distance", 3}, {"orientation", "O2"}});
   auto *surface =
       dynamic_cast<cudaq::qec::surface_code::surface_code *>(surf_code.get());
   ASSERT_NE(nullptr, surface);
-  EXPECT_EQ(sc_orientation::XH, surface->grid.orientation);
+  EXPECT_EQ(sc_orientation::XH, surface->grid.get_orientation());
 }
 
-TEST(QECCodeTester, checkSurfaceCodeDefaultPreservesLegacyLayout) {
-  // The default orientation (ZH under Ising naming) is the original fixed
-  // surface-code layout.
+TEST(QECCodeTester, checkSurfaceCodeDefaultZHLayout) {
+  // Default construction uses the ZH orientation.
   stabilizer_grid grid(3);
   const auto role_at = [&grid](std::size_t row, std::size_t col) {
     return grid.roles[row * grid.grid_length + col];
@@ -821,10 +831,9 @@ TEST(QECCodeTester, checkSurfaceCodeOrientationAlgebra) {
 // Pin the EXACT role grid of every orientation at d=3 so permuting the
 // orientation labels (or regressing the boundary logic) fails. Grids derived by
 // tracing generate_grid_roles()/role_for_parity() and cross-checked against
-// Ising's code_rotation stabilizers; the ZH grid is the legacy default layout
-// (see checkSurfaceCodeDefaultPreservesLegacyLayout). Boundary summary: XV/ZH
-// put amx on left/right and amz on top/bottom; XH/ZV put amx on top/bottom and
-// amz on left/right (XV vs ZH and XH vs ZV differ in the bulk checkerboard).
+// Ising's code_rotation stabilizers. Boundary summary: XV/ZH put amx on
+// left/right and amz on top/bottom; XH/ZV put amx on top/bottom and amz on
+// left/right (XV vs ZH and XH vs ZV differ in the bulk checkerboard).
 TEST(QECCodeTester, checkSurfaceCodeAllOrientationGeometries) {
   // ---- XV ----
   {
@@ -910,7 +919,7 @@ TEST(QECCodeTester, checkSurfaceCodeAllOrientationGeometries) {
     EXPECT_EQ(surface_role::empty, role_at(3, 3));
   }
 
-  // ---- ZH (legacy default layout) ----
+  // ---- ZH ----
   {
     SCOPED_TRACE("ZH");
     stabilizer_grid grid(3, sc_orientation::ZH);
@@ -936,45 +945,6 @@ TEST(QECCodeTester, checkSurfaceCodeAllOrientationGeometries) {
     EXPECT_EQ(surface_role::amz, role_at(3, 1));
     EXPECT_EQ(surface_role::empty, role_at(3, 2));
     EXPECT_EQ(surface_role::empty, role_at(3, 3));
-  }
-}
-
-// After making get_spin_op_observables() orientation-aware, every orientation
-// must yield a VALID logical pair: the X observable commutes with all Z
-// stabilizers, the Z observable commutes with all X stabilizers, and the two
-// observables anticommute. This also pins which physical support each
-// orientation uses (top row vs left column).
-TEST(QECCodeTester, checkSurfaceCodeObservablesPerOrientation) {
-  for (auto orientation : {sc_orientation::XV, sc_orientation::XH,
-                           sc_orientation::ZV, sc_orientation::ZH}) {
-    SCOPED_TRACE(static_cast<int>(orientation));
-    constexpr std::uint32_t distance = 3;
-    stabilizer_grid grid(distance, orientation);
-
-    const auto observables = grid.get_spin_op_observables();
-    ASSERT_EQ(2u, observables.size());
-    // get_spin_op_observables() emits the X observable first, then Z.
-    const auto logical_x = support_of(observables[0]);
-    const auto logical_z = support_of(observables[1]);
-
-    // Pin the expected physical support for each orientation.
-    const auto top_row = top_row_support(distance);
-    const auto left_column = left_column_support(distance);
-    if (uses_horizontal_x_logical(orientation)) {
-      EXPECT_EQ(top_row, logical_x);
-      EXPECT_EQ(left_column, logical_z);
-    } else {
-      EXPECT_EQ(left_column, logical_x);
-      EXPECT_EQ(top_row, logical_z);
-    }
-
-    // Valid logical pair: X obs commutes with all Z stabs, Z obs commutes with
-    // all X stabs, and the two observables anticommute.
-    for (const auto &z_stabilizer : grid.z_stabilizers)
-      EXPECT_EQ(0, overlap_parity(logical_x, z_stabilizer));
-    for (const auto &x_stabilizer : grid.x_stabilizers)
-      EXPECT_EQ(0, overlap_parity(logical_z, x_stabilizer));
-    EXPECT_EQ(1, overlap_parity(logical_x, logical_z));
   }
 }
 

--- a/libs/qec/unittests/test_qec.cpp
+++ b/libs/qec/unittests/test_qec.cpp
@@ -20,6 +20,76 @@
 #include "cudaq/qec/plugin_loader.h"
 #include "cudaq/qec/version.h"
 
+namespace {
+
+using cudaq::qec::surface_code::sc_orientation;
+using cudaq::qec::surface_code::stabilizer_grid;
+using cudaq::qec::surface_code::surface_role;
+
+int overlap_parity(const std::vector<std::size_t> &a,
+                   const std::vector<std::size_t> &b) {
+  auto a_it = a.begin();
+  auto b_it = b.begin();
+  int parity = 0;
+  while (a_it != a.end() && b_it != b.end()) {
+    if (*a_it < *b_it) {
+      ++a_it;
+    } else if (*b_it < *a_it) {
+      ++b_it;
+    } else {
+      parity ^= 1;
+      ++a_it;
+      ++b_it;
+    }
+  }
+  return parity;
+}
+
+std::vector<std::size_t> top_row_logical_x(std::uint32_t distance) {
+  std::vector<std::size_t> support;
+  for (std::size_t i = 0; i < distance; ++i)
+    support.push_back(i);
+  return support;
+}
+
+std::vector<std::size_t> left_column_logical_z(std::uint32_t distance) {
+  std::vector<std::size_t> support;
+  for (std::size_t i = 0; i < distance * distance; i += distance)
+    support.push_back(i);
+  return support;
+}
+
+bool uses_horizontal_x_logical(sc_orientation orientation) {
+  return orientation == sc_orientation::XV || orientation == sc_orientation::ZH;
+}
+
+void expect_surface_code_algebra(sc_orientation orientation) {
+  constexpr std::uint32_t distance = 5;
+  stabilizer_grid grid(distance, orientation);
+  const auto expected_stabilizer_count = (distance * distance - 1) / 2;
+  EXPECT_EQ(expected_stabilizer_count, grid.x_stabilizers.size());
+  EXPECT_EQ(expected_stabilizer_count, grid.z_stabilizers.size());
+
+  const auto top_row = top_row_logical_x(distance);
+  const auto left_column = left_column_logical_z(distance);
+  const auto logical_x =
+      uses_horizontal_x_logical(orientation) ? top_row : left_column;
+  const auto logical_z =
+      uses_horizontal_x_logical(orientation) ? left_column : top_row;
+  EXPECT_EQ(1, overlap_parity(logical_x, logical_z));
+
+  for (const auto &x_stabilizer : grid.x_stabilizers) {
+    EXPECT_EQ(0, overlap_parity(x_stabilizer, logical_z));
+    for (const auto &z_stabilizer : grid.z_stabilizers)
+      EXPECT_EQ(0, overlap_parity(x_stabilizer, z_stabilizer));
+  }
+
+  for (const auto &z_stabilizer : grid.z_stabilizers)
+    EXPECT_EQ(0, overlap_parity(z_stabilizer, logical_x));
+}
+
+} // namespace
+
 TEST(StabilizerTester, checkConstructFromSpinOps) {
   {
     // Constructor will always auto sort
@@ -680,6 +750,59 @@ TEST(QECCodeTester, checkRepetition) {
 TEST(QECNoiseModelTester, ConstructsTwoQubitBitflipChannel) {
   // Direct construction covers the inline Kraus construction path.
   EXPECT_NO_THROW({ cudaq::qec::two_qubit_bitflip channel(0.05); });
+}
+
+TEST(QECCodeTester, checkSurfaceCodeOrientationParser) {
+  using cudaq::qec::surface_code::parse_orientation;
+
+  EXPECT_EQ(sc_orientation::XV, parse_orientation("XV"));
+  EXPECT_EQ(sc_orientation::XH, parse_orientation(" xh "));
+  EXPECT_EQ(sc_orientation::ZV, parse_orientation("ZV"));
+  EXPECT_EQ(sc_orientation::ZH, parse_orientation("zh"));
+  EXPECT_THROW(parse_orientation("north"), std::runtime_error);
+
+  auto surf_code = cudaq::qec::get_code(
+      "surface_code",
+      cudaqx::heterogeneous_map{{"distance", 3}, {"orientation", "XH"}});
+  auto *surface =
+      dynamic_cast<cudaq::qec::surface_code::surface_code *>(surf_code.get());
+  ASSERT_NE(nullptr, surface);
+  EXPECT_EQ(sc_orientation::XH, surface->grid.orientation);
+}
+
+TEST(QECCodeTester, checkSurfaceCodeXVPreservesLegacyLayout) {
+  stabilizer_grid grid(3, sc_orientation::XV);
+  const auto role_at = [&grid](std::size_t row, std::size_t col) {
+    return grid.roles[row * grid.grid_length + col];
+  };
+
+  EXPECT_EQ(surface_role::empty, role_at(0, 0));
+  EXPECT_EQ(surface_role::empty, role_at(0, 1));
+  EXPECT_EQ(surface_role::amz, role_at(0, 2));
+  EXPECT_EQ(surface_role::empty, role_at(0, 3));
+
+  EXPECT_EQ(surface_role::amx, role_at(1, 0));
+  EXPECT_EQ(surface_role::amz, role_at(1, 1));
+  EXPECT_EQ(surface_role::amx, role_at(1, 2));
+  EXPECT_EQ(surface_role::empty, role_at(1, 3));
+
+  EXPECT_EQ(surface_role::empty, role_at(2, 0));
+  EXPECT_EQ(surface_role::amx, role_at(2, 1));
+  EXPECT_EQ(surface_role::amz, role_at(2, 2));
+  EXPECT_EQ(surface_role::amx, role_at(2, 3));
+
+  EXPECT_EQ(surface_role::empty, role_at(3, 0));
+  EXPECT_EQ(surface_role::amz, role_at(3, 1));
+  EXPECT_EQ(surface_role::empty, role_at(3, 2));
+  EXPECT_EQ(surface_role::empty, role_at(3, 3));
+}
+
+TEST(QECCodeTester, checkSurfaceCodeOrientationAlgebra) {
+  for (auto orientation : {sc_orientation::XV, sc_orientation::XH,
+                           sc_orientation::ZV, sc_orientation::ZH}) {
+    SCOPED_TRACE(static_cast<int>(orientation));
+    expect_surface_code_algebra(orientation);
+  }
 }
 
 TEST(QECCodeTester, checkSurfaceCode) {

--- a/libs/qec/unittests/test_qec.cpp
+++ b/libs/qec/unittests/test_qec.cpp
@@ -805,6 +805,180 @@ TEST(QECCodeTester, checkSurfaceCodeOrientationAlgebra) {
   }
 }
 
+namespace {
+
+// Recover the integer support (indices of non-identity Paulis) of a single
+// spin_op_term pauli word, e.g. "XIXII" -> {0, 2}.
+std::vector<std::size_t> support_of(const cudaq::spin_op_term &term) {
+  std::vector<std::size_t> support;
+  const std::string word = term.get_pauli_word();
+  for (std::size_t i = 0; i < word.size(); ++i)
+    if (word[i] != 'I')
+      support.push_back(i);
+  return support;
+}
+
+} // namespace
+
+// Pin the EXACT role grid of every orientation at d=3 so permuting the
+// orientation labels (or regressing the boundary logic) fails. The grids are
+// derived by tracing generate_grid_roles()/role_for_parity(); the XV grid
+// matches checkSurfaceCodeXVPreservesLegacyLayout. Boundary summary: XV/ZH put
+// amx on left/right and amz on top/bottom; XH/ZV put amx on top/bottom and amz
+// on left/right (XV vs ZH and XH vs ZV differ in the bulk checkerboard).
+TEST(QECCodeTester, checkSurfaceCodeAllOrientationGeometries) {
+  // ---- XV ----
+  {
+    SCOPED_TRACE("XV");
+    stabilizer_grid grid(3, sc_orientation::XV);
+    const auto role_at = [&grid](std::size_t row, std::size_t col) {
+      return grid.roles[row * grid.grid_length + col];
+    };
+    EXPECT_EQ(surface_role::empty, role_at(0, 0));
+    EXPECT_EQ(surface_role::empty, role_at(0, 1));
+    EXPECT_EQ(surface_role::amz, role_at(0, 2));
+    EXPECT_EQ(surface_role::empty, role_at(0, 3));
+
+    EXPECT_EQ(surface_role::amx, role_at(1, 0));
+    EXPECT_EQ(surface_role::amz, role_at(1, 1));
+    EXPECT_EQ(surface_role::amx, role_at(1, 2));
+    EXPECT_EQ(surface_role::empty, role_at(1, 3));
+
+    EXPECT_EQ(surface_role::empty, role_at(2, 0));
+    EXPECT_EQ(surface_role::amx, role_at(2, 1));
+    EXPECT_EQ(surface_role::amz, role_at(2, 2));
+    EXPECT_EQ(surface_role::amx, role_at(2, 3));
+
+    EXPECT_EQ(surface_role::empty, role_at(3, 0));
+    EXPECT_EQ(surface_role::amz, role_at(3, 1));
+    EXPECT_EQ(surface_role::empty, role_at(3, 2));
+    EXPECT_EQ(surface_role::empty, role_at(3, 3));
+  }
+
+  // ---- XH ----
+  {
+    SCOPED_TRACE("XH");
+    stabilizer_grid grid(3, sc_orientation::XH);
+    const auto role_at = [&grid](std::size_t row, std::size_t col) {
+      return grid.roles[row * grid.grid_length + col];
+    };
+    EXPECT_EQ(surface_role::empty, role_at(0, 0));
+    EXPECT_EQ(surface_role::amx, role_at(0, 1));
+    EXPECT_EQ(surface_role::empty, role_at(0, 2));
+    EXPECT_EQ(surface_role::empty, role_at(0, 3));
+
+    EXPECT_EQ(surface_role::empty, role_at(1, 0));
+    EXPECT_EQ(surface_role::amz, role_at(1, 1));
+    EXPECT_EQ(surface_role::amx, role_at(1, 2));
+    EXPECT_EQ(surface_role::amz, role_at(1, 3));
+
+    EXPECT_EQ(surface_role::amz, role_at(2, 0));
+    EXPECT_EQ(surface_role::amx, role_at(2, 1));
+    EXPECT_EQ(surface_role::amz, role_at(2, 2));
+    EXPECT_EQ(surface_role::empty, role_at(2, 3));
+
+    EXPECT_EQ(surface_role::empty, role_at(3, 0));
+    EXPECT_EQ(surface_role::empty, role_at(3, 1));
+    EXPECT_EQ(surface_role::amx, role_at(3, 2));
+    EXPECT_EQ(surface_role::empty, role_at(3, 3));
+  }
+
+  // ---- ZV ----
+  {
+    SCOPED_TRACE("ZV");
+    stabilizer_grid grid(3, sc_orientation::ZV);
+    const auto role_at = [&grid](std::size_t row, std::size_t col) {
+      return grid.roles[row * grid.grid_length + col];
+    };
+    EXPECT_EQ(surface_role::empty, role_at(0, 0));
+    EXPECT_EQ(surface_role::empty, role_at(0, 1));
+    EXPECT_EQ(surface_role::amx, role_at(0, 2));
+    EXPECT_EQ(surface_role::empty, role_at(0, 3));
+
+    EXPECT_EQ(surface_role::amz, role_at(1, 0));
+    EXPECT_EQ(surface_role::amx, role_at(1, 1));
+    EXPECT_EQ(surface_role::amz, role_at(1, 2));
+    EXPECT_EQ(surface_role::empty, role_at(1, 3));
+
+    EXPECT_EQ(surface_role::empty, role_at(2, 0));
+    EXPECT_EQ(surface_role::amz, role_at(2, 1));
+    EXPECT_EQ(surface_role::amx, role_at(2, 2));
+    EXPECT_EQ(surface_role::amz, role_at(2, 3));
+
+    EXPECT_EQ(surface_role::empty, role_at(3, 0));
+    EXPECT_EQ(surface_role::amx, role_at(3, 1));
+    EXPECT_EQ(surface_role::empty, role_at(3, 2));
+    EXPECT_EQ(surface_role::empty, role_at(3, 3));
+  }
+
+  // ---- ZH ----
+  {
+    SCOPED_TRACE("ZH");
+    stabilizer_grid grid(3, sc_orientation::ZH);
+    const auto role_at = [&grid](std::size_t row, std::size_t col) {
+      return grid.roles[row * grid.grid_length + col];
+    };
+    EXPECT_EQ(surface_role::empty, role_at(0, 0));
+    EXPECT_EQ(surface_role::amz, role_at(0, 1));
+    EXPECT_EQ(surface_role::empty, role_at(0, 2));
+    EXPECT_EQ(surface_role::empty, role_at(0, 3));
+
+    EXPECT_EQ(surface_role::empty, role_at(1, 0));
+    EXPECT_EQ(surface_role::amx, role_at(1, 1));
+    EXPECT_EQ(surface_role::amz, role_at(1, 2));
+    EXPECT_EQ(surface_role::amx, role_at(1, 3));
+
+    EXPECT_EQ(surface_role::amx, role_at(2, 0));
+    EXPECT_EQ(surface_role::amz, role_at(2, 1));
+    EXPECT_EQ(surface_role::amx, role_at(2, 2));
+    EXPECT_EQ(surface_role::empty, role_at(2, 3));
+
+    EXPECT_EQ(surface_role::empty, role_at(3, 0));
+    EXPECT_EQ(surface_role::empty, role_at(3, 1));
+    EXPECT_EQ(surface_role::amz, role_at(3, 2));
+    EXPECT_EQ(surface_role::empty, role_at(3, 3));
+  }
+}
+
+// After making get_spin_op_observables() orientation-aware, every orientation
+// must yield a VALID logical pair: the X observable commutes with all Z
+// stabilizers, the Z observable commutes with all X stabilizers, and the two
+// observables anticommute. This also pins which physical support each
+// orientation uses (top row vs left column).
+TEST(QECCodeTester, checkSurfaceCodeObservablesPerOrientation) {
+  for (auto orientation : {sc_orientation::XV, sc_orientation::XH,
+                           sc_orientation::ZV, sc_orientation::ZH}) {
+    SCOPED_TRACE(static_cast<int>(orientation));
+    constexpr std::uint32_t distance = 3;
+    stabilizer_grid grid(distance, orientation);
+
+    const auto observables = grid.get_spin_op_observables();
+    ASSERT_EQ(2u, observables.size());
+    // get_spin_op_observables() emits the X observable first, then Z.
+    const auto logical_x = support_of(observables[0]);
+    const auto logical_z = support_of(observables[1]);
+
+    // Pin the expected physical support for each orientation.
+    const auto top_row = top_row_logical_x(distance);
+    const auto left_column = left_column_logical_z(distance);
+    if (uses_horizontal_x_logical(orientation)) {
+      EXPECT_EQ(top_row, logical_x);
+      EXPECT_EQ(left_column, logical_z);
+    } else {
+      EXPECT_EQ(left_column, logical_x);
+      EXPECT_EQ(top_row, logical_z);
+    }
+
+    // Valid logical pair: X obs commutes with all Z stabs, Z obs commutes with
+    // all X stabs, and the two observables anticommute.
+    for (const auto &z_stabilizer : grid.z_stabilizers)
+      EXPECT_EQ(0, overlap_parity(logical_x, z_stabilizer));
+    for (const auto &x_stabilizer : grid.x_stabilizers)
+      EXPECT_EQ(0, overlap_parity(logical_z, x_stabilizer));
+    EXPECT_EQ(1, overlap_parity(logical_x, logical_z));
+  }
+}
+
 TEST(QECCodeTester, checkSurfaceCode) {
   {
     // must provide distance

--- a/libs/qec/unittests/test_qec.cpp
+++ b/libs/qec/unittests/test_qec.cpp
@@ -88,6 +88,17 @@ void expect_surface_code_algebra(sc_orientation orientation) {
     EXPECT_EQ(0, overlap_parity(z_stabilizer, logical_x));
 }
 
+// Recover the integer support (indices of non-identity Paulis) of a single
+// spin_op_term pauli word, e.g. "XIXII" -> {0, 2}.
+std::vector<std::size_t> support_of(const cudaq::spin_op_term &term) {
+  std::vector<std::size_t> support;
+  const std::string word = term.get_pauli_word();
+  for (std::size_t i = 0; i < word.size(); ++i)
+    if (word[i] != 'I')
+      support.push_back(i);
+  return support;
+}
+
 } // namespace
 
 TEST(StabilizerTester, checkConstructFromSpinOps) {
@@ -806,21 +817,6 @@ TEST(QECCodeTester, checkSurfaceCodeOrientationAlgebra) {
     expect_surface_code_algebra(orientation);
   }
 }
-
-namespace {
-
-// Recover the integer support (indices of non-identity Paulis) of a single
-// spin_op_term pauli word, e.g. "XIXII" -> {0, 2}.
-std::vector<std::size_t> support_of(const cudaq::spin_op_term &term) {
-  std::vector<std::size_t> support;
-  const std::string word = term.get_pauli_word();
-  for (std::size_t i = 0; i < word.size(); ++i)
-    if (word[i] != 'I')
-      support.push_back(i);
-  return support;
-}
-
-} // namespace
 
 // Pin the EXACT role grid of every orientation at d=3 so permuting the
 // orientation labels (or regressing the boundary logic) fails. Grids derived by

--- a/libs/qec/unittests/test_qec.cpp
+++ b/libs/qec/unittests/test_qec.cpp
@@ -45,14 +45,14 @@ int overlap_parity(const std::vector<std::size_t> &a,
   return parity;
 }
 
-std::vector<std::size_t> top_row_logical_x(std::uint32_t distance) {
+std::vector<std::size_t> top_row_support(std::uint32_t distance) {
   std::vector<std::size_t> support;
   for (std::size_t i = 0; i < distance; ++i)
     support.push_back(i);
   return support;
 }
 
-std::vector<std::size_t> left_column_logical_z(std::uint32_t distance) {
+std::vector<std::size_t> left_column_support(std::uint32_t distance) {
   std::vector<std::size_t> support;
   for (std::size_t i = 0; i < distance * distance; i += distance)
     support.push_back(i);
@@ -70,8 +70,8 @@ void expect_surface_code_algebra(sc_orientation orientation) {
   EXPECT_EQ(expected_stabilizer_count, grid.x_stabilizers.size());
   EXPECT_EQ(expected_stabilizer_count, grid.z_stabilizers.size());
 
-  const auto top_row = top_row_logical_x(distance);
-  const auto left_column = left_column_logical_z(distance);
+  const auto top_row = top_row_support(distance);
+  const auto left_column = left_column_support(distance);
   const auto logical_x =
       uses_horizontal_x_logical(orientation) ? top_row : left_column;
   const auto logical_z =
@@ -962,8 +962,8 @@ TEST(QECCodeTester, checkSurfaceCodeObservablesPerOrientation) {
     const auto logical_z = support_of(observables[1]);
 
     // Pin the expected physical support for each orientation.
-    const auto top_row = top_row_logical_x(distance);
-    const auto left_column = left_column_logical_z(distance);
+    const auto top_row = top_row_support(distance);
+    const auto left_column = left_column_support(distance);
     if (uses_horizontal_x_logical(orientation)) {
       EXPECT_EQ(top_row, logical_x);
       EXPECT_EQ(left_column, logical_z);


### PR DESCRIPTION
## Summary

The rotated `surface_code` previously hard-coded a single stabilizer layout.
This PR adds a first-class `sc_orientation` enum and threads it through
`stabilizer_grid`, letting callers choose which Pauli type occupies the bulk
interior and which boundary pair carries X- vs Z-type stabilizers.

The orientation names follow Ising’s `code_rotation` geometry convention. To
preserve existing CUDA-QX behavior, the default orientation is `ZH`. Existing
callers that do not set an orientation keep the same stabilizers, observables,
and DEM behavior.

## What's Added

- `sc_orientation` enum: `XV`, `XH`, `ZV`, `ZH`.
- `sc_orientation_from_str(const std::string&)`: converts canonical names and
  Ising aliases to `sc_orientation`, case-insensitively with surrounding
  whitespace ignored:
  - `XV` / `O1`
  - `XH` / `O2`
  - `ZV` / `O3`
  - `ZH` / `O4`
- `stabilizer_grid` gains an orientation-aware constructor:
  `stabilizer_grid(uint32_t distance, sc_orientation orientation = sc_orientation::ZH)`.
- `stabilizer_grid` stores orientation privately and exposes it through
  `get_orientation()`.
- `generate_grid_roles()` now derives the bulk checkerboard and boundary
  stabilizer types from the selected orientation.
- `surface_code(const heterogeneous_map&)` accepts an `"orientation"` option,
  defaulting to `"ZH"`.
- Python bindings expose `sc_orientation` and the orientation-aware
  `stabilizer_grid` constructor, accepting either the enum or a string.
  The grid’s orientation is available as a read-only Python property.

## Orientation Semantics

The names follow Ising’s `code_rotation` convention:

- first character: bulk syndrome type
- second character: `rotated_type`

| Orientation | X-type boundaries | Z-type boundaries |
| --- | --- | --- |
| `XV` | left / right | top / bottom |
| `XH` | top / bottom | left / right |
| `ZV` | top / bottom | left / right |
| `ZH` | left / right | top / bottom |

`XV`/`ZH` share boundary placement but differ in the bulk X/Z checkerboard.
Likewise, `XH`/`ZV` share boundary placement but differ in the bulk checkerboard.
All four are distinct layouts.

## Observables

`get_spin_op_observables()` is orientation-aware and returns a valid logical
pair for the selected orientation:

| Orientation | X observable | Z observable |
| --- | --- | --- |
| `XV`, `ZH` | top row | left column |
| `XH`, `ZV` | left column | top row |

The default `ZH` orientation preserves the previous observable convention:
X along the top row and Z along the left column.

## Testing

C++ (`test_qec.cpp`):

- `checkSurfaceCodeOrientationFromString`: string conversion, alias handling,
  invalid-input rejection, and construction via `get_code(..., {"orientation", ...})`.
- `checkSurfaceCodeDefaultZHLayout`: verifies the default `ZH` layout.
- `checkSurfaceCodeAllOrientationGeometries`: pins the exact distance-3 role
  grid for all four orientations, guarding against label swaps or boundary
  regressions.
- `checkSurfaceCodeOrientationAlgebra`: verifies all stabilizers commute, the
  logical pair is valid for all four orientations, and the expected observable
  supports are returned.

Python (`test_surface_code.py`):

- Orientation-aware `stabilizer_grid` construction using enum, canonical string,
  and Ising alias string forms.
- Read-only orientation inspection from Python.
- `get_code(..., orientation=...)` coverage for orientation strings.

## Backward Compatibility

Existing callers that do not specify an orientation are unaffected. The default
is now named `ZH` to match Ising geometry naming, but it is the same physical
layout CUDA-QX previously used.

This is a self-contained library/bindings change with no new runtime
dependencies.