### PR TITLE
Bump CUDA-Q commit (with non-trivial updates)

### DIFF
--- a/.cudaq_version
+++ b/.cudaq_version
@@ -1,6 +1,6 @@
 {
   "cudaq": {
     "repository": "NVIDIA/cuda-quantum",
-    "ref": "d201ab9674daa88d72f8603a35776cdacb192ef6"
+    "ref": "0be565550f4c23affdcbed9e4eaec38d2d0915e6"
   }
 }

--- a/cmake/Modules/CUDA-QX.cmake
+++ b/cmake/Modules/CUDA-QX.cmake
@@ -125,7 +125,7 @@ function(_cudaqx_import_nvqir_target target_name library_name)
     set_target_properties(${target_name} PROPERTIES
       IMPORTED_LOCATION "${CUDAQ_LIBRARY_DIR}/${library_name}${CMAKE_SHARED_LIBRARY_SUFFIX}"
       IMPORTED_SONAME "${library_name}${CMAKE_SHARED_LIBRARY_SUFFIX}"
-      IMPORTED_LINK_INTERFACE_LIBRARIES "cudaq::cudaq-platform-default;cudaq::cudaq-em-default")
+      IMPORTED_LINK_INTERFACE_LIBRARIES "cudaq::cudaq-platform-default;cudaq::cudaq-em-default;cudaq::cudaq-mlir-runtime")
   endif()
 endfunction()
 

--- a/libs/qec/python/CMakeLists.txt
+++ b/libs/qec/python/CMakeLists.txt
@@ -43,6 +43,7 @@ target_link_libraries(${MODULE_NAME}
     cudaq-qec
     cudaq-qec-realtime-decoding
     cudaq::cudaq-python-interop
+    cudaq::cudaq-mlir-runtime
 )
 
 find_package(CUDAToolkit REQUIRED)

--- a/libs/qec/unittests/decoders/realtime/test_realtime_decoding.cu
+++ b/libs/qec/unittests/decoders/realtime/test_realtime_decoding.cu
@@ -599,7 +599,8 @@ TEST_F(RealtimeDecodingTest, DispatchKernelAllShotsGraphLaunch) {
   cudaError_t create_err = cudaq_create_dispatch_graph_regular(
       rx_flags_, tx_flags_, rx_data_, tx_data_, slot_size_, slot_size_,
       d_function_entries_, func_count_, d_graph_io_ctx_, d_shutdown_flag_,
-      d_stats_, num_slots_, 1, 32, dispatch_stream, &dispatch_ctx);
+      d_stats_, num_slots_, 1, 32, /*triggered_graph_exec=*/nullptr,
+      dispatch_stream, &dispatch_ctx);
 
   if (create_err != cudaSuccess) {
     cudaStreamDestroy(dispatch_stream);


### PR DESCRIPTION
Includes updates required due to https://github.com/NVIDIA/cuda-quantum/pull/4699 and https://github.com/NVIDIA/cuda-quantum/pull/4783