### PR TITLE
Stabilizer round kernels in Python no longer fail when return type annotation is incorrect

### DIFF
--- a/docs/sphinx/components/qec/introduction.rst
+++ b/docs/sphinx/components/qec/introduction.rst
@@ -264,6 +264,11 @@ to prototype and develop new codes.
       :start-after: [Begin Documentation2]
       :end-before: [End Documentation2]
 
+   .. note::
+
+      The kernel registered for :code:`stabilizer_round` must be annotated to
+      return :code:`list[cudaq.measure_handle]`. 
+
 3. **Implement the Code Class**:
 
    Create a class decorated with :code:`@qec.code` that implements the required interface:

--- a/docs/sphinx/examples/qec/python/custom_repetition_code_fine_grain_noise.py
+++ b/docs/sphinx/examples/qec/python/custom_repetition_code_fine_grain_noise.py
@@ -45,7 +45,7 @@ def prep1(logicalQubit: patch):
 
 
 @cudaq.kernel
-def stabilizer_round(logicalQubit: patch) -> list[bool]:
+def stabilizer_round(logicalQubit: patch) -> list[cudaq.measure_handle]:
     # Run one round of stabilizer measurements for the Z-type repetition code
 
     num_ancilla = len(logicalQubit.ancz)

--- a/docs/sphinx/examples/qec/python/my_steane.py
+++ b/docs/sphinx/examples/qec/python/my_steane.py
@@ -24,7 +24,7 @@ def prep0(logicalQubit: patch):
 
 @cudaq.kernel
 def stabilizer(logicalQubit: patch, x_stabilizers: list[int],
-               z_stabilizers: list[int]) -> list[bool]:
+               z_stabilizers: list[int]) -> list[cudaq.measure_handle]:
     # Measure X stabilizers
     h(logicalQubit.ancx)
     for xi in range(len(logicalQubit.ancx)):

