### PR TITLE
Guard deprecated TRT FP16 builder API behind NV_TENSORRT_MAJOR < 11

### DIFF
--- a/libs/qec/lib/realtime/ai_decoder_service.cu
+++ b/libs/qec/lib/realtime/ai_decoder_service.cu
@@ -325,9 +325,10 @@ void ai_decoder_service::build_engine_from_onnx(
   // network ignores BuilderFlag::kFP16/kBF16/kFP8/kINT8 and builds per
   // the dtypes declared in the ONNX.
   if (!strongly_typed) {
-    // platformHasFastFp16 and BuilderFlag::kFP16 are deprecated in TRT
-    // 10.x in favor of strongly-typed networks; the hint is still
-    // supported and is what we want for unquantized FP32/FP16 ONNX.
+    // platformHasFastFp16 and BuilderFlag::kFP16 were deprecated in TRT
+    // 10.x and removed in TRT 11.x in favor of strongly-typed networks.
+    // For TRT < 11, the hint is still useful for unquantized FP32/FP16 ONNX.
+#if NV_TENSORRT_MAJOR < 11
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
     if (builder->platformHasFastFp16()) {
@@ -338,6 +339,7 @@ void ai_decoder_service::build_engine_from_onnx(
                   "Using FP32.\n");
     }
 #pragma GCC diagnostic pop
+#endif
   }
 
   auto parser = std::unique_ptr<nvonnxparser::IParser>(


### PR DESCRIPTION
## Description

platformHasFastFp16() and BuilderFlag::kFP16 were removed in TRT 11.x. Guard the weakly-typed FP16 precision hint block so it only compiles on TRT < 11; TRT 11+ users rely on strongly-typed networks instead.

## Runtime / performance impact

N/A

## Self-review checklist

Please confirm each item before requesting review. Check `[x]` or strike
through and explain.

### Before requesting review
- [x] I reviewed my own full diff in GitHub or my editor.
- [x] PR is in Draft if it is not yet ready for review.
- [x] Temporary / debugging changes have been removed.
- [x] Local test logs reviewed; no unexplained warnings or errors.
- [x] CI logs reviewed; no unexplained warnings or errors.
- [x] Full CI has been run.

### Scope and size
- [x] PR is under ~1000 lines, or an exception is justified in the description.
- [x] Refactoring-only changes are isolated in their own PR(s).
- [x] No existing tests were disabled or modified just to make this PR pass
      (if so, an issue has been raised).

### Tests
- [x] New functionality has new tests.
- [x] Tests fail if the new functionality is broken (including crashes), not
      just when it is missing.
- [x] Negative tests added where exceptions are expected.
- [x] Truth data added where simple `EXPECT_*` / `assert` checks are
      insufficient for algorithmic correctness.
- [x] CI runtime impact considered; team notified if significant.

### Documentation
- [x] Public-facing APIs have Doxygen docs.
- [x] User-visible behavior changes have public docs, or a follow-up is
      tracked.

### Code style
- [x] Naming follows the existing convention (`snake_case` vs `camelCase`) for
      the area being modified.

### Dependencies
- [x] No new third-party dependencies, **or** the team has been notified and
      OSRB tickets filed.
