### PR TITLE
Bump CUDA-Q commit and fix for breaking changes

### DIFF
--- a/.cudaq_version
+++ b/.cudaq_version
@@ -1,6 +1,6 @@
 {
   "cudaq": {
     "repository": "NVIDIA/cuda-quantum",
-    "ref": "704938b2492793c461f8141f61465db1d71a2f1a"
+    "ref": "c0a143b3116b65c771048fc3f5bb02894e347bba"
   }
 }

--- a/.cudaq_version
+++ b/.cudaq_version
@@ -1,6 +1,6 @@
 {
   "cudaq": {
     "repository": "NVIDIA/cuda-quantum",
-    "ref": "c0a143b3116b65c771048fc3f5bb02894e347bba"
+    "ref": "8b3f04beefbebd1294209b90c4a3b42b7e03ee03"
   }
 }

--- a/.cudaq_version
+++ b/.cudaq_version
@@ -1,6 +1,6 @@
 {
   "cudaq": {
     "repository": "NVIDIA/cuda-quantum",
-    "ref": "102e8acf324e3a8e714015fd7bb250e1720f60d8"
+    "ref": "704938b2492793c461f8141f61465db1d71a2f1a"
   }
 }

--- a/.cudaq_version
+++ b/.cudaq_version
@@ -1,6 +1,6 @@
 {
   "cudaq": {
     "repository": "NVIDIA/cuda-quantum",
-    "ref": "8b3f04beefbebd1294209b90c4a3b42b7e03ee03"
+    "ref": "5439aff2c851a1b06ced9f24cdec7b5bfc3273ac"
   }
 }

--- a/.cudaq_version
+++ b/.cudaq_version
@@ -1,6 +1,6 @@
 {
   "cudaq": {
     "repository": "NVIDIA/cuda-quantum",
-    "ref": "3b20c9669c10d6e9bc0fe1758757f5240c588faa"
+    "ref": "102e8acf324e3a8e714015fd7bb250e1720f60d8"
   }
 }

