### PR TITLE
Remove CUDAQ Deps: Additional server cmake closure tests

### DIFF
--- a/libs/qec/unittests/CMakeLists.txt
+++ b/libs/qec/unittests/CMakeLists.txt
@@ -662,6 +662,99 @@ if(TARGET cudaq-qec-decoders AND TARGET cudaq-qec-realtime-decoding)
 endif()
 
 # ==============================================================================
+# Architectural guardrail: the realtime decoding server deliverables must stay
+# free of the *heavy* CUDA-Q runtime: the core runtime (libcudaq), the simulator
+# dispatch (libnvqir), the QEC umbrella library (libcudaq-qec), and the MLIR JIT
+# runtime (libcudaq-mlir-runtime).  Pulling any of those back in would drag the
+# whole CUDA-Q execution stack (quantum_platform, execution manager, JIT
+# compiler) into the server package.
+#
+# Covered here (each only when built):
+#   - cudaq-qec-realtime-decoding-server-cqr / -simulation-cqr (the cudaq-realtime
+#     host-dispatch server + simulated-QPU client; built only when the cudaq
+#     device_call service is available)
+#
+# Unlike the decoder/realtime closure check above, the server libraries DO
+# legitimately depend on libcudaq-common / libcudaq-operator (they provide the
+# nvq++ kernel-registration symbols baked into the device code) and on the
+# allowed libcudaq-realtime, so those are intentionally NOT forbidden here.  This
+# guardrail is created whenever a server target is built.
+# ==============================================================================
+# Candidate server targets, each guarded so the check adapts to what was built.
+set(_srv_closure_targets "")
+foreach(_t IN ITEMS
+    cudaq-qec-realtime-decoding-server-cqr
+    cudaq-qec-realtime-decoding-simulation-cqr
+    )
+  if(TARGET ${_t})
+    list(APPEND _srv_closure_targets ${_t})
+  endif()
+endforeach()
+
+if(_srv_closure_targets)
+  if(NOT DEFINED _dep_closure_script)
+    set(_dep_closure_script
+      "${CMAKE_CURRENT_SOURCE_DIR}/check_dependency_closure.cmake")
+  endif()
+
+  # Heavy CUDA-Q runtime roots the server must never acquire.  Matching is
+  # anchored (^<stem>\.so), so "libcudaq" flags libcudaq.so but never
+  # libcudaq-common.so / libcudaq-realtime.so / libcudaq-qec-decoders.so,
+  # "libcudaq-qec" flags libcudaq-qec.so but never libcudaq-qec-decoders.so, and
+  # "libcustabilizer" flags libcustabilizer.so.0 (cuStabilizer, pulled only by
+  # libcudaq-qec).
+  set(_srv_closure_forbidden
+    "libcudaq-qec|libcudaq|libnvqir|libcudaq-mlir-runtime|libcustabilizer")
+
+  set(_srv_closure_libs "")
+  foreach(_t IN LISTS _srv_closure_targets)
+    if(_srv_closure_libs)
+      string(APPEND _srv_closure_libs "|")
+    endif()
+    string(APPEND _srv_closure_libs "$<TARGET_FILE:${_t}>")
+  endforeach()
+
+  # Search path for the transitive soname walk: build tree first, then the
+  # CUDA-Q install and realtime prefixes so intentionally-allowed deps
+  # (common/operator/realtime) resolve and their subtrees are inspected too.
+  # The server libraries only DT_NEEDED libs in lib/ (decoder plugins are
+  # dlopen'd, never linked), so lib/decoder-plugins is not needed here.
+  set(_srv_closure_search "${CMAKE_BINARY_DIR}/lib")
+  if(DEFINED CUDAQ_INSTALL_DIR AND CUDAQ_INSTALL_DIR)
+    string(APPEND _srv_closure_search "|${CUDAQ_INSTALL_DIR}/lib")
+  endif()
+  if(DEFINED CUDAQ_REALTIME_ROOT AND CUDAQ_REALTIME_ROOT)
+    string(APPEND _srv_closure_search "|${CUDAQ_REALTIME_ROOT}/lib")
+  endif()
+
+  add_dependencies(CUDAQXQECUnitTests ${_srv_closure_targets})
+
+  add_test(NAME qec_realtime_server_dependency_closure
+    COMMAND ${CMAKE_COMMAND}
+      "-DLIBS=${_srv_closure_libs}"
+      "-DFORBIDDEN=${_srv_closure_forbidden}"
+      "-DTRANSITIVE=ON"
+      "-DEXTRA_SEARCH_DIRS=${_srv_closure_search}"
+      -P "${_dep_closure_script}")
+  set_tests_properties(qec_realtime_server_dependency_closure
+    PROPERTIES LABELS "qec")
+
+  # Negative self-test: the server libraries DO legitimately depend on
+  # libcudaq-common, so forbidding it MUST fire.  This proves the guardrail is
+  # actually inspecting the server closure (and not silently passing).
+  add_test(NAME qec_realtime_server_dependency_closure_selftest
+    COMMAND ${CMAKE_COMMAND}
+      "-DLIBS=${_srv_closure_libs}"
+      "-DFORBIDDEN=libcudaq-common"
+      "-DTRANSITIVE=ON"
+      "-DEXTRA_SEARCH_DIRS=${_srv_closure_search}"
+      "-DEXPECT_FAIL=ON"
+      -P "${_dep_closure_script}")
+  set_tests_properties(qec_realtime_server_dependency_closure_selftest
+    PROPERTIES LABELS "qec")
+endif()
+
+# ==============================================================================
 
 add_subdirectory(backend-specific)
 add_subdirectory(realtime)


### PR DESCRIPTION
## Description

Additional cmake dependency closure test missing in [PR#645](https://github.com/NVIDIA/cudaqx/pull/645)

## Runtime / performance impact
N/A

## Self-review checklist

Please confirm each item before requesting review. Check `[x]` or strike
through and explain.

### Before requesting review
- [x] I reviewed my own full diff in GitHub or my editor.
- [x] PR is in Draft if it is not yet ready for review.
- [x] Temporary / debugging changes have been removed.
- [x] Local test logs reviewed; no unexplained warnings or errors.
- [x] CI logs reviewed; no unexplained warnings or errors.
- [x] Full CI has been run.

### Scope and size
- [x] PR is under ~1000 lines, or an exception is justified in the description.
- [x] Refactoring-only changes are isolated in their own PR(s).
- [x] No existing tests were disabled or modified just to make this PR pass
      (if so, an issue has been raised).

### Tests
- [x] New functionality has new tests.
- [x] Tests fail if the new functionality is broken (including crashes), not
      just when it is missing.
- [x] Negative tests added where exceptions are expected.
- [x] Truth data added where simple `EXPECT_*` / `assert` checks are
      insufficient for algorithmic correctness.
- [x] CI runtime impact considered; team notified if significant.

### Documentation
- [x] Public-facing APIs have Doxygen docs.
- [x] User-visible behavior changes have public docs, or a follow-up is
      tracked.

### Code style
- [x] Naming follows the existing convention (`snake_case` vs `camelCase`) for
      the area being modified.

### Dependencies
- [x] No new third-party dependencies, **or** the team has been notified and
      OSRB tickets filed.
