### PR TITLE
Add realtime build to cudaqx-dev image

### DIFF
--- a/.github/actions/get-cudaq-build/action.yaml
+++ b/.github/actions/get-cudaq-build/action.yaml
@@ -50,6 +50,7 @@ runs:
         # This are a list of files that when changed should require a new cudaq build
         to_hash: |
           .github/actions/get-cudaq-build/**
+          scripts/build_cudaq_with_realtime.sh
           .cudaq_version
       run: |
         hash=${{ hashFiles(format('{0}', env.to_hash)) }}

--- a/.github/actions/get-cudaq-build/build_cudaq.sh
+++ b/.github/actions/get-cudaq-build/build_cudaq.sh
@@ -9,10 +9,9 @@ set -e
 # the terms of the Apache License 2.0 which accompanies this distribution.     #
 # ============================================================================ #
 
-# Thin wrapper that delegates to cudaq/scripts/build_cudaq.sh. Translates the
-# positional-args contract used by .github/actions/get-cudaq-build/action.yaml
-# into the env-var + flag interface expected by upstream, and installs the base
-# realtime package that CUDA-Q links against for device_call support.
+# Thin wrapper that preserves the positional-args contract used by
+# .github/actions/get-cudaq-build/action.yaml while delegating the actual
+# realtime + CUDA-Q build to scripts/build_cudaq_with_realtime.sh.
 BUILD_TYPE=${1:-"Release"}
 LAUNCHER=${2:-""}  # accepted for backward compat; upstream auto-detects ccache via PATH
 CC=${3:-"gcc"}
@@ -29,14 +28,7 @@ export CUDAQ_WERROR=${CUDAQ_WERROR:-OFF}
 # CUDAQ_INSTALL_PREFIX / CUQUANTUM_INSTALL_PREFIX / CUTENSOR_INSTALL_PREFIX /
 # CCACHE_DIR are expected to be set by the calling action (see action.yaml).
 
-cmake -G Ninja -S cudaq/realtime -B cudaq/realtime/build \
-  -DCMAKE_BUILD_TYPE="$BUILD_TYPE" \
-  -DCMAKE_INSTALL_PREFIX="$CUDAQ_INSTALL_PREFIX" \
-  -DCUDAQ_REALTIME_BUILD_TESTS=OFF \
-  -DCUDAQ_REALTIME_BUILD_EXAMPLES=OFF \
-  -DCUDAQ_REALTIME_ENABLE_HOLOLINK_TOOLS=OFF
-cmake --build cudaq/realtime/build --target install --parallel
+script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+repo_root=$(cd "$script_dir/../../.." && pwd)
 
-cd cudaq
-bash scripts/build_cudaq.sh -v -c "$BUILD_TYPE" -- \
-  "-DCUDAQ_REALTIME_DIR=$CUDAQ_INSTALL_PREFIX"
+bash "$repo_root/scripts/build_cudaq_with_realtime.sh" "$BUILD_TYPE" "$CC" "$CXX"

--- a/docker/build_env/cudaqx.dev.Dockerfile
+++ b/docker/build_env/cudaqx.dev.Dockerfile
@@ -24,6 +24,7 @@ RUN apt-get update && CUDA_DASH=$(echo $cuda_version | tr '.' '-') \
   && apt-get autoremove -y --purge && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 COPY .cudaq_version /cudaq_version
+COPY scripts/build_cudaq_with_realtime.sh /usr/local/bin/build_cudaq_with_realtime.sh
 
 ENV CUDAQ_INSTALL_PREFIX=/usr/local/cudaq
 
@@ -34,8 +35,8 @@ RUN mkdir -p /workspaces/cudaq && cd /workspaces/cudaq \
   && git remote add origin https://github.com/${CUDAQ_REPO} \
   && git fetch -q --depth=1 origin ${CUDAQ_COMMIT} \
   && git reset --hard FETCH_HEAD \
-  && bash scripts/build_cudaq.sh -v \
-  && rm -rf build
+  && CUDAQ_SRC=/workspaces/cudaq bash /usr/local/bin/build_cudaq_with_realtime.sh \
+  && rm -rf build realtime/build
 
 #RUN mkdir -p /workspaces/cudaqx && cd /workspaces/cudaqx \
 #  && cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -DCUDAQ_DIR=/usr/local/cudaq/lib/cmake/cudaq .. \

--- a/scripts/build_cudaq_with_realtime.sh
+++ b/scripts/build_cudaq_with_realtime.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+set -euo pipefail
+
+# ============================================================================ #
+# Copyright (c) 2026 NVIDIA Corporation & Affiliates.                          #
+# All rights reserved.                                                         #
+#                                                                              #
+# This source code and the accompanying materials are made available under     #
+# the terms of the Apache License 2.0 which accompanies this distribution.     #
+# ============================================================================ #
+
+# Build and install cudaq-realtime, then build CUDA-Q against that install so
+# device_call support is enabled in the final CUDA-Q prefix.
+#
+# Positional arguments:
+#   1. CMAKE_BUILD_TYPE
+#   2. C compiler
+#   3. C++ compiler
+#
+# Environment:
+#   CUDAQ_SRC             CUDA-Q source checkout, default: ./cudaq
+#   CUDAQ_INSTALL_PREFIX  CUDA-Q install prefix, default: /usr/local/cudaq
+
+log() { printf '\033[1;34m==>\033[0m %s\n' "$*"; }
+
+BUILD_TYPE=${1:-"Release"}
+CC=${2:-${CC:-"gcc"}}
+CXX=${3:-${CXX:-"g++"}}
+
+export CC
+export CXX
+
+: "${CUDAQ_SRC:=cudaq}"
+: "${CUDAQ_INSTALL_PREFIX:=/usr/local/cudaq}"
+
+CUDAQ_SRC=$(cd "$CUDAQ_SRC" && pwd)
+
+log "Building cudaq-realtime from $CUDAQ_SRC/realtime"
+cmake -G Ninja -S "$CUDAQ_SRC/realtime" -B "$CUDAQ_SRC/realtime/build" \
+  -DCMAKE_BUILD_TYPE="$BUILD_TYPE" \
+  -DCMAKE_INSTALL_PREFIX="$CUDAQ_INSTALL_PREFIX" \
+  -DCUDAQ_REALTIME_BUILD_TESTS=OFF \
+  -DCUDAQ_REALTIME_BUILD_EXAMPLES=OFF \
+  -DCUDAQ_REALTIME_ENABLE_HOLOLINK_TOOLS=OFF
+cmake --build "$CUDAQ_SRC/realtime/build" --target install --parallel
+
+log "Building CUDA-Q with realtime support"
+(
+  cd "$CUDAQ_SRC"
+  bash scripts/build_cudaq.sh -v -c "$BUILD_TYPE" -- \
+    "-DCUDAQ_REALTIME_DIR=$CUDAQ_INSTALL_PREFIX"
+)


### PR DESCRIPTION
<!--
Thanks for contributing to CUDA-Q Libraries!

Please read the full Pull Request Guidelines in Contributing.md:
https://github.com/NVIDIA/cudaqx/blob/main/Contributing.md#pull-request-guidelines
-->

## Description
In the `cudaqx-dev` Docker image, build and install CUDA-Q realtime, then build CUDA-Q with realtime support. This matches the current CI build setup.

Verification: built the `cudaqx-dev` image locally and confirmed the CUDA-Q realtime artifacts were installed.

<!-- What does this PR change, and why? Link related issues. -->

## Runtime / performance impact

<!--
If this change affects performance, paste benchmark numbers here.
Otherwise write "N/A".
-->

## Self-review checklist

Please confirm each item before requesting review. Check `[x]` or strike
through and explain.

### Before requesting review
- [x] I reviewed my own full diff in GitHub or my editor.
- [x] PR is in Draft if it is not yet ready for review.
- [x] Temporary / debugging changes have been removed.
- [x] Local test logs reviewed; no unexplained warnings or errors.
- [x] CI logs reviewed; no unexplained warnings or errors.
- [x] Full CI has been run.

### Scope and size
- [x] PR is under ~1000 lines, or an exception is justified in the description.
- [x] Refactoring-only changes are isolated in their own PR(s).
- [x] No existing tests were disabled or modified just to make this PR pass
      (if so, an issue has been raised).

### Tests
- [x] New functionality has new tests.
- [x] Tests fail if the new functionality is broken (including crashes), not
      just when it is missing.
- [x] Negative tests added where exceptions are expected.
- [x] Truth data added where simple `EXPECT_*` / `assert` checks are
      insufficient for algorithmic correctness.
- [x] CI runtime impact considered; team notified if significant.

### Documentation
- [x] Public-facing APIs have Doxygen docs.
- [x] User-visible behavior changes have public docs, or a follow-up is
      tracked.

### Code style
- [x] Naming follows the existing convention (`snake_case` vs `camelCase`) for
      the area being modified.

### Dependencies
- [x] No new third-party dependencies, **or** the team has been notified and
      OSRB tickets filed.