--- a/libs/qec/python/bindings/py_code.cpp
+++ b/libs/qec/python/bindings/py_code.cpp
@@ -141,6 +141,28 @@ public:
 
       // Make sure we cast the function pointer correctly
       if (opKeyEnum == operation::stabilizer_round) {
+        // The kernel must return list[cudaq.measure_handle]; a list[bool]
+        // return discriminates measurements to bits and drops the record
+        // indices that cudaq.detector needs. Validate the lowered return type.
+        nb::object retTyObj =
+            nb::hasattr(kernel, "return_type") ? kernel.attr("return_type")
+                                               : nb::none();
+        bool returnsHandleVector = false;
+        if (!retTyObj.is_none()) {
+          nb::object cc = nb::module_::import_("cudaq.mlir.dialects").attr("cc");
+          nb::object stdvecTy = cc.attr("StdvecType");
+          if (nb::cast<bool>(stdvecTy.attr("isinstance")(retTyObj))) {
+            nb::object eleTy = stdvecTy.attr("getElementType")(retTyObj);
+            returnsHandleVector = nb::cast<bool>(
+                cc.attr("MeasureHandleType").attr("isinstance")(eleTy));
+          }
+        }
+        if (!returnsHandleVector)
+          throw std::runtime_error(
+              "Invalid stabilizer_round kernel: it must return "
+              "list[cudaq.measure_handle]. Change the kernel's return "
+              "annotation to '-> list[cudaq.measure_handle]'.");
+
         encoding fptr = kernInterop->getDirectKernelCall<qkernel<
             std::vector<measure_result>(patch, const std::vector<std::size_t> &,
                                         const std::vector<std::size_t> &)>>();

--- a/libs/qec/python/bindings/py_code.cpp
+++ b/libs/qec/python/bindings/py_code.cpp
@@ -144,12 +144,13 @@ public:
         // The kernel must return list[cudaq.measure_handle]; a list[bool]
         // return discriminates measurements to bits and drops the record
         // indices that cudaq.detector needs. Validate the lowered return type.
-        nb::object retTyObj =
-            nb::hasattr(kernel, "return_type") ? kernel.attr("return_type")
-                                               : nb::none();
+        nb::object retTyObj = nb::hasattr(kernel, "return_type")
+                                  ? kernel.attr("return_type")
+                                  : nb::none();
         bool returnsHandleVector = false;
         if (!retTyObj.is_none()) {
-          nb::object cc = nb::module_::import_("cudaq.mlir.dialects").attr("cc");
+          nb::object cc =
+              nb::module_::import_("cudaq.mlir.dialects").attr("cc");
           nb::object stdvecTy = cc.attr("StdvecType");
           if (nb::cast<bool>(stdvecTy.attr("isinstance")(retTyObj))) {
             nb::object eleTy = stdvecTy.attr("getElementType")(retTyObj);

--- a/libs/qec/python/cudaq_qec/plugins/codes/example.py
+++ b/libs/qec/python/cudaq_qec/plugins/codes/example.py
@@ -26,7 +26,7 @@ def prep0(logicalQubit: patch):
 
 @cudaq.kernel
 def stabilizer(logicalQubit: patch, x_stabilizers: list[int],
-               z_stabilizers: list[int]) -> list[bool]:
+               z_stabilizers: list[int]) -> list[cudaq.measure_handle]:
     h(logicalQubit.ancx)
     for xi in range(len(logicalQubit.ancx)):
         for di in range(len(logicalQubit.data)):

--- a/libs/qec/python/tests/test_code.py
+++ b/libs/qec/python/tests/test_code.py
@@ -9,6 +9,7 @@ import pytest
 import numpy as np
 import cudaq
 import cudaq_qec as qec
+from cudaq_qec import patch
 
 
 def test_get_code():
@@ -116,35 +117,58 @@ def test_python_code():
     assert not np.any(syndromes)
 
 
-def test_stabilizer_round_invalid_annotation():
-    # A stabilizer_round kernel must return list[cudaq.measure_handle]. A
-    # list[bool] annotation drops the measurement handles, so code
-    # registration must reject it rather than silently miscompile.
-    from cudaq_qec import patch
+# stabilizer_round kernels with invalid (non list[cudaq.measure_handle])
+# return annotations. The bodies are minimal; only the annotation matters.
+@cudaq.kernel
+def _stab_list_bool(q: patch, xs: list[int], zs: list[int]) -> list[bool]:
+    return mz([*q.ancx, *q.ancz])
 
-    @cudaq.kernel
-    def bad_stabilizer(logicalQubit: patch, x_stabilizers: list[int],
-                       z_stabilizers: list[int]) -> list[bool]:
-        h(logicalQubit.ancx)
-        results = mz([*logicalQubit.ancx, *logicalQubit.ancz])
-        reset(logicalQubit.ancx)
-        reset(logicalQubit.ancz)
-        return results
 
-    @qec.code('py-bad-stabilizer-return')
-    class BadStabilizerReturnCode:
+@cudaq.kernel
+def _stab_bool(q: patch, xs: list[int], zs: list[int]) -> bool:
+    return mz(q.ancx[0])
+
+
+@cudaq.kernel
+def _stab_int(q: patch, xs: list[int], zs: list[int]) -> int:
+    return cudaq.to_integer(cudaq.to_bools(mz([*q.ancx, *q.ancz])))
+
+
+@cudaq.kernel
+def _stab_void(q: patch, xs: list[int], zs: list[int]):
+    mz([*q.ancx, *q.ancz])
+
+
+@cudaq.kernel
+def _stab_none(q: patch, xs: list[int], zs: list[int]) -> None:
+    mz([*q.ancx, *q.ancz])
+
+
+@pytest.mark.parametrize("kernel,name", [
+    (_stab_list_bool, 'py-bad-stab-list-bool'),
+    (_stab_bool, 'py-bad-stab-bool'),
+    (_stab_int, 'py-bad-stab-int'),
+    (_stab_void, 'py-bad-stab-void'),
+    (_stab_none, 'py-bad-stab-none'),
+])
+def test_stabilizer_round_invalid_annotation(kernel, name):
+    # A stabilizer_round must return list[cudaq.measure_handle]; any other
+    # annotation drops the measurement handles, so registration must reject it.
+    @qec.code(name)
+    class BadCode:
 
         def __init__(self, **kwargs):
             qec.Code.__init__(self, **kwargs)
             self.stabilizers = [
-                cudaq.SpinOperator.from_word(word) for word in [
+                cudaq.SpinOperator.from_word(w) for w in [
                     "XXXXIII", "IXXIXXI", "IIXXIXX", "ZZZZIII", "IZZIZZI",
                     "IIZZIZZ"
                 ]
             ]
-            self.operation_encodings = {
-                qec.operation.stabilizer_round: bad_stabilizer
-            }
+            self.pauli_observables = [
+                cudaq.SpinOperator.from_word(p) for p in ["IIIIXXX", "IIIIZZZ"]
+            ]
+            self.operation_encodings = {qec.operation.stabilizer_round: kernel}
 
         def get_num_data_qubits(self):
             return 7
@@ -164,8 +188,8 @@ def test_stabilizer_round_invalid_annotation():
         def get_num_z_stabilizers(self):
             return 3
 
-    with pytest.raises(RuntimeError):
-        qec.get_code('py-bad-stabilizer-return')
+    with pytest.raises(RuntimeError, match="list\\[cudaq.measure_handle\\]"):
+        qec.get_code(name)
 
 
 def test_invalid_code():

--- a/libs/qec/python/tests/test_code.py
+++ b/libs/qec/python/tests/test_code.py
@@ -116,6 +116,58 @@ def test_python_code():
     assert not np.any(syndromes)
 
 
+def test_stabilizer_round_invalid_annotation():
+    # A stabilizer_round kernel must return list[cudaq.measure_handle]. A
+    # list[bool] annotation drops the measurement handles, so code
+    # registration must reject it rather than silently miscompile.
+    from cudaq_qec import patch
+
+    @cudaq.kernel
+    def bad_stabilizer(logicalQubit: patch, x_stabilizers: list[int],
+                       z_stabilizers: list[int]) -> list[bool]:
+        h(logicalQubit.ancx)
+        results = mz([*logicalQubit.ancx, *logicalQubit.ancz])
+        reset(logicalQubit.ancx)
+        reset(logicalQubit.ancz)
+        return results
+
+    @qec.code('py-bad-stabilizer-return')
+    class BadStabilizerReturnCode:
+
+        def __init__(self, **kwargs):
+            qec.Code.__init__(self, **kwargs)
+            self.stabilizers = [
+                cudaq.SpinOperator.from_word(word) for word in [
+                    "XXXXIII", "IXXIXXI", "IIXXIXX", "ZZZZIII", "IZZIZZI",
+                    "IIZZIZZ"
+                ]
+            ]
+            self.operation_encodings = {
+                qec.operation.stabilizer_round: bad_stabilizer
+            }
+
+        def get_num_data_qubits(self):
+            return 7
+
+        def get_num_ancilla_x_qubits(self):
+            return 3
+
+        def get_num_ancilla_z_qubits(self):
+            return 3
+
+        def get_num_ancilla_qubits(self):
+            return 6
+
+        def get_num_x_stabilizers(self):
+            return 3
+
+        def get_num_z_stabilizers(self):
+            return 3
+
+    with pytest.raises(RuntimeError):
+        qec.get_code('py-bad-stabilizer-return')
+
+
 def test_invalid_code():
     with pytest.raises(RuntimeError):
         qec.get_code("invalid_code_name")


### PR DESCRIPTION
<!--
Thanks for contributing to CUDA-Q Libraries!

Please read the full Pull Request Guidelines in Contributing.md:
https://github.com/NVIDIA/cudaqx/blob/main/Contributing.md#pull-request-guidelines
-->

## Description

QEC codes defined in Python currently fail when the return type hint for the stabilizer round is not a `list[cudaq.measure_result]`. See this bug reproduction:

```
import cudaq
import cudaq_qec as qec
from cudaq_qec import patch

cudaq.set_target("stim")

NUM_ROUNDS = 3


@cudaq.kernel
def prep0(p: patch):
    pass


@cudaq.kernel
def stabilizer_ok(p: patch, x_stabilizers: list[int],
                   z_stabilizers: list[int]) -> list[cudaq.measure_handle]:
    x.ctrl(p.data[0], p.ancz[0])
    x.ctrl(p.data[1], p.ancz[0])
    res = mz(p.ancz)
    reset(p.ancz)
    return res


@cudaq.kernel
def stabilizer_bug(p: patch, x_stabilizers: list[int],
                   z_stabilizers: list[int]) -> list[bool]:
    x.ctrl(p.data[0], p.ancz[0])
    x.ctrl(p.data[1], p.ancz[0])
    res = mz(p.ancz)
    reset(p.ancz)
    return res


def register_code(name, stabilizer_round):
    @qec.code(name)
    class RepCode:

        def __init__(self, **kwargs):
            qec.Code.__init__(self, **kwargs)
            self.stabilizers = [cudaq.SpinOperator.from_word("ZZ")]
            self.pauli_observables = [cudaq.SpinOperator.from_word("ZI")]
            self.operation_encodings = {
                qec.operation.prep0: prep0,
                qec.operation.stabilizer_round: stabilizer_round,
            }

        def get_num_data_qubits(self):
            return 2

        def get_num_ancilla_x_qubits(self):
            return 0

        def get_num_ancilla_z_qubits(self):
            return 1

        def get_num_ancilla_qubits(self):
            return 1

        def get_num_x_stabilizers(self):
            return 0

        def get_num_z_stabilizers(self):
            return 1

    return qec.get_code(name)


ok_round = register_code("rep-fix", stabilizer_ok).get_stabilizer_round()
bug_round = register_code("rep-bug", stabilizer_bug).get_stabilizer_round()


@cudaq.kernel
def memory_fix():
    data = cudaq.qvector(2)
    ancx = cudaq.qvector(0)
    ancz = cudaq.qvector(1)
    p = patch(data, ancx, ancz)
    x_stabilizers = [0, 0]
    z_stabilizers = [1, 1]
    r0 = ok_round(p, x_stabilizers, z_stabilizers)
    r1 = ok_round(p, x_stabilizers, z_stabilizers)
    r2 = ok_round(p, x_stabilizers, z_stabilizers)
    cudaq.detectors(r0, r1)
    cudaq.detectors(r1, r2)


@cudaq.kernel
def memory_bug():
    data = cudaq.qvector(2)
    ancx = cudaq.qvector(0)
    ancz = cudaq.qvector(1)
    p = patch(data, ancx, ancz)
    x_stabilizers = [0, 0]
    z_stabilizers = [1, 1]
    r0 = bug_round(p, x_stabilizers, z_stabilizers)
    r1 = bug_round(p, x_stabilizers, z_stabilizers)
    r2 = bug_round(p, x_stabilizers, z_stabilizers)
    cudaq.detectors(r0, r1)
    cudaq.detectors(r1, r2)


_, m2d, _ = cudaq.dem_from_kernel(memory_fix, return_measurement_matrices=True)
print("fix m2d shape:", m2d.shape)  # Success

_, m2d, _ = cudaq.dem_from_kernel(memory_bug, return_measurement_matrices=True)
print("bug m2d shape:", m2d.shape)  # Fails: list[bool] return drops the
#                                     measurement handles the detectors need
```

Several of our examples annotate Python codes to return `list[bool]`, which will give unexpected behavior if probed in depth beyond the current unit tests. This can also cause user-defined codes to silently fail. This PR addresses this bug by adding a check to the type annotation which will throw an exception if the type annotation is unexpected, and instruct the user on how to fix it. Marked as breaking since stabilizer round kernels annotated to return bools will now throw an exception.

<!-- What does this PR change, and why? Link related issues. -->

## Runtime / performance impact

<!--
If this change affects performance, paste benchmark numbers here.
Otherwise write "N/A".
-->
N/A

## Self-review checklist

Please confirm each item before requesting review. Check `[x]` or strike
through and explain.

### Before requesting review
- [x] I reviewed my own full diff in GitHub or my editor.
- [x] PR is in Draft if it is not yet ready for review.
- [x] Temporary / debugging changes have been removed.
- [x] Local test logs reviewed; no unexplained warnings or errors.
- [x] CI logs reviewed; no unexplained warnings or errors.
- [x] Full CI has been run.

### Scope and size
- [x] PR is under ~1000 lines, or an exception is justified in the description.
- [x] Refactoring-only changes are isolated in their own PR(s).
- [x] No existing tests were disabled or modified just to make this PR pass
      (if so, an issue has been raised).

### Tests
- [x] New functionality has new tests.
- [x] Tests fail if the new functionality is broken (including crashes), not
      just when it is missing.
- [x] Negative tests added where exceptions are expected.
- [x] Truth data added where simple `EXPECT_*` / `assert` checks are
      insufficient for algorithmic correctness.
- [x] CI runtime impact considered; team notified if significant.

### Documentation
- [x] Public-facing APIs have Doxygen docs.
- [x] User-visible behavior changes have public docs, or a follow-up is
      tracked.

### Code style
- [x] Naming follows the existing convention (`snake_case` vs `camelCase`) for
      the area being modified.

### Dependencies
- [x] No new third-party dependencies, **or** the team has been notified and
      OSRB tickets filed.
