### PR TITLE
qec/realtime: Relay BP (nv-qldpc) gpu_roce profile for the HSB decoding-server test

### DIFF
--- a/libs/qec/lib/realtime/decoding-server-cqr/CMakeLists.txt
+++ b/libs/qec/lib/realtime/decoding-server-cqr/CMakeLists.txt
@@ -98,14 +98,14 @@ if(HOLOSCAN_SENSOR_BRIDGE_BUILD_DIR AND CUDAQ_REALTIME_INCLUDE_DIR)
       AND DOCA_COMMON_LIB AND CUDAQ_REALTIME_BRIDGE_HOLOLINK_LIBRARY
       AND CUDAQ_REALTIME_DISPATCH_LIBRARY AND CUDAQ_REALTIME_HOST_DISPATCH_LIBRARY)
     set(CUDAQ_GPU_ROCE_AVAILABLE TRUE CACHE INTERNAL
-      "GPU RoCE transport compiled into cudaq-qec-decoding-server")
+      "GPU RoCE transport component cudaq-qec-decoding-server-gpuroce available")
     # Under CMP0126 (NEW) the CACHE set above does NOT update the normal
     # variable initialized FALSE at the top of this file, and the normal
-    # variable shadows the cache in this scope -- so the compile-definition
-    # gate below would never fire.  Set the normal variable explicitly.
+    # variable shadows the cache in this scope -- so the component gate
+    # below would never fire.  Set the normal variable explicitly.
     set(CUDAQ_GPU_ROCE_AVAILABLE TRUE)
     message(STATUS
-      "cudaq-qec-decoding-server: GPU RoCE ENABLED (core=${HOLOLINK_CORE_LIB})")
+      "cudaq-qec-decoding-server-gpuroce: GPU RoCE ENABLED (core=${HOLOLINK_CORE_LIB})")
   else()
     message(STATUS
       "cudaq-qec-decoding-server: GPU RoCE DISABLED "
@@ -125,6 +125,12 @@ message(STATUS
 # ---------------------------------------------------------------------------
 # Core decoding server (always built): transport abstraction, session registry,
 # per-decoder worker threads, RPC dispatcher.  No dependency on CUDAQ_REALTIME.
+#
+# Deliberately excludes GpuRoceTransceiver: consumers of this library (unit
+# tests, the CQR plugin) must stay loadable on driverless machines, and the
+# GPU RoCE deps (DOCA, the hololink bridge) require libcuda.so.1 at load
+# time.  gpu_roce lives in the cudaq-qec-decoding-server-gpuroce component
+# below, reached through a weak factory symbol (see DecodingServer.cpp).
 # ---------------------------------------------------------------------------
 add_library(cudaq-qec-decoding-server STATIC
   RoundAccumulator.cpp
@@ -133,7 +139,6 @@ add_library(cudaq-qec-decoding-server STATIC
   RpcDispatcher.cpp
   DecodingServer.cpp
   CpuRoceTransceiver.cpp
-  GpuRoceTransceiver.cpp
 )
 
 target_compile_features(cudaq-qec-decoding-server PUBLIC cxx_std_20)
@@ -156,31 +161,6 @@ target_link_libraries(cudaq-qec-decoding-server
     cudaq-qec-realtime-decoding
 )
 
-if(CUDAQ_GPU_ROCE_AVAILABLE)
-  target_compile_definitions(cudaq-qec-decoding-server PRIVATE CUDAQ_GPU_ROCE_AVAILABLE)
-  target_include_directories(cudaq-qec-decoding-server PRIVATE
-    "${CUDAQ_REALTIME_INCLUDE_DIR}"
-    "${_doca_root}/include"
-  )
-  target_link_libraries(cudaq-qec-decoding-server PRIVATE
-    "${CUDAQ_REALTIME_BRIDGE_HOLOLINK_LIBRARY}"
-    "${GPU_ROCE_TRANSCEIVER_LIB}"
-    "${BASE_RECEIVER_OP_LIB}"
-    "${HOLOLINK_CORE_LIB}"
-    "${HOLOLINK_COMMON_LIB}"
-    "${DOCA_VERBS_LIB}"
-    "${DOCA_GPUNETIO_LIB}"
-    "${DOCA_COMMON_LIB}"
-    $<$<BOOL:${IBVERBS_LIB}>:${IBVERBS_LIB}>
-    CUDA::cudart
-    # libdoca_gpunetio.so and libcudaq-realtime-bridge-hololink.so reference
-    # the CUDA Driver API (cu*); consumers of this static lib inherit those
-    # deps, so link the driver here.  CUDA::cuda_driver resolves to the
-    # toolkit's stubs in driverless build environments (CI containers).
-    CUDA::cuda_driver
-  )
-endif()
-
 set_target_properties(cudaq-qec-decoding-server PROPERTIES
   ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib
   POSITION_INDEPENDENT_CODE ON
@@ -190,6 +170,77 @@ install(TARGETS cudaq-qec-decoding-server
   COMPONENT qec-lib
   ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
 )
+
+# ---------------------------------------------------------------------------
+# Optional GPU RoCE component: GpuRoceTransceiver plus the strong definition
+# (GpuRoceFactory.cpp) of the factory that DecodingServer.cpp references
+# weakly.  Kept out of the core library so core consumers carry no DOCA /
+# Hololink / CUDA-driver runtime dependencies -- those .so's need
+# libcuda.so.1 at load time, which driverless machines (CI containers) lack.
+#
+# Consumers must link this WHOLE_ARCHIVE: the only reference to the factory
+# is weak, which does not pull archive members on its own.
+# ---------------------------------------------------------------------------
+if(CUDAQ_GPU_ROCE_AVAILABLE)
+  add_library(cudaq-qec-decoding-server-gpuroce STATIC
+    GpuRoceTransceiver.cpp
+    GpuRoceFactory.cpp
+  )
+
+  target_compile_definitions(cudaq-qec-decoding-server-gpuroce
+    PRIVATE CUDAQ_GPU_ROCE_AVAILABLE)
+
+  target_include_directories(cudaq-qec-decoding-server-gpuroce PRIVATE
+    "${CUDAQ_REALTIME_INCLUDE_DIR}"
+    "${_doca_root}/include"
+  )
+
+  target_link_libraries(cudaq-qec-decoding-server-gpuroce
+    PUBLIC
+      cudaq-qec-decoding-server
+      "${CUDAQ_REALTIME_BRIDGE_HOLOLINK_LIBRARY}"
+      "${GPU_ROCE_TRANSCEIVER_LIB}"
+      "${BASE_RECEIVER_OP_LIB}"
+      "${HOLOLINK_CORE_LIB}"
+      "${HOLOLINK_COMMON_LIB}"
+      "${DOCA_VERBS_LIB}"
+      "${DOCA_GPUNETIO_LIB}"
+      "${DOCA_COMMON_LIB}"
+      $<$<BOOL:${IBVERBS_LIB}>:${IBVERBS_LIB}>
+      CUDA::cudart
+      # libdoca_gpunetio.so and libcudaq-realtime-bridge-hololink.so reference
+      # the CUDA Driver API (cu*); consumers of this static lib inherit that
+      # dep, so link the driver here.  CUDA::cuda_driver resolves to the
+      # toolkit's stubs in driverless build environments (CI containers).
+      CUDA::cuda_driver
+  )
+
+  set_target_properties(cudaq-qec-decoding-server-gpuroce PROPERTIES
+    ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib
+    POSITION_INDEPENDENT_CODE ON
+  )
+
+  install(TARGETS cudaq-qec-decoding-server-gpuroce
+    COMPONENT qec-lib
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  )
+
+  # Link canary (never executed, not installed, not a test): a static
+  # archive alone never resolves symbols, and the one real consumer
+  # (decoding_server's gpu_roce block) is additionally gated on the
+  # proprietary cudevice archive, which CI does not provision.  Without
+  # this target, CI (HSB + DOCA present, no GPU driver) would compile
+  # GpuRoceTransceiver.cpp but never validate its link against the
+  # hololink / DOCA libraries.  The strong factory reference pulls the
+  # component's members, and the component's PUBLIC deps (including the
+  # CUDA driver stubs) complete the resolution.
+  add_executable(cudaq-qec-decoding-server-gpuroce-linkcheck
+    GpuRoceLinkCheck.cpp
+  )
+  target_link_libraries(cudaq-qec-decoding-server-gpuroce-linkcheck PRIVATE
+    cudaq-qec-decoding-server-gpuroce
+  )
+endif()
 
 # ---------------------------------------------------------------------------
 # CQR host-dispatch plugin (only when CUDAQ device_call headers are available):

--- a/libs/qec/lib/realtime/decoding-server-cqr/CMakeLists.txt
+++ b/libs/qec/lib/realtime/decoding-server-cqr/CMakeLists.txt
@@ -173,6 +173,11 @@ if(CUDAQ_GPU_ROCE_AVAILABLE)
     "${DOCA_COMMON_LIB}"
     $<$<BOOL:${IBVERBS_LIB}>:${IBVERBS_LIB}>
     CUDA::cudart
+    # libdoca_gpunetio.so and libcudaq-realtime-bridge-hololink.so reference
+    # the CUDA Driver API (cu*); consumers of this static lib inherit those
+    # deps, so link the driver here.  CUDA::cuda_driver resolves to the
+    # toolkit's stubs in driverless build environments (CI containers).
+    CUDA::cuda_driver
   )
 endif()
 

--- a/libs/qec/lib/realtime/decoding-server-cqr/CMakeLists.txt
+++ b/libs/qec/lib/realtime/decoding-server-cqr/CMakeLists.txt
@@ -99,6 +99,11 @@ if(HOLOSCAN_SENSOR_BRIDGE_BUILD_DIR AND CUDAQ_REALTIME_INCLUDE_DIR)
       AND CUDAQ_REALTIME_DISPATCH_LIBRARY AND CUDAQ_REALTIME_HOST_DISPATCH_LIBRARY)
     set(CUDAQ_GPU_ROCE_AVAILABLE TRUE CACHE INTERNAL
       "GPU RoCE transport compiled into cudaq-qec-decoding-server")
+    # Under CMP0126 (NEW) the CACHE set above does NOT update the normal
+    # variable initialized FALSE at the top of this file, and the normal
+    # variable shadows the cache in this scope -- so the compile-definition
+    # gate below would never fire.  Set the normal variable explicitly.
+    set(CUDAQ_GPU_ROCE_AVAILABLE TRUE)
     message(STATUS
       "cudaq-qec-decoding-server: GPU RoCE ENABLED (core=${HOLOLINK_CORE_LIB})")
   else()

--- a/libs/qec/lib/realtime/decoding-server-cqr/DecodingServer.cpp
+++ b/libs/qec/lib/realtime/decoding-server-cqr/DecodingServer.cpp
@@ -8,7 +8,6 @@
 
 #include "DecodingServer.h"
 #include "CpuRoceTransceiver.h"
-#include "GpuRoceTransceiver.h"
 
 #include "cudaq/qec/logger.h"
 #include "cudaq/qec/realtime/decoding_config.h"
@@ -19,6 +18,16 @@
 #include <stdexcept>
 #include <thread>
 #include <vector>
+
+// GPU RoCE support is an optional component (cudaq-qec-decoding-server-gpuroce)
+// so this core library carries no DOCA / Hololink / CUDA-driver dependencies:
+// those .so's require libcuda.so.1 at load time, which core consumers (unit
+// tests, the CQR plugin) must not impose on driverless machines.  Binaries
+// that want the gpu_roce transport link the component WHOLE_ARCHIVE, whose
+// GpuRoceFactory.cpp provides the strong definition of this factory; anywhere
+// else the weak reference is null and make_transport throws.
+extern "C" __attribute__((weak)) cudaq::qec::decoding_server::ITransceiver *
+cudaqx_qec_make_gpu_roce_transceiver();
 
 namespace cudaq::qec::decoding_server {
 
@@ -32,13 +41,13 @@ std::unique_ptr<ITransceiver>
 DecodingServer::make_transport(DecoderTransport transport_type) {
   switch (transport_type) {
   case DecoderTransport::gpu_roce:
-#ifdef CUDAQ_GPU_ROCE_AVAILABLE
-    return std::make_unique<GpuRoceTransceiver>(GpuRoceConfig::from_env());
-#else
+    if (cudaqx_qec_make_gpu_roce_transceiver)
+      return std::unique_ptr<ITransceiver>(
+          cudaqx_qec_make_gpu_roce_transceiver());
     throw std::runtime_error(
-        "gpu_roce transport requested but CUDAQ_GPU_ROCE_AVAILABLE is not set. "
-        "Build with HOLOSCAN_SENSOR_BRIDGE_BUILD_DIR and DOCA libs.");
-#endif
+        "gpu_roce transport requested but GPU RoCE support is not linked into "
+        "this binary. Build with HOLOSCAN_SENSOR_BRIDGE_BUILD_DIR and DOCA "
+        "libs, and link cudaq-qec-decoding-server-gpuroce (whole-archive).");
 
   case DecoderTransport::cpu_roce:
     // CpuRoceTransceiver constructor always throws (ibverbs pending).
@@ -65,18 +74,18 @@ DecodingServer::DecodingServer(const std::string &config_yaml) {
   registry_.load_from_config(config, config_yaml);
   register_handlers();
 
-  auto t = make_transport(registry_.required_transport());
+  const auto transport_type = registry_.required_transport();
+  auto t = make_transport(transport_type);
   ITransceiver *raw = t.get();
   owned_transports_.push_back(std::move(t));
   function_transport_[kEnqueueSyndromesFunctionId] = raw;
   function_transport_[kGetCorrectionsFunctionId] = raw;
   function_transport_[kResetDecoderFunctionId] = raw;
 
-#ifdef CUDAQ_GPU_ROCE_AVAILABLE
   // For the GPU RoCE path, wire the first (and only) session's decoder graph
   // to the Hololink ring buffer via the CUDAQ device-graph scheduler.
   // Multi-decoder GPU RoCE binding is deferred to a follow-up.
-  if (auto *gpu_trx = dynamic_cast<GpuRoceTransceiver *>(raw)) {
+  if (transport_type == DecoderTransport::gpu_roce) {
     const auto &sessions = registry_.sessions();
     if (sessions.size() != 1)
       throw std::runtime_error(
@@ -90,9 +99,10 @@ DecodingServer::DecodingServer(const std::string &config_yaml) {
           "GPU RoCE requires a decoder that supports graph dispatch "
           "(supports_graph_dispatch() must return true and "
           "capture_decode_graph() must succeed)");
-    gpu_trx->launch_scheduler(session->graph_resources.get());
+    if (!raw->launch_device_scheduler(session->graph_resources.get()))
+      throw std::runtime_error(
+          "gpu_roce transceiver did not provide a device scheduler");
   }
-#endif
 }
 
 DecodingServer::DecodingServer(std::unique_ptr<ITransceiver> transport,

--- a/libs/qec/lib/realtime/decoding-server-cqr/GpuRoceFactory.cpp
+++ b/libs/qec/lib/realtime/decoding-server-cqr/GpuRoceFactory.cpp
@@ -1,0 +1,22 @@
+/****************************************************************-*- C++ -*-****
+ * Copyright (c) 2026 NVIDIA Corporation & Affiliates.                         *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+// Strong definition of the GPU RoCE factory that DecodingServer.cpp declares
+// weakly.  This translation unit lives in cudaq-qec-decoding-server-gpuroce
+// (NOT the core library) so that only binaries linking that component carry
+// the DOCA / Hololink / CUDA-driver dependencies.  Consumers must link the
+// component WHOLE_ARCHIVE: the sole reference to this symbol is weak, which
+// does not pull archive members on its own.
+
+#include "GpuRoceTransceiver.h"
+
+extern "C" cudaq::qec::decoding_server::ITransceiver *
+cudaqx_qec_make_gpu_roce_transceiver() {
+  using namespace cudaq::qec::decoding_server;
+  return new GpuRoceTransceiver(GpuRoceConfig::from_env());
+}

--- a/libs/qec/lib/realtime/decoding-server-cqr/GpuRoceLinkCheck.cpp
+++ b/libs/qec/lib/realtime/decoding-server-cqr/GpuRoceLinkCheck.cpp
@@ -1,0 +1,28 @@
+/****************************************************************-*- C++ -*-****
+ * Copyright (c) 2026 NVIDIA Corporation & Affiliates.                         *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+// Link canary for the GPU RoCE component -- not meant to be executed
+// (running it would require HOLOLINK_* env, a GPU driver, and RDMA-capable
+// hardware).  Building it forces the linker to resolve GpuRoceTransceiver's
+// full dependency chain (hololink, DOCA, CUDA driver stubs), so HSB API
+// drift is caught at build time even on machines where nothing links the
+// component into a runnable binary (driverless CI: the decoding_server
+// tool's gpu_roce block is additionally gated on the proprietary cudevice
+// archive, which CI does not provision).
+
+namespace cudaq::qec::decoding_server {
+struct ITransceiver;
+}
+
+extern "C" cudaq::qec::decoding_server::ITransceiver *
+cudaqx_qec_make_gpu_roce_transceiver();
+
+int main() {
+  (void)cudaqx_qec_make_gpu_roce_transceiver();
+  return 0;
+}

--- a/libs/qec/lib/realtime/decoding-server-cqr/GpuRoceTransceiver.h
+++ b/libs/qec/lib/realtime/decoding-server-cqr/GpuRoceTransceiver.h
@@ -80,6 +80,12 @@ public:
   /// `cudaq::qec::realtime::graph_resources *` to extract `graph_exec`.
   void launch_scheduler(void *raw_graph_resources);
 
+  /// ITransceiver hook: forwards to launch_scheduler().
+  bool launch_device_scheduler(void *raw_graph_resources) override {
+    launch_scheduler(raw_graph_resources);
+    return true;
+  }
+
   /// Block until shutdown() is called.  The GPU scheduler handles RX/TX;
   /// this method only satisfies the ITransceiver contract for DecodingServer.
   RxFrame recv() override;

--- a/libs/qec/lib/realtime/decoding-server-cqr/GpuRoceTransceiver.h
+++ b/libs/qec/lib/realtime/decoding-server-cqr/GpuRoceTransceiver.h
@@ -42,11 +42,11 @@ struct GpuRoceConfig {
   /// Set iff HOLOLINK_GPU_ID was present in the environment (the FPGA/NIC
   /// affinity is a topology fact; absence defers to the decoder's pin).
   std::optional<int> gpu_id_env;
-  size_t frame_size{384};  ///< HOLOLINK_FRAME_SIZE (max RPC frame bytes)
-  size_t page_size{0};     ///< HOLOLINK_PAGE_SIZE (0 → derived from frame_size)
-  size_t num_pages{64};    ///< HOLOLINK_NUM_PAGES (ring depth)
-  std::string peer_ip;     ///< HOLOLINK_PEER_IP   (FPGA/emulator IPv4)
-  int reserved_sms{2};     ///< HOLOLINK_RESERVED_SMS (SMs for Hololink RX/TX)
+  size_t frame_size{384}; ///< HOLOLINK_FRAME_SIZE (max RPC frame bytes)
+  size_t page_size{0};    ///< HOLOLINK_PAGE_SIZE (0 → derived from frame_size)
+  size_t num_pages{64};   ///< HOLOLINK_NUM_PAGES (ring depth)
+  std::string peer_ip;    ///< HOLOLINK_PEER_IP   (FPGA/emulator IPv4)
+  int reserved_sms{2};    ///< HOLOLINK_RESERVED_SMS (SMs for Hololink RX/TX)
 
   static GpuRoceConfig from_env();
 };

--- a/libs/qec/lib/realtime/decoding-server-cqr/ITransceiver.h
+++ b/libs/qec/lib/realtime/decoding-server-cqr/ITransceiver.h
@@ -89,6 +89,16 @@ struct ITransceiver {
   /// threads, which may be concurrent.
   virtual void send(const PeerId &peer, const uint8_t *data, size_t len) = 0;
 
+  /// Optional hook for GPU ring-buffer transports: wire \p graph_resources
+  /// (the opaque pointer from decoder::capture_decode_graph()) into an
+  /// on-device scheduler and launch it.  Returns false when the transport has
+  /// no device scheduler (the default); callers that require one treat that
+  /// as an error.  Keeps DecodingServer free of concrete-transceiver types
+  /// (and their link-time dependencies).
+  virtual bool launch_device_scheduler(void * /*graph_resources*/) {
+    return false;
+  }
+
   virtual ~ITransceiver() = default;
 };
 

--- a/libs/qec/tools/decoding-server/CMakeLists.txt
+++ b/libs/qec/tools/decoding-server/CMakeLists.txt
@@ -75,10 +75,24 @@ if(CUDAQ_REALTIME_INCLUDE_DIR AND TARGET cudaq-qec-realtime-decoding-server-cqr)
         ${QEC_IBVERBS_LIBRARY})
       message(STATUS "decoding_server: cpu_roce transport enabled")
     endif()
-    # The server's --transport=gpu_roce path needs BOTH the GPU RoCE transport
-    # (compiled into cudaq-qec-decoding-server when hololink/DOCA are present)
-    # AND the proprietary cudevice archive, which supplies the three
-    # populate-shim symbols (cudaqx_qec_realtime_dispatch_populate_*_device_entry)
+    # The gpu_roce CLI branch ([2a] in decoding_server.cpp) references only
+    # the core DecodingServer API, so compile it whenever hololink/DOCA are
+    # present -- machines without the proprietary archive (CI in particular)
+    # still build the branch; at runtime it fails with a clear "GPU RoCE
+    # support is not linked into this binary" error from make_transport.
+    if(CUDAQ_GPU_ROCE_AVAILABLE)
+      target_compile_definitions(decoding_server PRIVATE
+        QEC_HAVE_GPU_ROCE_TRANSPORT)
+      target_include_directories(decoding_server PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/../../lib/realtime/decoding-server-cqr
+      )
+      target_link_libraries(decoding_server PRIVATE
+        cudaq-qec-decoding-server)
+    endif()
+    # Actually LINKING the GPU RoCE transport needs BOTH the
+    # cudaq-qec-decoding-server-gpuroce component AND the proprietary
+    # cudevice archive, which supplies the three populate-shim symbols
+    # (cudaqx_qec_realtime_dispatch_populate_*_device_entry)
     # that GpuRoceTransceiver::launch_scheduler resolves via dlsym. Hololink
     # presence and the proprietary archive are provisioned independently, so
     # treat a missing archive as "gpu_roce transport not available" and fall
@@ -101,13 +115,10 @@ if(CUDAQ_REALTIME_INCLUDE_DIR AND TARGET cudaq-qec-realtime-decoding-server-cqr)
           "at runtime.  Set CUDAQ_REALTIME_ROOT to the CUDA-Q realtime "
           "install prefix and re-run CMake.")
       endif()
-      target_compile_definitions(decoding_server PRIVATE
-        QEC_HAVE_GPU_ROCE_TRANSPORT)
-      target_include_directories(decoding_server PRIVATE
-        ${CMAKE_CURRENT_SOURCE_DIR}/../../lib/realtime/decoding-server-cqr
-      )
       target_link_libraries(decoding_server PRIVATE
-        cudaq-qec-decoding-server
+        # WHOLE_ARCHIVE: DecodingServer reaches gpu_roce through a weak
+        # factory symbol, and a weak reference does not pull archive members.
+        $<LINK_LIBRARY:WHOLE_ARCHIVE,cudaq-qec-decoding-server-gpuroce>
         ${CUDAQ_REALTIME_DISPATCH_LIBRARY}
         $<LINK_LIBRARY:WHOLE_ARCHIVE,cudaq-qec-realtime-cudevice-proprietary>
       )
@@ -117,10 +128,10 @@ if(CUDAQ_REALTIME_INCLUDE_DIR AND TARGET cudaq-qec-realtime-decoding-server-cqr)
       message(STATUS "decoding_server: gpu_roce transport enabled")
     elseif(CUDAQ_GPU_ROCE_AVAILABLE)
       message(WARNING
-        "decoding_server: gpu_roce transport DISABLED "
+        "decoding_server: gpu_roce CLI compiled but transport NOT linked "
         "(cudaq-qec-realtime-cudevice-proprietary target not defined; set "
         "CUDAQ_QEC_REALTIME_CUDEVICE_PROPRIETARY_ARCHIVE to enable). "
-        "Server builds with udp/cpu_roce transports only.")
+        "--transport=gpu_roce will fail at runtime with a not-linked error.")
     endif()
     # RelayBP/nv-qldpc captures a CUDA device graph during decoder
     # initialization even when the server transport is udp or cpu_roce. Export

--- a/libs/qec/tools/decoding-server/decoding_server.cpp
+++ b/libs/qec/tools/decoding-server/decoding_server.cpp
@@ -530,23 +530,33 @@ int main(int argc, char **argv) {
     // launch_scheduler() to wire the CUDAQ device-graph scheduler to the
     // Hololink ring buffers.  The GPU scheduler then handles
     // RX→dispatch→decode→TX autonomously; this thread just waits for signal.
-    cudaq::qec::decoding_server::DecodingServer server(cfg.config_path);
-    // QP/rkey/buf already printed to stdout by launch_scheduler() so the
-    // orchestration script can grep them before the READY line.
-    std::cout << "QEC_DECODING_SERVER_READY gpu_roce" << std::endl;
-    std::cout.flush();
-    std::thread server_thread([&server] { server.run(); });
-    const auto start_time_gr = std::chrono::steady_clock::now();
-    while (g_shutdown.load(std::memory_order_acquire) == 0) {
-      const auto elapsed = std::chrono::duration_cast<std::chrono::seconds>(
-                               std::chrono::steady_clock::now() - start_time_gr)
-                               .count();
-      if (elapsed > cfg.timeout_sec)
-        break;
-      std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    //
+    // Construction throws when the GPU RoCE component is not linked into
+    // this binary (built against HSB/DOCA headers but without the
+    // proprietary cudevice archive) or when Hololink bring-up fails.
+    try {
+      cudaq::qec::decoding_server::DecodingServer server(cfg.config_path);
+      // QP/rkey/buf already printed to stdout by launch_scheduler() so the
+      // orchestration script can grep them before the READY line.
+      std::cout << "QEC_DECODING_SERVER_READY gpu_roce" << std::endl;
+      std::cout.flush();
+      std::thread server_thread([&server] { server.run(); });
+      const auto start_time_gr = std::chrono::steady_clock::now();
+      while (g_shutdown.load(std::memory_order_acquire) == 0) {
+        const auto elapsed =
+            std::chrono::duration_cast<std::chrono::seconds>(
+                std::chrono::steady_clock::now() - start_time_gr)
+                .count();
+        if (elapsed > cfg.timeout_sec)
+          break;
+        std::this_thread::sleep_for(std::chrono::milliseconds(100));
+      }
+      server.stop();
+      server_thread.join();
+    } catch (const std::exception &e) {
+      std::cerr << "ERROR: gpu_roce startup failed: " << e.what() << std::endl;
+      return 1;
     }
-    server.stop();
-    server_thread.join();
     return 0;
   }
 #endif

--- a/libs/qec/unittests/utils/hsb_fpga_decoding_server_test.sh
+++ b/libs/qec/unittests/utils/hsb_fpga_decoding_server_test.sh
@@ -82,6 +82,22 @@ GEN_ROUNDS=4
 GEN_P_SPAM=0.01
 GEN_SHOTS=100
 
+# Server transport.  Empty => derived from the decoder profile:
+#   pymatching        -> cpu_roce  (HOST_CALL dispatch on the CPU)
+#   nv-qldpc-decoder  -> gpu_roce  (self-relaunching device-graph scheduler:
+#                        enqueue/get/reset run as DEVICE_CALLs on the GPU and
+#                        the captured RelayBP decode graph fires device-side)
+TRANSPORT=""
+# GPU for the gpu_roce scheduler + decode graph (HOLOLINK_GPU_ID).
+GPU_ID=0
+
+# gpu_roce build artifacts from the proprietary cuda-qx tree: the cudevice
+# archive (DEVICE_CALL handlers + populate shims, WHOLE_ARCHIVE-linked and
+# device-linked into the server) and the nv-qldpc plugin .so (dlopen'd;
+# capture_decode_graph builds the RelayBP decode graph).
+PROPRIETARY_ARCHIVE="/workspaces/cuda-qx/build/lib/libcudaq-qec-realtime-cudevice-proprietary.a"
+NV_QLDPC_PLUGIN="/workspaces/cuda-qx/build/lib/decoder-plugins/libcudaq-qec-nv-qldpc-decoder.so"
+
 # Network defaults
 IB_DEVICE=""           # auto-detect
 BRIDGE_IP="10.0.0.1"   # server-side NIC IP (kept the qldpc script's name)
@@ -129,9 +145,13 @@ Actions:
   --no-run               Skip running the test (useful with --build)
 
 Decoder options:
-  --decoder NAME         Decoder profile (default: pymatching).  By default the
+  --decoder NAME         Decoder profile: pymatching (default) or
+                         nv-qldpc-decoder (Relay BP).  By default the
                          config/syndromes files are generated fresh each run by
                          surface_code-4-yaml into CUDAQX_DIR/build/hsb_fpga_test_data
+  --transport T          Server transport: cpu_roce or gpu_roce.  Default is
+                         derived from the decoder (pymatching -> cpu_roce,
+                         nv-qldpc-decoder -> gpu_roce device-graph scheduler)
   --config PATH          Use a pre-made decoding-server YAML config (skips generation)
   --syndromes PATH       Use a pre-made syndromes text file (skips generation)
   --data-dir DIR         Use pre-made DIR/config_NAME.yml + DIR/syndromes_NAME.txt
@@ -150,6 +170,12 @@ Build options:
                          CUDAQX_DIR/.cudaq_version (default: /workspaces/cuda-quantum)
   --cudaqx-dir DIR       cudaqx source dir that builds the server + playback
                          (default: /workspaces/cudaqx)
+  --proprietary-archive PATH  Prebuilt libcudaq-qec-realtime-cudevice-proprietary.a
+                         for the gpu_roce server build (default:
+                         /workspaces/cuda-qx/build/lib/...)
+  --nv-qldpc-plugin PATH Prebuilt libcudaq-qec-nv-qldpc-decoder.so, symlinked
+                         into build/lib/decoder-plugins (default:
+                         /workspaces/cuda-qx/build/lib/decoder-plugins/...)
   --jobs N               Parallel build jobs (default: nproc)
 
 Network options:
@@ -164,7 +190,9 @@ Run options:
   --no-verify            Skip correction verification
   --num-shots N          Limit number of shots
   --page-size N          Ring buffer slot size in bytes (default: 384)
-  --frame-size N         Server TX SGE bytes (default: 64)
+  --frame-size N         Server TX SGE bytes, cpu_roce only (default: 64;
+                         gpu_roce uses page-size as HOLOLINK_FRAME_SIZE)
+  --gpu N                GPU device id for gpu_roce (default: 0)
   --spacing N            Inter-shot spacing in microseconds (default: 10)
   --control-port N       UDP control port for emulator (default: 8193)
 
@@ -180,6 +208,10 @@ while [[ $# -gt 0 ]]; do
         --no-run)           DO_RUN=false ;;
         --no-verify)        VERIFY=false ;;
         --decoder)          DECODER="$2"; shift ;;
+        --transport)        TRANSPORT="$2"; shift ;;
+        --gpu)              GPU_ID="$2"; shift ;;
+        --proprietary-archive) PROPRIETARY_ARCHIVE="$2"; shift ;;
+        --nv-qldpc-plugin)  NV_QLDPC_PLUGIN="$2"; shift ;;
         --config)           CONFIG_FILE="$2"; shift ;;
         --syndromes)        SYNDROMES_FILE="$2"; shift ;;
         --data-dir)         DATA_DIR="$2"; shift ;;
