### PR TITLE
Include cmake/ in cudaq realtime sparse checkout; fix test

### DIFF
--- a/.cudaq_version
+++ b/.cudaq_version
@@ -1,6 +1,6 @@
 {
   "cudaq": {
     "repository": "NVIDIA/cuda-quantum",
-    "ref": "b60e69f8498e5d0c82329cb77ae45c559005cede"
+    "ref": "5439aff2c851a1b06ced9f24cdec7b5bfc3273ac"
   }
 }

--- a/.cudaq_version
+++ b/.cudaq_version
@@ -1,6 +1,6 @@
 {
   "cudaq": {
     "repository": "NVIDIA/cuda-quantum",
-    "ref": "5439aff2c851a1b06ced9f24cdec7b5bfc3273ac"
+    "ref": "b60e69f8498e5d0c82329cb77ae45c559005cede"
   }
 }

--- a/.github/actions/build-lib/build_qec.sh
+++ b/.github/actions/build-lib/build_qec.sh
@@ -20,7 +20,7 @@ if [ -z "$CUDAQ_REALTIME_ROOT" ]; then
   git clone --filter=blob:none --no-checkout "https://github.com/${CUDAQ_REPO}.git" cudaq-realtime-src
   cd cudaq-realtime-src
   git sparse-checkout init --cone
-  git sparse-checkout set realtime
+  git sparse-checkout set realtime cmake
   git checkout "$CUDAQ_REF"
 
   # Install build tools and DOCA/Holoscan SDK for HSB.

--- a/.github/workflows/all_libs_release.yaml
+++ b/.github/workflows/all_libs_release.yaml
@@ -116,7 +116,7 @@ jobs:
           git clone --filter=blob:none --no-checkout "https://github.com/${CUDAQ_REPO}.git" cudaq-realtime-src
           cd cudaq-realtime-src
           git sparse-checkout init --cone
-          git sparse-checkout set realtime
+          git sparse-checkout set realtime cmake
           git checkout "$CUDAQ_REF"
           cd realtime && mkdir -p build && cd build
           cmake -G Ninja -DCMAKE_INSTALL_PREFIX=$CUDAQ_REALTIME_ROOT ..

--- a/libs/qec/python/tests/test_decoding_config.py
+++ b/libs/qec/python/tests/test_decoding_config.py
@@ -577,7 +577,9 @@ def test_configure_decoders_from_str_smoke():
     decoder_config.syndrome_size = 3
     decoder_config.H_sparse = [1, 2, 3, -1, 6, 7, 8, -1, -1]
     decoder_config.set_decoder_custom_args(nv)
-    yaml_str = decoder_config.to_yaml_str()
+    multi_decoder_config = qec.multi_decoder_config()
+    multi_decoder_config.decoders = [decoder_config]
+    yaml_str = multi_decoder_config.to_yaml_str()
     # Do not instantiate the decoder if it is not available.
     if not is_nv_qldpc_decoder_available():
         return


### PR DESCRIPTION
cuda-quantum commit 604d3034 ([#4870](https://github.com/NVIDIA/cuda-quantum/pull/4870)) made realtime/unittests include cmake/modules/CUDAQGtestDiscovery.cmake from the repo root, which the realtime-only sparse checkout in CI does not fetch, breaking configure with "include could not find requested file". Fetch cmake/ alongside realtime/ in both places that clone the realtime sources.