--- a/libs/qec/lib/realtime/CMakeLists.txt
+++ b/libs/qec/lib/realtime/CMakeLists.txt
@@ -245,8 +245,24 @@ install(TARGETS cudaq-qec-realtime-decoding
 # ---------------------------------------------------------------------------
 # RealtimePipeline shared library
 # Requires pre-installed cudaq-realtime (set CUDAQ_REALTIME_ROOT)
+#
+# EXPERIMENTAL / temporarily disabled: realtime_pipeline.cu relies on host
+# dispatch API surface (skip_stream_sweep, caller-owned worker streams, and
+# per-worker pre/post-launch hooks) that was removed upstream in CUDA-Q PR4770
+# ("Split graph launch dispatch from the host ring loop").  Until it is ported
+# to the new graph_launch_engine API, keep this target off by default so CI
+# builds green.  Dependent unit tests (test_realtime_pipeline,
+# test_realtime_predecoder_w_pymatching, hololink bridge) auto-skip when this
+# target does not exist.
 # ---------------------------------------------------------------------------
-if(CMAKE_CUDA_COMPILER AND CUDAQ_REALTIME_INCLUDE_DIR)
+option(CUDAQX_QEC_ENABLE_REALTIME_PIPELINE
+  "Build the experimental cudaq-realtime-pipeline library (needs porting to \
+the post-PR4770 CUDA-Q graph_launch_engine API)" OFF)
+
+if(NOT CUDAQX_QEC_ENABLE_REALTIME_PIPELINE)
+  message(STATUS "RealtimePipeline: skipping (experimental; disabled by "
+                 "default -- set CUDAQX_QEC_ENABLE_REALTIME_PIPELINE=ON to build)")
+elseif(CMAKE_CUDA_COMPILER AND CUDAQ_REALTIME_INCLUDE_DIR)
     cudaq_qec_find_realtime_library(_CUDAQ_RT_LIB
       NAMES cudaq-realtime
       PATH_SUFFIXES lib

--- a/libs/qec/lib/realtime/qec_realtime_session.cpp
+++ b/libs/qec/lib/realtime/qec_realtime_session.cpp
@@ -440,7 +440,9 @@ void qec_realtime_session::finalize() {
   }
 
   std::memset(&ringbuffer_, 0, sizeof(ringbuffer_));
-  std::memset(&host_ctx_, 0, sizeof(host_ctx_));
+  std::memset(&host_table_, 0, sizeof(host_table_));
+  std::memset(&host_config_, 0, sizeof(host_config_));
+  host_engine_ = nullptr;
 
   if (was_initialized)
     CUDA_QEC_INFO("qec_realtime_session: finalized");
@@ -820,43 +822,42 @@ void qec_realtime_session::start_device_loop() {
 
 void qec_realtime_session::start_host_loop() {
   if (!device_mode_) {
-    // HOST mode: inline HOST_CALL handlers, no graph worker pool.
-    std::memset(&host_ctx_, 0, sizeof(host_ctx_));
-    host_ctx_.ringbuffer = ringbuffer_;
-    host_ctx_.config.num_slots = static_cast<std::uint32_t>(num_slots_);
-    host_ctx_.config.slot_size = static_cast<std::uint32_t>(slot_size_);
-    host_ctx_.config.dispatch_path = CUDAQ_DISPATCH_PATH_HOST;
-    host_ctx_.config.dispatch_mode = CUDAQ_DISPATCH_HOST_CALL;
-    host_ctx_.config.skip_tx_markers = 1;
+    // HOST mode: inline HOST_CALL handlers, no graph worker pool.  Every table
+    // entry is HOST_CALL, so cudaq_graph_launch_engine_create() would build no
+    // workers -- we skip it entirely and drive the ring loop with a NULL
+    // engine (the loop runs HOST_CALL handlers inline).
+    std::memset(&host_config_, 0, sizeof(host_config_));
+    host_config_.num_slots = static_cast<std::uint32_t>(num_slots_);
+    host_config_.slot_size = static_cast<std::uint32_t>(slot_size_);
+    host_config_.dispatch_path = CUDAQ_DISPATCH_PATH_HOST;
+    host_config_.dispatch_mode = CUDAQ_DISPATCH_HOST_CALL;
+    host_config_.skip_tx_markers = 1;
     // shared_ring_mode lets the loop scan the whole ring for a non-zero
     // rx_flag instead of sitting on a single advancing cursor.  The producer's
     // acquire_slot() reuses the first free slot (slot 0 for serialized
     // round-trips), so without ring-scanning the loop's cursor would advance
     // past the reused slot and deadlock.  There is no second dispatcher here;
     // we only want the scan behavior.
-    host_ctx_.config.shared_ring_mode = 1;
-    host_ctx_.function_table.entries = function_table_host_;
-    host_ctx_.function_table.count =
-        static_cast<std::uint32_t>(function_table_count_);
-    host_ctx_.shutdown_flag = &shutdown_flag_;
-    host_ctx_.stats_counter = &host_stats_counter_;
-    host_ctx_.skip_stream_sweep = true;
+    host_config_.shared_ring_mode = 1;
+    host_table_.entries = function_table_host_;
+    host_table_.count = static_cast<std::uint32_t>(function_table_count_);
+    host_engine_ = nullptr;
     shutdown_flag_ = 0;
 
-    host_loop_thread_ =
-        std::thread([this]() { cudaq_host_dispatcher_loop(&host_ctx_); });
+    host_loop_thread_ = std::thread([this]() {
+      cudaq_host_ring_dispatch_loop(&ringbuffer_, &host_table_, &host_config_,
+                                    /*engine=*/nullptr, &shutdown_flag_,
+                                    &host_stats_counter_);
+    });
     return;
   }
 
-  // DEVICE mode: one graph worker per captured decoder.
-  host_workers_.assign(num_decoders_with_graph_,
-                       cudaq_host_dispatch_worker_t{});
-  // host_worker_streams_ is indexed by *source* decoder_id (sparse), not packed
-  // worker slot, because callers pass decoder_id.
-  host_worker_streams_.assign(decoders_.size(),
-                              static_cast<cudaStream_t>(nullptr));
+  // DEVICE mode: the GRAPH_LAUNCH engine builds one worker per GRAPH_LAUNCH
+  // entry in the function table (created earlier with graph_exec / function_id
+  // / routing_key already populated) and owns the worker streams, idle mask,
+  // inflight-slot tags, and per-worker GraphIOContext array.
 
-  // The host_dispatcher.h public ctx exposes a SINGLE mailbox bank per ctx.
+  // cudaq_graph_launch_engine_create takes a SINGLE external mailbox bank.
   // Demo 1's scope is one decoder per session, so the single-bank limitation
   // is fine -- the lone worker dispatches every enqueue RPC.
   if (num_decoders_with_graph_ > 1)
@@ -864,95 +865,50 @@ void qec_realtime_session::start_host_loop() {
         "qec_realtime_session::initialize: multi-decoder host dispatch is not "
         "yet supported (num_decoders_with_graph=" +
         std::to_string(num_decoders_with_graph_) +
-        ").  libcudaq-realtime's host dispatcher exposes a single h_mailbox_"
-        "bank per loop ctx; Demo 1 is scoped to one decoder.");
+        ").  The GRAPH_LAUNCH engine accepts a single external h_mailbox_bank; "
+        "Demo 1 is scoped to one decoder.");
 
+  // The lone captured decoder's pinned mailbox is the engine's external bank.
   void **mailbox_bank = nullptr;
-
-  std::size_t slot = 0;
   for (std::size_t i = 0; i < decoders_.size(); ++i) {
     if (!captured_graphs_[i])
       continue;
     auto *gres = static_cast<cudaq::qec::realtime::graph_resources *>(
         captured_graphs_[i]);
-
-    cudaStream_t stream = nullptr;
-    if (cudaStreamCreate(&stream) != cudaSuccess)
-      throw std::runtime_error(
-          "qec_realtime_session::initialize: cudaStreamCreate for HOST_LOOP "
-          "worker " +
-          std::to_string(slot) + " (decoder_id=" + std::to_string(i) +
-          ") failed");
-    host_worker_streams_[i] = stream;
-
-    auto &w = host_workers_[slot];
-    w.graph_exec = gres->graph_exec;
-    w.stream = stream;
-    w.function_id = cudaq::qec::decoding::rpc::kEnqueueSyndromesFunctionId;
-    w.routing_key = static_cast<std::uint64_t>(i);
-    w.pre_launch_fn = nullptr;
-    w.pre_launch_data = nullptr;
-    w.post_launch_fn = nullptr;
-    w.post_launch_data = nullptr;
-
-    if (slot == 0)
-      mailbox_bank = gres->h_mailbox;
-    ++slot;
+    mailbox_bank = gres->h_mailbox;
+    break;
   }
 
-  host_idle_mask_storage_ = new std::uint64_t(
-      num_decoders_with_graph_ < 64
-          ? ((std::uint64_t{1} << num_decoders_with_graph_) - 1)
-          : ~std::uint64_t{0});
-  host_live_dispatched_storage_ = new std::uint64_t(0);
-  host_inflight_slot_tags_ = new int[num_decoders_with_graph_];
-  for (std::size_t i = 0; i < num_decoders_with_graph_; ++i)
-    host_inflight_slot_tags_[i] = -1;
-
-  // Per-worker GraphIOContext array (pinned-mapped so both CPU monitor and GPU
-  // graph see the same backing).
-  {
-    void *h = nullptr;
-    void *d = nullptr;
-    const std::size_t bytes =
-        num_decoders_with_graph_ * sizeof(cudaq::realtime::GraphIOContext);
-    if (!allocate_pinned_mapped(bytes, &h, &d))
-      throw std::runtime_error("qec_realtime_session::start_host_loop: failed "
-                               "to allocate per-worker "
-                               "GraphIOContext array");
-    std::memset(h, 0, bytes);
-    io_ctxs_host_ = static_cast<cudaq::realtime::GraphIOContext *>(h);
-    io_ctxs_dev_ = static_cast<cudaq::realtime::GraphIOContext *>(d);
-  }
-
-  std::memset(&host_ctx_, 0, sizeof(host_ctx_));
-  host_ctx_.ringbuffer = ringbuffer_;
-  host_ctx_.config.num_slots = static_cast<std::uint32_t>(num_slots_);
-  host_ctx_.config.slot_size = static_cast<std::uint32_t>(slot_size_);
-  host_ctx_.config.shared_ring_mode = 1;
-  host_ctx_.config.skip_tx_markers = 1;
+  std::memset(&host_config_, 0, sizeof(host_config_));
+  host_config_.num_slots = static_cast<std::uint32_t>(num_slots_);
+  host_config_.slot_size = static_cast<std::uint32_t>(slot_size_);
+  host_config_.shared_ring_mode = 1;
+  host_config_.skip_tx_markers = 1;
   // The host loop dereferences these entries on the CPU, so it must use the
   // host view of the (pinned-mapped) table.  Under UVA the host and device
   // addresses are equal, but the host pointer is the correct/portable choice;
   // the device dispatcher separately receives function_table_dev_ via
   // cudaq_dispatcher_set_function_table().
-  host_ctx_.function_table.entries = function_table_host_;
-  host_ctx_.function_table.count =
-      static_cast<std::uint32_t>(function_table_count_);
-  host_ctx_.workers = host_workers_.data();
-  host_ctx_.num_workers = host_workers_.size();
-  host_ctx_.h_mailbox_bank = mailbox_bank;
-  host_ctx_.shutdown_flag = shutdown_flag_host_;
-  host_ctx_.stats_counter = &host_stats_counter_;
-  host_ctx_.live_dispatched = host_live_dispatched_storage_;
-  host_ctx_.idle_mask = host_idle_mask_storage_;
-  host_ctx_.inflight_slot_tags = host_inflight_slot_tags_;
-  host_ctx_.io_ctxs_host = io_ctxs_host_;
-  host_ctx_.io_ctxs_dev = io_ctxs_dev_;
-  host_ctx_.skip_stream_sweep = false;
+  host_table_.entries = function_table_host_;
+  host_table_.count = static_cast<std::uint32_t>(function_table_count_);
 
-  host_loop_thread_ =
-      std::thread([this]() { cudaq_host_dispatcher_loop(&host_ctx_); });
+  // The engine reads graph_exec / function_id / routing_key from the
+  // GRAPH_LAUNCH table entries and allocates its own worker streams + a
+  // GraphIOContext array (the latter only when rx_data != tx_data).
+  cudaq_status_t engine_st = CUDAQ_OK;
+  host_engine_ = cudaq_graph_launch_engine_create(
+      &ringbuffer_, &host_table_, &host_config_, mailbox_bank, &engine_st);
+  if (engine_st != CUDAQ_OK || !host_engine_)
+    throw std::runtime_error(
+        "qec_realtime_session::start_host_loop: "
+        "cudaq_graph_launch_engine_create failed (status=" +
+        std::to_string(static_cast<int>(engine_st)) + ")");
+
+  host_loop_thread_ = std::thread([this]() {
+    cudaq_host_ring_dispatch_loop(&ringbuffer_, &host_table_, &host_config_,
+                                  host_engine_, shutdown_flag_host_,
+                                  &host_stats_counter_);
+  });
 }
 
 //==============================================================================
@@ -985,24 +941,11 @@ void qec_realtime_session::stop_loops() {
     device_manager_ = nullptr;
   }
 
-  for (auto s : host_worker_streams_) {
-    if (s)
-      cudaStreamDestroy(s);
-  }
-  host_worker_streams_.clear();
-  host_workers_.clear();
-
-  delete host_idle_mask_storage_;
-  host_idle_mask_storage_ = nullptr;
-  delete host_live_dispatched_storage_;
-  host_live_dispatched_storage_ = nullptr;
-  delete[] host_inflight_slot_tags_;
-  host_inflight_slot_tags_ = nullptr;
-
-  if (io_ctxs_host_) {
-    cudaFreeHost(io_ctxs_host_);
-    io_ctxs_host_ = nullptr;
-    io_ctxs_dev_ = nullptr;
+  // The engine owns the worker streams, idle mask, inflight-slot tags, and
+  // GraphIOContext array; destroy it after the driving loop has stopped.
+  if (host_engine_) {
+    cudaq_graph_launch_engine_destroy(host_engine_);
+    host_engine_ = nullptr;
   }
 }
 

--- a/libs/qec/lib/realtime/qec_realtime_session.h
+++ b/libs/qec/lib/realtime/qec_realtime_session.h
@@ -13,7 +13,7 @@
 #include "cudaq/qec/decoder.h"
 #include "cudaq/realtime/daemon/dispatcher/cudaq_realtime.h"
 #include "cudaq/realtime/daemon/dispatcher/dispatch_kernel_launch.h"
-#include "cudaq/realtime/daemon/dispatcher/host_dispatcher.h"
+#include "cudaq/realtime/daemon/dispatcher/graph_launch_engine.h"
 
 #include <cstdint>
 #include <memory>
@@ -127,12 +127,11 @@ public:
   std::size_t slot_size() const { return slot_size_; }
 
   /// @brief (DEVICE mode) CUDA stream backing the HOST_LOOP worker for the
-  /// decoder at index `decoder_id`.  Returns nullptr in HOST mode, out of
-  /// range, or for a decoder that did not capture a graph.
-  cudaStream_t host_worker_stream(std::size_t decoder_id) const {
-    return decoder_id < host_worker_streams_.size()
-               ? host_worker_streams_[decoder_id]
-               : nullptr;
+  /// decoder at index `decoder_id`.  Since PR4770 the GRAPH_LAUNCH engine owns
+  /// (and hides) the per-worker streams, so this is no longer externally
+  /// observable; retained for API compatibility, always returns nullptr.
+  cudaStream_t host_worker_stream(std::size_t /*decoder_id*/) const {
+    return nullptr;
   }
 
   /// @brief (DEVICE mode) Number of decoders that captured a CUDA graph.
@@ -206,21 +205,18 @@ private:
   int *shutdown_flag_dev_ = nullptr;
 
   // ---- HOST_LOOP wiring (both modes) ----
-  cudaq_host_dispatch_loop_ctx_t host_ctx_{};
+  // The GRAPH_LAUNCH engine (DEVICE mode) owns the worker streams, idle mask,
+  // inflight-slot tags, and per-worker GraphIOContext array.  It is built from
+  // the GRAPH_LAUNCH entries of `function_table_host_` and is NULL in HOST mode
+  // (all-HOST_CALL table -> no graph workers).
+  cudaq_function_table_t host_table_{};
+  cudaq_dispatcher_config_t host_config_{};
+  cudaq_graph_launch_engine_t *host_engine_ = nullptr;
   std::thread host_loop_thread_;
   std::uint64_t host_stats_counter_ = 0;
   // Plain (non-pinned) shutdown flag for HOST mode (no device kernel shares
   // it).
   int shutdown_flag_ = 0;
-
-  // ---- DEVICE-mode HOST_LOOP graph workers ----
-  std::vector<cudaq_host_dispatch_worker_t> host_workers_;
-  std::vector<cudaStream_t> host_worker_streams_;
-  std::uint64_t *host_idle_mask_storage_ = nullptr;
-  std::uint64_t *host_live_dispatched_storage_ = nullptr;
-  int *host_inflight_slot_tags_ = nullptr;
-  cudaq::realtime::GraphIOContext *io_ctxs_host_ = nullptr;
-  cudaq::realtime::GraphIOContext *io_ctxs_dev_ = nullptr;
 
   // ---- Graph state (DEVICE mode only) ----
   std::vector<void *> captured_graphs_;

--- a/libs/qec/lib/realtime/qec_realtime_session.h
+++ b/libs/qec/lib/realtime/qec_realtime_session.h
@@ -149,14 +149,6 @@ public:
   std::size_t producer_cursor() const { return producer_cursor_; }
   void set_producer_cursor(std::size_t slot) { producer_cursor_ = slot; }
 
-  /// @brief (DEVICE mode) CUDA stream backing the HOST_LOOP worker for the
-  /// decoder at index `decoder_id`.  Since PR4770 the GRAPH_LAUNCH engine owns
-  /// (and hides) the per-worker streams, so this is no longer externally
-  /// observable; retained for API compatibility, always returns nullptr.
-  cudaStream_t host_worker_stream(std::size_t /*decoder_id*/) const {
-    return nullptr;
-  }
-
   /// @brief (DEVICE mode) Number of decoders that captured a CUDA graph.
   std::size_t num_decoders_with_graph() const {
     return num_decoders_with_graph_;

--- a/libs/qec/unittests/CMakeLists.txt
+++ b/libs/qec/unittests/CMakeLists.txt
@@ -353,7 +353,8 @@ if(CUDAQ_REALTIME_ROOT AND CMAKE_CUDA_COMPILER)
       PATHS ${TENSORRT_ROOT}/lib /usr/lib/x86_64-linux-gnu /usr/lib/aarch64-linux-gnu /usr/local/cuda/lib64 /usr/local/tensorrt/lib /opt/tensorrt/lib
     )
 
-    if(TENSORRT_INCLUDE_DIR_FOR_PIPELINE AND TENSORRT_LIBRARY_FOR_PIPELINE AND TENSORRT_ONNX_PARSER_FOR_PIPELINE)
+    if(TENSORRT_INCLUDE_DIR_FOR_PIPELINE AND TENSORRT_LIBRARY_FOR_PIPELINE AND TENSORRT_ONNX_PARSER_FOR_PIPELINE
+       AND TARGET cudaq-realtime-pipeline)
       get_filename_component(_cuda_bin_pipe "${CMAKE_CUDA_COMPILER}" DIRECTORY)
       get_filename_component(_cuda_root_pipe "${_cuda_bin_pipe}" DIRECTORY)
       set(_cuda_cccl_include_pipe "${_cuda_root_pipe}/include/cccl")

--- a/libs/qec/unittests/realtime/test_realtime_predecoder_w_pymatching.cpp
+++ b/libs/qec/unittests/realtime/test_realtime_predecoder_w_pymatching.cpp
@@ -32,7 +32,7 @@
 #include <unistd.h>
 
 #include "cudaq/qec/realtime/ai_decoder_service.h"
-#include "cudaq/realtime/daemon/dispatcher/host_dispatcher.h"
+#include "cudaq/realtime/daemon/dispatcher/graph_launch_engine.h"
 
 #define CUDA_CHECK(call)                                                       \
   do {                                                                         \


### PR DESCRIPTION
Ref: https://github.com/NVIDIA/cuda-quantum/pull/4770

Migrate qec_realtime_session to the new engine API:
  - DEVICE mode builds a cudaq_graph_launch_engine_t from the GRAPH_LAUNCH entries of the function table (which already carry graph_exec / function_id / routing_key). The engine now owns the worker streams, idle mask, inflight-slot tags, and per-worker GraphIOContext array, so the hand-rolled worker/stream/mask/io-ctx setup is gone. The lone captured decoder's pinned mailbox is passed as the engine's external mailbox bank.
  - HOST mode drives cudaq_host_ring_dispatch_loop with a NULL engine (all entries are HOST_CALL), preserving the shared-ring scan behavior.
  - Teardown destroys the engine after the loop thread is joined. Semantics are preserved: DEVICE mode already used auto-sweep, and QEC always uses separate RX/TX ring buffers so the engine takes the same GraphIOContext path as before.

Disable the experimental cudaq-realtime-pipeline target by default (new CUDAQX_QEC_ENABLE_REALTIME_PIPELINE option, OFF). realtime_pipeline.cu depends on host-dispatch API surface PR4770 dropped (skip_stream_sweep, caller-owned worker streams, per-worker pre/post-launch hooks) and needs a separate port. Dependent unit tests auto-skip when the target does not exist.