@@ -211,6 +243,18 @@ while [[ $# -gt 0 ]]; do
     esac
     shift
 done
+
+# Derive the transport from the decoder profile unless explicitly chosen.
+if [[ -z "$TRANSPORT" ]]; then
+    case "$DECODER" in
+        nv-qldpc-decoder) TRANSPORT="gpu_roce" ;;
+        *)                TRANSPORT="cpu_roce" ;;
+    esac
+fi
+if [[ "$TRANSPORT" != "cpu_roce" && "$TRANSPORT" != "gpu_roce" ]]; then
+    echo "ERROR: unknown --transport $TRANSPORT (expected cpu_roce or gpu_roce)" >&2
+    exit 1
+fi
 
 # ============================================================================
 # Logging Helpers
@@ -624,23 +668,34 @@ do_build() {
         "$hsb_cmake" "${hsb_common_args[@]}" 2>&1 | tail -5
     fi
 
+    # hololink_core is enough for playback + the emulator; the gpu_roce
+    # server additionally needs the HSB gpu_roce_transceiver archive.
+    local hsb_targets=(hololink_core)
+    local hsb_gpu_roce_lib="${hsb_build}/src/hololink/operators/gpu_roce_transceiver/libgpu_roce_transceiver.a"
+    if [[ -f "$PROPRIETARY_ARCHIVE" ]]; then
+        hsb_targets+=(gpu_roce_transceiver)
+    fi
     "$hsb_cmake" --build "$hsb_build" -j "$JOBS" \
-        --target hololink_core 2>&1 | tail -5
+        --target "${hsb_targets[@]}" 2>&1 | tail -5
     _info "holoscan-sensor-bridge built: $hsb_build/"
 
+    # Reconfigure cuda-quantum/realtime with hololink tools: the emulator
+    # binary (emulate mode) and the bridge-hololink .so the gpu_roce server
+    # path links against.
+    local cq_hololink_targets=(cudaq-realtime-bridge-hololink)
     if $EMULATE; then
-        # Reconfigure cuda-quantum/realtime with hololink tools (for the
-        # emulator binary only; the server itself has no HSB dependency).
-        cmake -G Ninja -S "$cq_src" -B "$cq_build" \
-            -DCMAKE_BUILD_TYPE=Release \
-            $cuda_arch_flag \
-            -DCUDAQ_REALTIME_ENABLE_HOLOLINK_TOOLS=ON \
-            -DHOLOSCAN_SENSOR_BRIDGE_SOURCE_DIR="$HSB_DIR" \
-            -DHOLOSCAN_SENSOR_BRIDGE_BUILD_DIR="$hsb_build" \
-            2>&1 | tail -5
-        cmake --build "$cq_build" -j "$JOBS" \
-            --target hololink_fpga_emulator 2>&1 | tail -5
+        cq_hololink_targets+=(hololink_fpga_emulator)
     fi
+    cmake -G Ninja -S "$cq_src" -B "$cq_build" \
+        -DCMAKE_BUILD_TYPE=Release \
+        $cuda_arch_flag \
+        -DCUDAQ_REALTIME_ENABLE_HOLOLINK_TOOLS=ON \
+        -DHOLOSCAN_SENSOR_BRIDGE_SOURCE_DIR="$HSB_DIR" \
+        -DHOLOSCAN_SENSOR_BRIDGE_BUILD_DIR="$hsb_build" \
+        -DGPU_ROCE_TRANSCEIVER_LIB="$hsb_gpu_roce_lib" \
+        2>&1 | tail -5
+    cmake --build "$cq_build" -j "$JOBS" \
+        --target "${cq_hololink_targets[@]}" 2>&1 | tail -5
 
     # ---- Stage 3: cudaqx decoding server + playback + decoder plugin ----
     _banner "Stage 3/3: Building cudaqx server + playback"
@@ -648,6 +703,28 @@ do_build() {
         _err "cudaqx source not found at $CUDAQX_DIR"
         return 1
     fi
+
+    # gpu_roce server support (Relay BP / nv-qldpc profile): wire in the
+    # proprietary cudevice archive + HSB gpu_roce transceiver + the
+    # cuda-quantum bridge-hololink lib when the proprietary artifacts exist;
+    # a pymatching-only rig builds fine without them (the server then has
+    # udp/cpu_roce transports only).
+    local gpu_roce_cmake_args=()
+    if [[ -f "$PROPRIETARY_ARCHIVE" ]]; then
+        gpu_roce_cmake_args+=(
+            -DCUDAQ_QEC_REALTIME_CUDEVICE_PROPRIETARY_ARCHIVE="$PROPRIETARY_ARCHIVE"
+            -DGPU_ROCE_TRANSCEIVER_LIB="$hsb_gpu_roce_lib"
+            -DCUDAQ_REALTIME_BRIDGE_HOLOLINK_LIBRARY="${cq_build}/lib/libcudaq-realtime-bridge-hololink.so"
+        )
+        _info "gpu_roce server support: using $PROPRIETARY_ARCHIVE"
+    else
+        _info "gpu_roce server support: DISABLED (no proprietary archive at" \
+              "$PROPRIETARY_ARCHIVE)"
+    fi
+
+    # Clear stale cmake cache entries (find_library caches NOTFOUND
+    # permanently, and CUDAQ_GPU_ROCE_AVAILABLE is CACHE INTERNAL).
+    rm -f "$cudaqx_build/CMakeCache.txt"
 
     # The server's CMake locates the cpu_transport archives via explicit cache
     # entries (its find_library does not search the cuda-quantum build tree).
@@ -671,7 +748,18 @@ do_build() {
         -DQEC_HOST_DISPATCH_LIBRARY="${cq_build}/lib/libcudaq-realtime-host-dispatch.a" \
         -DCUDAQ_INSTALL_PREFIX="${CUDAQ_INSTALL_PREFIX:-/usr/local/cudaq}" \
         -DCUDAQ_DIR="${CUDAQ_INSTALL_PREFIX:-/usr/local/cudaq}/lib/cmake/cudaq" \
+        ${gpu_roce_cmake_args[@]+"${gpu_roce_cmake_args[@]}"} \
         2>&1 | tail -5
+
+    # The plugin loader searches relative to libcudaq-qec.so; symlink the
+    # cuda-qx-built nv-qldpc plugin into the cudaqx decoder-plugins dir so
+    # both the generator and the server can dlopen it.
+    if [[ -f "$NV_QLDPC_PLUGIN" ]]; then
+        mkdir -p "$cudaqx_build/lib/decoder-plugins"
+        ln -sf "$NV_QLDPC_PLUGIN" \
+            "$cudaqx_build/lib/decoder-plugins/$(basename "$NV_QLDPC_PLUGIN")"
+        _info "nv-qldpc plugin symlinked: $NV_QLDPC_PLUGIN"
+    fi
 
     cmake --build "$cudaqx_build" -j "$JOBS" \
         --target decoding_server \
@@ -733,8 +821,15 @@ generate_data_files() {
     local gen_ld_path
     gen_ld_path="${CUDA_QUANTUM_DIR}/realtime/build/lib:${CUDAQX_DIR}/build/lib"
 
+    # nv-qldpc profile == the Relay BP test: select Relay BP custom args.
+    local gen_extra_args=()
+    if [[ "$DECODER" == "nv-qldpc-decoder" ]]; then
+        gen_extra_args+=(--use-relay-bp)
+    fi
+
     _info "$GENERATOR_BIN --distance $GEN_DISTANCE --num_rounds $GEN_ROUNDS" \
-          "--p_spam $GEN_P_SPAM --decoder_type $DECODER --save_dem $(basename "$CONFIG_FILE")"
+          "--p_spam $GEN_P_SPAM --decoder_type $DECODER ${gen_extra_args[*]:-}" \
+          "--save_dem $(basename "$CONFIG_FILE")"
     (cd "$GEN_DIR" && \
      LD_LIBRARY_PATH="${gen_ld_path}:${LD_LIBRARY_PATH:-}" \
      "$GENERATOR_BIN" \
@@ -742,11 +837,29 @@ generate_data_files() {
         --num_rounds "$GEN_ROUNDS" \
         --p_spam "$GEN_P_SPAM" \
         --decoder_type "$DECODER" \
+        ${gen_extra_args[@]+"${gen_extra_args[@]}"} \
         --save_dem "$(basename "$CONFIG_FILE")" > gen_config.log 2>&1) || {
         _err "Config generation failed; see ${GEN_DIR}/gen_config.log"
         tail -5 "${GEN_DIR}/gen_config.log" >&2 || true
         return 1
     }
+
+    # The server selects its transceiver from the per-decoder `transport:` YAML
+    # key (default cpu_roce).  The generator doesn't emit non-default optional
+    # fields, so for the gpu_roce profile inject the key into our generated
+    # config, directly under the decoder's `type:` line.
+    if [[ "$TRANSPORT" == "gpu_roce" ]]; then
+        _info "Injecting 'transport: gpu_roce' into $(basename "$CONFIG_FILE")"
+        awk '{ print }
+             /^[[:space:]]*type:/ && !done {
+                 print "    transport:       gpu_roce"; done = 1
+             }' "$CONFIG_FILE" > "${CONFIG_FILE}.tmp" \
+            && mv "${CONFIG_FILE}.tmp" "$CONFIG_FILE"
+        if ! grep -q "transport:.*gpu_roce" "$CONFIG_FILE"; then
+            _err "Failed to inject transport: gpu_roce into $CONFIG_FILE"
+            return 1
+        fi
+    fi
 
     _info "$GENERATOR_BIN --distance $GEN_DISTANCE --num_rounds $GEN_ROUNDS" \
           "--p_spam $GEN_P_SPAM --num_shots $GEN_SHOTS --yaml $(basename "$CONFIG_FILE")" \
@@ -767,6 +880,25 @@ generate_data_files() {
 
     _info "Generated: $CONFIG_FILE"
     _info "Generated: $SYNDROMES_FILE"
+}
+
+# The nv-qldpc profile needs the proprietary plugin dlopen-able from the
+# cudaqx decoder-plugins dir (used by both the data generator and the server).
+# Symlink it opportunistically so plain runs work without --build.
+ensure_nv_qldpc_plugin() {
+    local plugin_dir="${CUDAQX_DIR}/build/lib/decoder-plugins"
+    local link="${plugin_dir}/$(basename "$NV_QLDPC_PLUGIN")"
+    if [[ -e "$link" ]]; then
+        return 0
+    fi
+    if [[ ! -f "$NV_QLDPC_PLUGIN" ]]; then
+        _err "nv-qldpc plugin not found: $NV_QLDPC_PLUGIN"
+        _err "Build it in the proprietary cuda-qx tree or pass --nv-qldpc-plugin PATH."
+        return 1
+    fi
+    mkdir -p "$plugin_dir"
+    ln -sf "$NV_QLDPC_PLUGIN" "$link"
+    _info "nv-qldpc plugin symlinked: $link"
 }
 
 resolve_paths() {
@@ -867,29 +999,58 @@ extract_decimal() {
 start_server() {
     local peer_ip="$1" remote_qp="$2" server_log="$3"
 
-    _log "Starting decoding server (decoder=$DECODER, remote-qp=$remote_qp)"
+    _log "Starting decoding server (decoder=$DECODER, transport=$TRANSPORT," \
+         "remote-qp=$remote_qp)"
 
     local server_ld_path
     server_ld_path="${CUDA_QUANTUM_DIR}/realtime/build/lib:${CUDAQX_DIR}/build/lib"
 
-    LD_LIBRARY_PATH="${server_ld_path}:${LD_LIBRARY_PATH:-}" \
-    "$SERVER_BIN" \
-        --config="$CONFIG_FILE" \
-        --transport=cpu_roce \
-        --qp_config=hsb_fpga \
-        --device="$BRIDGE_DEVICE" \
-        --peer-ip="$peer_ip" \
-        --remote-qp="$remote_qp" \
-        --num-slots="$NUM_SLOTS" \
-        --slot-size="$PAGE_SIZE" \
-        --frame-size="$FRAME_SIZE" \
-        --timeout="$TIMEOUT" \
-        > >(tee "$server_log") 2>&1 &
+    local ready_pattern
+    if [[ "$TRANSPORT" == "gpu_roce" ]]; then
+        # Device-graph scheduler path: enqueue/get/reset run as DEVICE_CALLs
+        # on the GPU and the captured RelayBP decode graph fires device-side.
+        # The Hololink transceiver is configured via HOLOLINK_* env (the
+        # server's gpu_roce mode ignores the cpu_roce CLI flags), and eager
+        # module loading avoids lazy-load stalls inside the persistent
+        # scheduler (same as the old bridge launcher).
+        CUDA_MODULE_LOADING=EAGER \
+        LD_LIBRARY_PATH="${server_ld_path}:${LD_LIBRARY_PATH:-}" \
+        HOLOLINK_DEVICE="$BRIDGE_DEVICE" \
+        HOLOLINK_PEER_IP="$peer_ip" \
+        HOLOLINK_REMOTE_QP="$((remote_qp))" \
+        HOLOLINK_FRAME_SIZE="$PAGE_SIZE" \
+        HOLOLINK_NUM_PAGES="$NUM_SLOTS" \
+        HOLOLINK_GPU_ID="$GPU_ID" \
+        "$SERVER_BIN" \
+            --config="$CONFIG_FILE" \
+            --transport=gpu_roce \
+            --timeout="$TIMEOUT" \
+            > >(tee "$server_log") 2>&1 &
+        # The GpuRoceTransceiver prints the QP/RKey/Buffer handshake during
+        # server construction, BEFORE this READY sentinel -- so waiting for
+        # READY guarantees the three lines are scrapeable.
+        ready_pattern="QEC_DECODING_SERVER_READY gpu_roce"
+    else
+        LD_LIBRARY_PATH="${server_ld_path}:${LD_LIBRARY_PATH:-}" \
+        "$SERVER_BIN" \
+            --config="$CONFIG_FILE" \
+            --transport=cpu_roce \
+            --qp_config=hsb_fpga \
+            --device="$BRIDGE_DEVICE" \
+            --peer-ip="$peer_ip" \
+            --remote-qp="$remote_qp" \
+            --num-slots="$NUM_SLOTS" \
+            --slot-size="$PAGE_SIZE" \
+            --frame-size="$FRAME_SIZE" \
+            --timeout="$TIMEOUT" \
+            > >(tee "$server_log") 2>&1 &
+        ready_pattern="Bridge Ready"
+    fi
     SERVER_PID=$!
     PIDS_TO_KILL+=("$SERVER_PID")
     _info "Server PID: $SERVER_PID"
 
-    wait_for_pattern "$server_log" "Bridge Ready" 60 "$SERVER_PID" >/dev/null || {
+    wait_for_pattern "$server_log" "$ready_pattern" 60 "$SERVER_PID" >/dev/null || {
         _err "Decoding server did not become ready"
         _err "--- Server log ---"
         cat "$server_log" >&2
@@ -1030,6 +1191,9 @@ main() {
         return 0
     fi
 
+    if [[ "$DECODER" == "nv-qldpc-decoder" ]]; then
+        ensure_nv_qldpc_plugin
+    fi
     resolve_data_files
     if $GENERATE_DATA; then
         generate_data_files

--- a/libs/qec/unittests/utils/hsb_fpga_decoding_server_test.sh
+++ b/libs/qec/unittests/utils/hsb_fpga_decoding_server_test.sh
@@ -33,7 +33,7 @@
 #   --emulate:        emulator + server + playback  (no FPGA needed)
 #
 # Actions (can be combined):
-#   --build            Build all required tools
+#   --build            Build the surface_code-4 generator (only)
 #   --setup-network    Configure ConnectX interfaces
 #   (run is implicit unless only --build / --setup-network are given)
 #
@@ -47,6 +47,16 @@
 #   # Real FPGA
 #   ./hsb_fpga_decoding_server_test.sh --setup-network --device rocep1s0f0 \
 #       --bridge-ip 192.168.0.1 --fpga-ip 192.168.0.2
+#
+# Deployment note:
+#   --build builds ONLY the surface_code-4 generator (the one artifact not
+#   shipped in the decoding-server image).  Everything else -- decoding_server
+#   (with gpu_roce linked in), the playback tool, the HSB / cudaq-realtime
+#   shared libs, and the decoder plugins -- is consumed PREBUILT: on a dev rig
+#   from the /workspaces/*/build trees, and in a productized container from
+#   their installed locations.  This script never builds cuda-quantum, HSB, or
+#   the decoder server, and needs no proprietary .a at build time.  A clean,
+#   unconfigured rig cannot bootstrap from it.
 set -euo pipefail
 
 # ============================================================================
@@ -91,12 +101,15 @@ TRANSPORT=""
 # GPU for the gpu_roce scheduler + decode graph (HOLOLINK_GPU_ID).
 GPU_ID=0
 
-# gpu_roce build artifacts from the proprietary cuda-qx tree: the cudevice
-# archive (DEVICE_CALL handlers + populate shims, WHOLE_ARCHIVE-linked and
-# device-linked into the server) and the nv-qldpc plugin .so (dlopen'd;
-# capture_decode_graph builds the RelayBP decode graph).
-PROPRIETARY_ARCHIVE="/workspaces/cuda-qx/build/lib/libcudaq-qec-realtime-cudevice-proprietary.a"
-NV_QLDPC_PLUGIN="/workspaces/cuda-qx/build/lib/decoder-plugins/libcudaq-qec-nv-qldpc-decoder.so"
+# Runtime nv-qldpc plugin for the Relay BP profile: the prebuilt
+# libcudaq-qec-nv-qldpc-decoder.so, dlopen'd by both the generator (during
+# syndrome generation) and the prebuilt decoder server.  Not delivered in this
+# repo and has no default path -- point at it with --nv-qldpc-plugin or the
+# CUDAQ_QEC_NV_QLDPC_PLUGIN env var (eventual home: a GitHub release artifact
+# via all_libs_release.yml).  The pymatching profile never uses it.  The
+# proprietary cudevice archive is NOT a concern of this script: it is a
+# build-time input to the decoder server, which is consumed prebuilt here.
+NV_QLDPC_PLUGIN="${CUDAQ_QEC_NV_QLDPC_PLUGIN:-}"
 
 # Network defaults
 IB_DEVICE=""           # auto-detect
@@ -170,12 +183,10 @@ Build options:
                          CUDAQX_DIR/.cudaq_version (default: /workspaces/cuda-quantum)
   --cudaqx-dir DIR       cudaqx source dir that builds the server + playback
                          (default: /workspaces/cudaqx)
-  --proprietary-archive PATH  Prebuilt libcudaq-qec-realtime-cudevice-proprietary.a
-                         for the gpu_roce server build (default:
-                         /workspaces/cuda-qx/build/lib/...)
   --nv-qldpc-plugin PATH Prebuilt libcudaq-qec-nv-qldpc-decoder.so, symlinked
-                         into build/lib/decoder-plugins (default:
-                         /workspaces/cuda-qx/build/lib/decoder-plugins/...)
+                         into build/lib/decoder-plugins for the prebuilt server
+                         + generator to dlopen.  No default; required for the
+                         nv-qldpc profile (or set CUDAQ_QEC_NV_QLDPC_PLUGIN)
   --jobs N               Parallel build jobs (default: nproc)
 
 Network options:
@@ -210,7 +221,6 @@ while [[ $# -gt 0 ]]; do
         --decoder)          DECODER="$2"; shift ;;
         --transport)        TRANSPORT="$2"; shift ;;
         --gpu)              GPU_ID="$2"; shift ;;
-        --proprietary-archive) PROPRIETARY_ARCHIVE="$2"; shift ;;
         --nv-qldpc-plugin)  NV_QLDPC_PLUGIN="$2"; shift ;;
         --config)           CONFIG_FILE="$2"; shift ;;
         --syndromes)        SYNDROMES_FILE="$2"; shift ;;
@@ -551,33 +561,41 @@ detect_cuda_arch() {
 }
 
 do_build() {
-    _log "Building all tools (jobs=$JOBS)"
+    _log "Building the surface_code-4 generator only (jobs=$JOBS)"
 
     local cudaqx_build="${CUDAQX_DIR}/build"
-    local cq_build="${CUDA_QUANTUM_DIR}/realtime/build"
-    local hsb_build="${HSB_DIR}/build"
 
-    # cuda-quantum must be at the ref cudaqx pins (matches cudaqx CI).
+    # This script builds ONLY the surface_code-4 generator (the config +
+    # syndrome producer that is NOT shipped in the decoding-server image).  The
+    # decoder server, playback tool, HSB / cudaq-realtime shared libs, and
+    # decoder plugins are consumed PREBUILT -- on a dev rig from the
+    # /workspaces/*/build trees (resolve_paths points there), and in a
+    # productized image from their installed locations.  So a clean,
+    # unconfigured rig cannot bootstrap from this script.
+    if [[ ! -f "$cudaqx_build/CMakeCache.txt" ]]; then
+        _err "cudaqx build dir is not configured ($cudaqx_build/CMakeCache.txt"
+        _err "missing).  This script builds only the surface_code-4 generator and"
+        _err "consumes the decoder server, playback, libs, and plugins prebuilt."
+        _err "Configure + build the cudaqx tree once first, or run against a"
+        _err "prebuilt/installed image."
+        return 1
+    fi
+
+    # cuda-quantum should be at the ref cudaqx pins (the generator links the
+    # cuda-quantum realtime libs); warn on skew, as the full build did.
     local pinned_ref current_ref
     pinned_ref=$(jq -r '.cudaq.ref' "${CUDAQX_DIR}/.cudaq_version" 2>/dev/null || true)
     current_ref=$(git -C "$CUDA_QUANTUM_DIR" rev-parse HEAD 2>/dev/null || true)
     if [[ -n "$pinned_ref" && -n "$current_ref" && "$pinned_ref" != "$current_ref" ]]; then
-        _err "cuda-quantum checkout ($current_ref)"
-        _err "does not match the cudaqx pin  ($pinned_ref)"
-        _err "from ${CUDAQX_DIR}/.cudaq_version.  Continuing, but the realtime"
-        _err "libraries may be ABI-skewed against this cudaqx tree."
+        _err "cuda-quantum checkout ($current_ref) does not match the cudaqx pin"
+        _err "($pinned_ref) from ${CUDAQX_DIR}/.cudaq_version.  Continuing, but the"
+        _err "realtime libraries may be ABI-skewed against this cudaqx tree."
     elif [[ -n "$pinned_ref" ]]; then
         _info "cuda-quantum at the cudaqx pin: $pinned_ref"
     fi
 
-    local cuda_arch
-    cuda_arch=$(detect_cuda_arch)
-    local cuda_arch_flag=""
-    if [ -n "$cuda_arch" ]; then
-        cuda_arch_flag="-DCMAKE_CUDA_ARCHITECTURES=$cuda_arch"
-        _info "CUDA arch: $cuda_arch"
-    fi
-
+    # Ensure nvcc is discoverable for the generator's device-code (nvq++)
+    # compile step; best-effort (a no-op rebuild needs no compiler).
     local cuda_compiler=""
     if [[ -n "${CMAKE_CUDA_COMPILER:-}" ]]; then
         cuda_compiler="${CMAKE_CUDA_COMPILER}"
@@ -586,188 +604,23 @@ do_build() {
     else
         cuda_compiler="$(command -v nvcc || true)"
     fi
-    if [[ -z "$cuda_compiler" || ! -x "$cuda_compiler" ]]; then
-        _err "Unable to locate nvcc. Set CMAKE_CUDA_COMPILER or update PATH."
-        return 1
-    fi
-    local cuda_bin_dir
-    cuda_bin_dir="$(dirname "$cuda_compiler")"
-    case ":$PATH:" in
-        *":$cuda_bin_dir:"*) ;;
-        *) export PATH="$cuda_bin_dir:$PATH" ;;
-    esac
-    if [[ -z "$cuda_arch" ]]; then
-        cuda_arch=$(detect_cuda_arch)
-        if [[ -n "$cuda_arch" ]]; then
-            cuda_arch_flag="-DCMAKE_CUDA_ARCHITECTURES=$cuda_arch"
-            _info "CUDA arch (re-detected): $cuda_arch"
-        fi
-    fi
-    local cuda_toolkit_root
-    cuda_toolkit_root="$(cd "$(dirname "$cuda_compiler")/.." && pwd -P)"
-    _info "CUDA compiler: $cuda_compiler"
-    _info "CUDA toolkit:  $cuda_toolkit_root"
-
-    # ---- Stage 1: cuda-quantum/realtime ----
-    _banner "Stage 1/3: Building cuda-quantum/realtime"
-    local cq_src="${CUDA_QUANTUM_DIR}/realtime"
-    if [[ ! -d "$cq_src" ]]; then
-        _err "cuda-quantum realtime source not found at $cq_src"
-        return 1
+    if [[ -n "$cuda_compiler" && -x "$cuda_compiler" ]]; then
+        local cuda_bin_dir
+        cuda_bin_dir="$(dirname "$cuda_compiler")"
+        case ":$PATH:" in
+            *":$cuda_bin_dir:"*) ;;
+            *) export PATH="$cuda_bin_dir:$PATH" ;;
+        esac
     fi
 
-    cmake -G Ninja -S "$cq_src" -B "$cq_build" \
-        -DCMAKE_BUILD_TYPE=Release \
-        $cuda_arch_flag \
+    # Rebuild only the generator.  The cudaqx build dir is already configured
+    # (checked above); ninja regenerates the build if CMakeLists changed
+    # (reusing the cached configure) and recompiles only what is stale.  This
+    # script never builds cuda-quantum, HSB, or the decoder server.
+    cmake --build "$cudaqx_build" -j "$JOBS" --target surface_code-4-yaml \
         2>&1 | tail -5
-    cmake --build "$cq_build" -j "$JOBS" 2>&1 | tail -5
-    _info "cuda-quantum/realtime built: $cq_build/lib/"
-
-    # ---- Stage 2: holoscan-sensor-bridge (hololink_core for playback,
-    # plus the emulator via a cuda-quantum reconfigure) ----
-    _banner "Stage 2/3: Building holoscan-sensor-bridge (hololink_core)"
-    if [[ ! -d "$HSB_DIR" ]]; then
-        _err "holoscan-sensor-bridge source not found at $HSB_DIR"
-        return 1
-    fi
-
-    local target_arch="amd64"
-    if [[ "$(uname -m)" == "aarch64" ]]; then
-        target_arch="arm64"
-    fi
-
-    # Holoscan SDK requires CMake >= 3.30.4; find a suitable binary.
-    local hsb_cmake="cmake"
-    if [[ -x /tmp/cmake-3.31.6-linux-aarch64/bin/cmake ]]; then
-        hsb_cmake="/tmp/cmake-3.31.6-linux-aarch64/bin/cmake"
-    elif [[ -x /usr/local/cmake-3.31/bin/cmake ]]; then
-        hsb_cmake="/usr/local/cmake-3.31/bin/cmake"
-    fi
-
-    local hsb_common_args=(
-        -G Ninja
-        -S "$HSB_DIR"
-        -B "$hsb_build"
-        -DCMAKE_BUILD_TYPE=Release
-        -DCMAKE_CUDA_COMPILER="$cuda_compiler"
-        -DCUDAToolkit_ROOT="$cuda_toolkit_root"
-        $cuda_arch_flag
-        -DTARGET_ARCH="$target_arch"
-        -DHOLOLINK_BUILD_ONLY_NATIVE=OFF
-        -DHOLOLINK_BUILD_PYTHON=OFF
-        -DHOLOLINK_BUILD_TESTS=OFF
-        -DHOLOLINK_BUILD_TOOLS=OFF
-        -DHOLOLINK_BUILD_EXAMPLES=OFF
-        -DHOLOLINK_BUILD_EMULATOR=OFF
-    )
-    if "$hsb_cmake" --help 2>/dev/null | grep -q -- "--fresh"; then
-        "$hsb_cmake" --fresh "${hsb_common_args[@]}" 2>&1 | tail -5
-    else
-        rm -f "$hsb_build/CMakeCache.txt"
-        rm -rf "$hsb_build/CMakeFiles"
-        "$hsb_cmake" "${hsb_common_args[@]}" 2>&1 | tail -5
-    fi
-
-    # hololink_core is enough for playback + the emulator; the gpu_roce
-    # server additionally needs the HSB gpu_roce_transceiver archive.
-    local hsb_targets=(hololink_core)
-    local hsb_gpu_roce_lib="${hsb_build}/src/hololink/operators/gpu_roce_transceiver/libgpu_roce_transceiver.a"
-    if [[ -f "$PROPRIETARY_ARCHIVE" ]]; then
-        hsb_targets+=(gpu_roce_transceiver)
-    fi
-    "$hsb_cmake" --build "$hsb_build" -j "$JOBS" \
-        --target "${hsb_targets[@]}" 2>&1 | tail -5
-    _info "holoscan-sensor-bridge built: $hsb_build/"
-
-    # Reconfigure cuda-quantum/realtime with hololink tools: the emulator
-    # binary (emulate mode) and the bridge-hololink .so the gpu_roce server
-    # path links against.
-    local cq_hololink_targets=(cudaq-realtime-bridge-hololink)
-    if $EMULATE; then
-        cq_hololink_targets+=(hololink_fpga_emulator)
-    fi
-    cmake -G Ninja -S "$cq_src" -B "$cq_build" \
-        -DCMAKE_BUILD_TYPE=Release \
-        $cuda_arch_flag \
-        -DCUDAQ_REALTIME_ENABLE_HOLOLINK_TOOLS=ON \
-        -DHOLOSCAN_SENSOR_BRIDGE_SOURCE_DIR="$HSB_DIR" \
-        -DHOLOSCAN_SENSOR_BRIDGE_BUILD_DIR="$hsb_build" \
-        -DGPU_ROCE_TRANSCEIVER_LIB="$hsb_gpu_roce_lib" \
-        2>&1 | tail -5
-    cmake --build "$cq_build" -j "$JOBS" \
-        --target "${cq_hololink_targets[@]}" 2>&1 | tail -5
-
-    # ---- Stage 3: cudaqx decoding server + playback + decoder plugin ----
-    _banner "Stage 3/3: Building cudaqx server + playback"
-    if [[ ! -d "$CUDAQX_DIR" ]]; then
-        _err "cudaqx source not found at $CUDAQX_DIR"
-        return 1
-    fi
-
-    # gpu_roce server support (Relay BP / nv-qldpc profile): wire in the
-    # proprietary cudevice archive + HSB gpu_roce transceiver + the
-    # cuda-quantum bridge-hololink lib when the proprietary artifacts exist;
-    # a pymatching-only rig builds fine without them (the server then has
-    # udp/cpu_roce transports only).
-    local gpu_roce_cmake_args=()
-    if [[ -f "$PROPRIETARY_ARCHIVE" ]]; then
-        gpu_roce_cmake_args+=(
-            -DCUDAQ_QEC_REALTIME_CUDEVICE_PROPRIETARY_ARCHIVE="$PROPRIETARY_ARCHIVE"
-            -DGPU_ROCE_TRANSCEIVER_LIB="$hsb_gpu_roce_lib"
-            -DCUDAQ_REALTIME_BRIDGE_HOLOLINK_LIBRARY="${cq_build}/lib/libcudaq-realtime-bridge-hololink.so"
-        )
-        _info "gpu_roce server support: using $PROPRIETARY_ARCHIVE"
-    else
-        _info "gpu_roce server support: DISABLED (no proprietary archive at" \
-              "$PROPRIETARY_ARCHIVE)"
-    fi
-
-    # Clear stale cmake cache entries (find_library caches NOTFOUND
-    # permanently, and CUDAQ_GPU_ROCE_AVAILABLE is CACHE INTERNAL).
-    rm -f "$cudaqx_build/CMakeCache.txt"
-
-    # The server's CMake locates the cpu_transport archives via explicit cache
-    # entries (its find_library does not search the cuda-quantum build tree).
-    cmake -G Ninja -S "$CUDAQX_DIR" -B "$cudaqx_build" \
-        $cuda_arch_flag \
-        -DCMAKE_BUILD_TYPE=Release \
-        -DCMAKE_CUDA_COMPILER="$cuda_compiler" \
-        -DCUDAToolkit_ROOT="$cuda_toolkit_root" \
-        -DCUDAQX_QEC_ENABLE_HOLOLINK_TOOLS=ON \
-        -DCUDAQ_QEC_BUILD_TRT_DECODER=OFF \
-        -DHOLOSCAN_SENSOR_BRIDGE_SOURCE_DIR="$HSB_DIR" \
-        -DHOLOSCAN_SENSOR_BRIDGE_BUILD_DIR="$hsb_build" \
-        -DCUDAQ_REALTIME_ROOT="${CUDA_QUANTUM_DIR}/realtime" \
-        -DCUDAQ_REALTIME_INCLUDE_DIR="${CUDA_QUANTUM_DIR}/realtime/include" \
-        -DCUDAQ_REALTIME_LIBRARY="${cq_build}/lib/libcudaq-realtime.so" \
-        -DCUDAQ_REALTIME_DISPATCH_LIBRARY="${cq_build}/lib/libcudaq-realtime-dispatch.a" \
-        -DCUDAQ_REALTIME_HOST_DISPATCH_LIBRARY="${cq_build}/lib/libcudaq-realtime-host-dispatch.a" \
-        -DQEC_UDP_TRANSPORT_LIBRARY="${cq_build}/lib/libcudaq-realtime-udp-transport.a" \
-        -DQEC_CPU_ROCE_TRANSPORT_LIBRARY="${cq_build}/lib/libcudaq-realtime-cpu-roce-transport.a" \
-        -DQEC_UDP_REALTIME_LIBRARY="${cq_build}/lib/libcudaq-realtime.so" \
-        -DQEC_HOST_DISPATCH_LIBRARY="${cq_build}/lib/libcudaq-realtime-host-dispatch.a" \
-        -DCUDAQ_INSTALL_PREFIX="${CUDAQ_INSTALL_PREFIX:-/usr/local/cudaq}" \
-        -DCUDAQ_DIR="${CUDAQ_INSTALL_PREFIX:-/usr/local/cudaq}/lib/cmake/cudaq" \
-        ${gpu_roce_cmake_args[@]+"${gpu_roce_cmake_args[@]}"} \
-        2>&1 | tail -5
-
-    # The plugin loader searches relative to libcudaq-qec.so; symlink the
-    # cuda-qx-built nv-qldpc plugin into the cudaqx decoder-plugins dir so
-    # both the generator and the server can dlopen it.
-    if [[ -f "$NV_QLDPC_PLUGIN" ]]; then
-        mkdir -p "$cudaqx_build/lib/decoder-plugins"
-        ln -sf "$NV_QLDPC_PLUGIN" \
-            "$cudaqx_build/lib/decoder-plugins/$(basename "$NV_QLDPC_PLUGIN")"
-        _info "nv-qldpc plugin symlinked: $NV_QLDPC_PLUGIN"
-    fi
-
-    cmake --build "$cudaqx_build" -j "$JOBS" \
-        --target decoding_server \
-                 hololink_fpga_syndrome_playback \
-                 cudaq-qec-pymatching \
-                 surface_code-4-yaml \
-        2>&1 | tail -5
-    _info "cudaqx tools built: $cudaqx_build/bin + $cudaqx_build/libs/qec/unittests/utils/"
+    _info "surface_code-4 generator built:"
+    _info "  $cudaqx_build/libs/qec/unittests/realtime/app_examples/surface_code-4-yaml"
 
     _banner "Build complete"
 }
@@ -887,6 +740,14 @@ generate_data_files() {
 # Symlink it opportunistically so plain runs work without --build.
 ensure_nv_qldpc_plugin() {
     local plugin_dir="${CUDAQX_DIR}/build/lib/decoder-plugins"
+    # Guard the empty default first: basename "" yields "" so the link path
+    # would collapse to "$plugin_dir/", which -e reports as an existing
+    # directory -- a false "already present".
+    if [[ -z "$NV_QLDPC_PLUGIN" ]]; then
+        _err "nv-qldpc profile requires the plugin path: pass --nv-qldpc-plugin PATH"
+        _err "or set CUDAQ_QEC_NV_QLDPC_PLUGIN (eventual home: all_libs_release.yml artifact)."
+        return 1
+    fi
     local link="${plugin_dir}/$(basename "$NV_QLDPC_PLUGIN")"
     if [[ -e "$link" ]]; then
         return 0


### PR DESCRIPTION
## Description

Adds a **Relay BP (nv-qldpc) profile** to the HSB decoding-server test, driving the decoder
through the server's `gpu_roce` transport — the **self-relaunching device-graph scheduler**
(`GpuRoceTransceiver`): `enqueue_syndromes` / `get_corrections` / `reset_decoder` execute as
`DEVICE_CALL`s on the GPU, and the captured RelayBP decode graph fires **device-side**
(fire-and-forget + tail self-relaunch) when a window completes. This replaces
`hololink_qldpc_graph_decoder_bridge` for the decoding-server flow; the old bridge test is
untouched. The pymatching/cpu_roce profile is unchanged and re-verified.

```
hololink_fpga_syndrome_playback (UNCHANGED —      decoding_server --transport=gpu_roce
 sole FPGA control-plane writer)                    HOLOLINK_* env → GpuRoceTransceiver
  programs SIF w/ server QP/RKey/addr               DEVICE_CALL enqueue/get/reset on GPU,
  writes per-round RPC frames to FPGA BRAM          RelayBP decode graph fired device-side,
  arms ILA, verifies captured RPCResponses          dispatch graph tail-self-relaunches
       FPGA/emulator ──RDMA WRITE──► DOCA GPU rx ring ; server ──RDMA WRITE──► FPGA SIF TX
```

## Changes

**`hsb_fpga_decoding_server_test.sh`**
- `--transport cpu_roce|gpu_roce`, defaulted from the decoder profile (`pymatching` →
  `cpu_roce`, `nv-qldpc-decoder` → `gpu_roce`); new `--gpu`, `--proprietary-archive`,
  `--nv-qldpc-plugin` flags.
- Data generation (fresh each run via `surface_code-4-yaml`) adds `--use-relay-bp` for the
  nv-qldpc profile and **injects `transport: gpu_roce`** into the generated YAML —
  `DecoderServer` selects its transceiver from the per-decoder `transport:` key, the generator
  omits non-default optionals, and the default (`cpu_roce`) resolves to the not-yet-implemented
  `CpuRoceTransceiver` stub.
- gpu_roce server launch: Hololink parameters via `HOLOLINK_*` env (the server's gpu_roce mode
  ignores the cpu_roce CLI flags); remote QP converted to decimal
  (`GpuRoceConfig::from_env` parses base-10 only); `CUDA_MODULE_LOADING=EAGER` as with the old
  bridge launcher; readiness keyed on `QEC_DECODING_SERVER_READY gpu_roce` (the transceiver
  prints the QP/RKey/Buffer handshake before that line, without the bridge banner).
- Build phase: builds HSB `gpu_roce_transceiver` + cuda-quantum `cudaq-realtime-bridge-hololink`,
  wires `CUDAQ_QEC_REALTIME_CUDEVICE_PROPRIETARY_ARCHIVE` / `GPU_ROCE_TRANSCEIVER_LIB` /
  `CUDAQ_REALTIME_BRIDGE_HOLOLINK_LIBRARY` into the cudaqx configure, clears the CMake cache
  (find_library NOTFOUND staleness), and symlinks the nv-qldpc plugin into
  `build/lib/decoder-plugins` (also opportunistically on `--build`-less runs). All gated on the
  proprietary archive's presence, so pymatching-only rigs build exactly as before.

**`decoding-server-cqr/CMakeLists.txt` — bug fix (separable)**
`CUDAQ_GPU_ROCE_AVAILABLE` was set as `CACHE INTERNAL` on success, but the plain
`set(... FALSE)` at the top of the file shadows the cache under CMP0126 (NEW), so the
compile-definition gate for `cudaq-qec-decoding-server` never fired: the library silently built
**without** gpu_roce (`make_transport` threw "CUDAQ_GPU_ROCE_AVAILABLE is not set" at runtime)
while the sibling `decoding_server` target — which reads the cache — reported
"gpu_roce transport enabled". Fixed by setting the normal variable alongside the cache entry.