### PR TITLE
Follow-up to #546 - fix CMake warning

### DIFF
--- a/libs/qec/lib/decoders/plugins/chromobius/CMakeLists.txt
+++ b/libs/qec/lib/decoders/plugins/chromobius/CMakeLists.txt
@@ -15,17 +15,6 @@ set(MODULE_NAME "cudaq-qec-chromobius")
 
 include(FetchContent)
 
-FetchContent_Declare(
-  chromobius
-  GIT_REPOSITORY https://github.com/quantumlib/chromobius.git
-  GIT_TAG efae0325e4a8fc13be981434d38e499aa06b989f # v1.1.1
-)
-
-FetchContent_GetProperties(chromobius)
-if(NOT chromobius_POPULATED)
-  FetchContent_Populate(chromobius)
-endif()
-
 if(NOT TARGET libpymatching)
   message(FATAL_ERROR
     "Chromobius decoder plugin requires the libpymatching target. "
@@ -37,32 +26,13 @@ if(NOT TARGET libstim)
     "Chromobius decoder plugin requires the libstim target provided by PyMatching.")
 endif()
 
-file(STRINGS
-  ${chromobius_SOURCE_DIR}/file_lists/source_files_no_main
-  CHROMOBIUS_SOURCE_FILES
+FetchContent_Declare(
+  chromobius
+  GIT_REPOSITORY https://github.com/quantumlib/chromobius.git
+  GIT_TAG efae0325e4a8fc13be981434d38e499aa06b989f # v1.1.1
+  EXCLUDE_FROM_ALL  # don't add chromobius's own executables/tests to ALL
 )
-list(TRANSFORM CHROMOBIUS_SOURCE_FILES
-  PREPEND "${chromobius_SOURCE_DIR}/"
-)
-
-set(CHROMOBIUS_STATIC_TARGET cudaq-qec-chromobius-static)
-add_library(${CHROMOBIUS_STATIC_TARGET} STATIC ${CHROMOBIUS_SOURCE_FILES})
-set_target_properties(${CHROMOBIUS_STATIC_TARGET} PROPERTIES
-  POSITION_INDEPENDENT_CODE ON
-)
-target_include_directories(${CHROMOBIUS_STATIC_TARGET}
-  PUBLIC
-    ${chromobius_SOURCE_DIR}/src
-)
-target_link_libraries(${CHROMOBIUS_STATIC_TARGET}
-  PRIVATE
-    libstim
-    libpymatching
-)
-target_compile_options(${CHROMOBIUS_STATIC_TARGET}
-  PRIVATE
-    $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-O3 -Wall -Wpedantic -fno-strict-aliasing>
-)
+FetchContent_MakeAvailable(chromobius)
 
 project(${MODULE_NAME})
 
@@ -94,7 +64,7 @@ target_link_libraries(${MODULE_NAME}
   PRIVATE
     cudaq::cudaq-common
     cudaq-qec
-    ${CHROMOBIUS_STATIC_TARGET}
+    libchromobius
     libstim
     libpymatching
 )


### PR DESCRIPTION
## Description

Fix this CMake warning:

```
CMake Warning (dev) at /home/.local/lib/python3.12/site-packages/cmake/data/share/cmake-3.31/Modules/FetchContent.cmake:1953 (message):
  Calling FetchContent_Populate(chromobius) is deprecated, call
  FetchContent_MakeAvailable(chromobius) instead.  Policy CMP0169 can be set
  to OLD to allow FetchContent_Populate(chromobius) to be called directly for
  now, but the ability to call it with declared details will be removed
  completely in a future version.
Call Stack (most recent call first):
  libs/qec/lib/decoders/plugins/chromobius/CMakeLists.txt:26 (FetchContent_Populate)
This warning is for project developers.  Use -Wno-dev to suppress it.
```

## Runtime / performance impact

N/A

## Self-review checklist

Please confirm each item before requesting review. Check `[x]` or strike
through and explain.

### Before requesting review
- [x] I reviewed my own full diff in GitHub or my editor.
- [x] PR is in Draft if it is not yet ready for review.
- [x] Temporary / debugging changes have been removed.
- [x] Local test logs reviewed; no unexplained warnings or errors.
- [x] CI logs reviewed; no unexplained warnings or errors.
- [x] Full CI has been run.

### Scope and size
- [x] PR is under ~1000 lines, or an exception is justified in the description.
- [x] Refactoring-only changes are isolated in their own PR(s).
- [x] No existing tests were disabled or modified just to make this PR pass
      (if so, an issue has been raised).

### Tests
- [x] New functionality has new tests.
- [x] Tests fail if the new functionality is broken (including crashes), not
      just when it is missing.
- [x] Negative tests added where exceptions are expected.
- [x] Truth data added where simple `EXPECT_*` / `assert` checks are
      insufficient for algorithmic correctness.
- [x] CI runtime impact considered; team notified if significant.

### Documentation
- [x] Public-facing APIs have Doxygen docs.
- [x] User-visible behavior changes have public docs, or a follow-up is
      tracked.

### Code style
- [x] Naming follows the existing convention (`snake_case` vs `camelCase`) for
      the area being modified.

### Dependencies
- [x] No new third-party dependencies, **or** the team has been notified and
      OSRB tickets filed.
