### PR TITLE
Fix surface-code hook errors with an orientation-aware CNOT schedule

### DIFF
--- a/docs/sphinx/components/qec/introduction.rst
+++ b/docs/sphinx/components/qec/introduction.rst
@@ -142,6 +142,20 @@ To implement a new quantum error correcting code:
            // Implement stabilizer measurements
        }
 
+   .. note::
+
+      The two vector arguments passed to the :code:`stabilizer_round` kernel
+      are the flattened X and Z stabilizer *schedule* matrices returned by
+      :cpp:func:`cudaq::qec::code::get_stabilizer_schedule_x` and
+      :cpp:func:`cudaq::qec::code::get_stabilizer_schedule_z`. By default
+      these equal the plain parity-check matrices (every entry 0 or 1), but a
+      code can override the :code:`get_stabilizer_schedule_*` methods to
+      encode a gate order, in which case entry :code:`k >= 1` means the
+      interaction executes at timestep :code:`k` (the built-in
+      :code:`surface_code` does this to avoid hook errors). A kernel that only
+      needs the support pattern should therefore test entries for
+      :code:`!= 0` rather than :code:`== 1`.
+
 4. **Register Operations**:
 
    In the constructor, register quantum kernels for each operation:

--- a/docs/sphinx/components/qec/introduction.rst
+++ b/docs/sphinx/components/qec/introduction.rst
@@ -287,7 +287,18 @@ to prototype and develop new codes.
    .. note::
 
       The kernel registered for :code:`stabilizer_round` must be annotated to
-      return :code:`list[cudaq.measure_handle]`. 
+      return :code:`list[cudaq.measure_handle]`.
+
+   .. note::
+
+      As in C++, the two list arguments passed to the
+      :code:`stabilizer_round` kernel are the flattened X and Z stabilizer
+      schedule matrices, which default to the parity-check matrices. A Python
+      code can optionally define :code:`get_stabilizer_schedule_x` /
+      :code:`get_stabilizer_schedule_z` methods returning a 2D array with the
+      same shape and support pattern as the corresponding parity-check
+      matrix, where entry :code:`k >= 1` schedules that interaction at
+      timestep :code:`k`.
 
 3. **Implement the Code Class**:
 

--- a/docs/sphinx/components/qec/introduction.rst
+++ b/docs/sphinx/components/qec/introduction.rst
@@ -83,6 +83,12 @@ The code base class provides:
        using stabilizer_round = cudaq::qkernel<std::vector<cudaq::measure_result>(
            patch, const std::vector<std::size_t>&, const std::vector<std::size_t>&)>;
 
+   The two vector arguments of :code:`stabilizer_round` are the flattened X and
+   Z stabilizer *schedule* matrices, which can encode an optimized gate order
+   on top of the parity-check support. See
+   :cpp:func:`cudaq::qec::code::get_stabilizer_schedule_x` for the encoding
+   and the default (the plain parity matrices).
+
 4. **Protected Members**:
 
    - :code:`operation_encodings`: Maps operations to their quantum kernel implementations. The key is the ``operation`` enum and the value is a variant on the above kernel type aliases.
@@ -481,6 +487,26 @@ print the layout. **Python:** :class:`cudaq_qec.stabilizer_grid` — see
 :cpp:class:`cudaq::qec::surface_code::stabilizer_grid` — see
 :ref:`qec_stabilizer_grid_cpp`. The header :file:`cudaq/qec/codes/surface_code.h`
 contains the full declaration.
+
+**Stabilizer measurement schedule**
+
+The surface code's :code:`stabilizer_round` kernel executes one depth-4
+extraction round: the X- and Z-check CNOTs are interleaved over four shared
+timesteps. Within each plaquette the CNOT order follows the standard zigzag
+schedule for the rotated surface code (`Tomita & Svore
+<https://arxiv.org/abs/1404.3747>`__): the X and Z plaquettes traverse their
+corners in transposed orders, selected per orientation so that mid-round
+ancilla faults ("hook errors", `Dennis et al.
+<https://arxiv.org/abs/quant-ph/0110143>`__) propagate onto data-qubit pairs
+perpendicular to the same-type logical operator. This preserves the full code
+distance :math:`d` under circuit-level noise; a naive schedule (both plaquette
+types in ascending qubit-index order) halves the effective distance of one
+memory basis. The schedule is available from the :code:`stabilizer_grid`
+helper via
+:cpp:func:`~cudaq::qec::surface_code::stabilizer_grid::get_cnot_schedule_x` /
+:code:`get_cnot_schedule_z` (matrix form) and
+:code:`get_cnot_schedule_pairs_x` / :code:`get_cnot_schedule_pairs_z` (flat
+pair-list form).
 
 Usage:
 

--- a/libs/qec/include/cudaq/qec/code.h
+++ b/libs/qec/include/cudaq/qec/code.h
@@ -103,7 +103,10 @@ public:
   /// @brief Type alias for two qubit quantum kernels
   using two_qubit_encoding = cudaq::qkernel<void(patch, patch)>;
 
-  /// @brief Type alias for stabilizer measurement kernels
+  /// @brief Type alias for stabilizer measurement kernels. The two vector
+  /// arguments are the flattened X and Z stabilizer schedule matrices (see
+  /// get_stabilizer_schedule_x/z()): entry 0 = no support, entry k >= 1 =
+  /// interaction at timestep k.
   using stabilizer_round = cudaq::qkernel<std::vector<cudaq::measure_result>(
       patch, const std::vector<std::size_t> &,
       const std::vector<std::size_t> &)>;
@@ -188,6 +191,26 @@ public:
   /// @brief Get the Z component of the parity check matrix
   /// @return Tensor representing Hz
   cudaqx::tensor<uint8_t> get_parity_z() const;
+
+  /// @brief Get the X-stabilizer schedule matrix passed to the code's
+  /// stabilizer_round kernel. Same shape and support pattern as
+  /// get_parity_x(); entry 0 means no support, entry k >= 1 means the
+  /// ancilla-data interaction executes at timestep k, so a code can encode an
+  /// optimized (e.g. hook-error-aware) gate order.
+  /// @return Tensor of scheduled interactions; the default implementation
+  /// returns get_parity_x() unchanged (every interaction at timestep 1, i.e.
+  /// ascending qubit-index order).
+  virtual cudaqx::tensor<uint8_t> get_stabilizer_schedule_x() const {
+    return get_parity_x();
+  }
+
+  /// @brief Get the Z-stabilizer schedule matrix passed to the code's
+  /// stabilizer_round kernel. See get_stabilizer_schedule_x().
+  /// @return Tensor of scheduled interactions; the default implementation
+  /// returns get_parity_z() unchanged.
+  virtual cudaqx::tensor<uint8_t> get_stabilizer_schedule_z() const {
+    return get_parity_z();
+  }
 
   /// @brief Get Lx stacked on Lz
   /// @return Tensor representing pauli observables

--- a/libs/qec/include/cudaq/qec/codes/surface_code.h
+++ b/libs/qec/include/cudaq/qec/codes/surface_code.h
@@ -196,6 +196,32 @@ public:
   /// @brief Get the stabilizers as a vector of cudaq::spin_op_terms
   std::vector<cudaq::spin_op_term> get_spin_op_stabilizers() const;
 
+  /// @brief Get the CNOT schedule matrix for the X stabilizers.
+  ///
+  /// @return Tensor with the same shape and support pattern as the X block of
+  /// the parity check matrix (num_x_stabilizers x distance^2). Entry 0 means
+  /// the ancilla does not touch that data qubit; entry k in [1, 4] means the
+  /// ancilla-data CNOT executes at timestep k of the stabilizer round.
+  ///
+  /// @note The per-plaquette CNOT order is chosen per the grid's orientation
+  /// so that mid-round ancilla faults ("hook errors"), which propagate onto
+  /// the data qubits of the remaining CNOTs, land perpendicular to the
+  /// same-type logical operator instead of along it, following the standard
+  /// zigzag schedule of https://arxiv.org/abs/1404.3747. Rows are ordered to
+  /// match the rows of to_parity_matrix()/code::get_parity_x().
+  cudaqx::tensor<uint8_t> get_cnot_schedule_x() const;
+
+  /// @brief Get the CNOT schedule matrix for the Z stabilizers.
+  ///
+  /// @return Tensor with the same shape and support pattern as the Z block of
+  /// the parity check matrix (num_z_stabilizers x distance^2). Entry 0 means
+  /// the ancilla does not touch that data qubit; entry k in [1, 4] means the
+  /// data-ancilla CNOT executes at timestep k of the stabilizer round.
+  ///
+  /// @note See get_cnot_schedule_x() for the hook-error rationale and row
+  /// ordering.
+  cudaqx::tensor<uint8_t> get_cnot_schedule_z() const;
+
   /// @brief Get the observables as a vector of cudaq::spin_op_terms
   ///
   /// @return The X logical observable first, followed by the Z logical
@@ -305,6 +331,14 @@ public:
   /// @brief Constructor for the surface_code
   surface_code(const heterogeneous_map &);
   // Grid constructor would be useful
+
+  /// @brief Get the hook-error-aware X-stabilizer CNOT schedule matrix.
+  /// See stabilizer_grid::get_cnot_schedule_x().
+  cudaqx::tensor<uint8_t> get_stabilizer_schedule_x() const override;
+
+  /// @brief Get the hook-error-aware Z-stabilizer CNOT schedule matrix.
+  /// See stabilizer_grid::get_cnot_schedule_z().
+  cudaqx::tensor<uint8_t> get_stabilizer_schedule_z() const override;
 
   /// @brief Extension creator function for the surface_code
   CUDAQ_EXTENSION_CUSTOM_CREATOR_FUNCTION(

--- a/libs/qec/include/cudaq/qec/codes/surface_code.h
+++ b/libs/qec/include/cudaq/qec/codes/surface_code.h
@@ -299,12 +299,15 @@ __qpu__ void prepm(patch p);
 ///
 /// @brief Perform stabilizer measurements on a surface_code patch
 /// @param p The patch to measure
-/// @param x_stabilizers Indices of X stabilizers to measure
-/// @param z_stabilizers Indices of Z stabilizers to measure
+/// @param x_stabilizer_schedule Flattened X-stabilizer CNOT schedule matrix
+/// (see stabilizer_grid::get_cnot_schedule_x): entry 0 = no support, entry
+/// k >= 1 = CNOT at timestep k
+/// @param z_stabilizer_schedule Flattened Z-stabilizer CNOT schedule matrix
+/// (see stabilizer_grid::get_cnot_schedule_z)
 /// @return Vector of measurement results
 __qpu__ std::vector<cudaq::measure_result>
-stabilizer(patch p, const std::vector<std::size_t> &x_stabilizers,
-           const std::vector<std::size_t> &z_stabilizers);
+stabilizer(patch p, const std::vector<std::size_t> &x_stabilizer_schedule,
+           const std::vector<std::size_t> &z_stabilizer_schedule);
 
 /// @brief surface_code implementation
 class surface_code : public cudaq::qec::code {

--- a/libs/qec/include/cudaq/qec/codes/surface_code.h
+++ b/libs/qec/include/cudaq/qec/codes/surface_code.h
@@ -222,6 +222,15 @@ public:
   /// ordering.
   cudaqx::tensor<uint8_t> get_cnot_schedule_z() const;
 
+  /// @brief Get the X-stabilizer CNOT schedule as a flat list of
+  /// (stabilizer index, data index) pairs, ordered by timestep within each
+  /// stabilizer — the replay format for kernels that take an explicit CNOT
+  /// pair list. Stabilizer indices match the rows of get_cnot_schedule_x().
+  std::vector<std::size_t> get_cnot_schedule_pairs_x() const;
+
+  /// @brief Z-stabilizer counterpart of get_cnot_schedule_pairs_x().
+  std::vector<std::size_t> get_cnot_schedule_pairs_z() const;
+
   /// @brief Get the observables as a vector of cudaq::spin_op_terms
   ///
   /// @return The X logical observable first, followed by the Z logical

--- a/libs/qec/lib/codes/surface_code.cpp
+++ b/libs/qec/lib/codes/surface_code.cpp
@@ -422,23 +422,54 @@ build_cnot_schedule(const std::vector<vec2d> &stab_coords,
 
   // Match the row order of to_parity_matrix(): within one stabilizer type the
   // sort comparator orders rows by the index of the first supported data
-  // qubit (no two same-type surface-code stabilizers share that index, so
-  // this order is total and deterministic).
-  auto first_support = [](const std::vector<uint8_t> &row) {
-    return std::find_if(row.begin(), row.end(),
-                        [](uint8_t v) { return v != 0; }) -
-           row.begin();
-  };
-  std::sort(rows.begin(), rows.end(),
-            [&](const std::vector<uint8_t> &a, const std::vector<uint8_t> &b) {
-              return first_support(a) < first_support(b);
-            });
+  // qubit. That order is total only because no two same-type surface-code
+  // stabilizers share a first-support index — enforce it rather than assume
+  // it, since a violation would silently pair schedule rows with the wrong
+  // ancilla/parity rows.
+  std::vector<std::pair<std::size_t, std::size_t>>
+      keyed; // (first support, row)
+  keyed.reserve(rows.size());
+  for (std::size_t r = 0; r < rows.size(); ++r) {
+    auto it = std::find_if(rows[r].begin(), rows[r].end(),
+                           [](uint8_t v) { return v != 0; });
+    keyed.emplace_back(it - rows[r].begin(), r);
+  }
+  std::sort(keyed.begin(), keyed.end());
+  for (std::size_t r = 1; r < keyed.size(); ++r)
+    if (keyed[r].first == keyed[r - 1].first)
+      throw std::runtime_error(
+          "surface-code CNOT schedule: two same-type stabilizers share their "
+          "first supported data qubit, so the schedule rows cannot be aligned "
+          "with the parity-matrix rows.");
 
   cudaqx::tensor<uint8_t> t({rows.size(), num_data});
   for (std::size_t r = 0; r < rows.size(); ++r)
     for (std::size_t c = 0; c < num_data; ++c)
-      t.at({r, c}) = rows[r][c];
+      t.at({r, c}) = rows[keyed[r].second][c];
   return t;
+}
+
+/// Flatten a schedule matrix into (stabilizer, data) index pairs ordered by
+/// timestep within each stabilizer — the replay format used by kernels that
+/// take an explicit CNOT pair list.
+std::vector<std::size_t>
+schedule_to_pairs(const cudaqx::tensor<uint8_t> &sched) {
+  std::vector<std::size_t> pairs;
+  const auto num_stabs = sched.shape()[0];
+  const auto num_data = sched.shape()[1];
+  std::vector<std::pair<uint8_t, std::size_t>> row; // (step, data)
+  for (std::size_t s = 0; s < num_stabs; ++s) {
+    row.clear();
+    for (std::size_t d = 0; d < num_data; ++d)
+      if (sched.at({s, d}) != 0)
+        row.emplace_back(sched.at({s, d}), d);
+    std::sort(row.begin(), row.end());
+    for (const auto &[step, d] : row) {
+      pairs.push_back(s);
+      pairs.push_back(d);
+    }
+  }
+  return pairs;
 }
 
 } // namespace
@@ -465,6 +496,14 @@ cudaqx::tensor<uint8_t> stabilizer_grid::get_cnot_schedule_z() const {
       orientation_ == sc_orientation::XV || orientation_ == sc_orientation::ZH;
   return build_cnot_schedule(z_stab_coords, data_indices, distance * distance,
                              /*use_col_major_order=*/!x_logical_on_top_row);
+}
+
+std::vector<std::size_t> stabilizer_grid::get_cnot_schedule_pairs_x() const {
+  return schedule_to_pairs(get_cnot_schedule_x());
+}
+
+std::vector<std::size_t> stabilizer_grid::get_cnot_schedule_pairs_z() const {
+  return schedule_to_pairs(get_cnot_schedule_z());
 }
 
 std::vector<cudaq::spin_op_term>

--- a/libs/qec/lib/codes/surface_code.cpp
+++ b/libs/qec/lib/codes/surface_code.cpp
@@ -386,6 +386,87 @@ stabilizer_grid::get_spin_op_stabilizers() const {
   return spin_op_stabs;
 }
 
+namespace {
+
+/// Corner offsets from a stabilizer grid coordinate to its four data qubits,
+/// listed in CNOT execution order (timesteps 1..4). Row-major ("Z"-shaped)
+/// visits NW, NE, SW, SE so the last two CNOTs touch a horizontally adjacent
+/// data pair; column-major ("N"-shaped) visits NW, SW, NE, SE so the last two
+/// touch a vertically adjacent pair. Assigning one shape to the X plaquettes
+/// and the transposed shape to the Z plaquettes is the standard zigzag
+/// schedule pair for the rotated surface code (Tomita & Svore,
+/// https://arxiv.org/abs/1404.3747; hook errors per Dennis et al.,
+/// https://arxiv.org/abs/quant-ph/0110143): it steers hook errors against
+/// the logical operators and stays conflict-free if the two timestep
+/// sequences are ever interleaved.
+constexpr int row_major_order[4][2] = {{-1, -1}, {-1, 0}, {0, -1}, {0, 0}};
+constexpr int col_major_order[4][2] = {{-1, -1}, {0, -1}, {-1, 0}, {0, 0}};
+
+cudaqx::tensor<uint8_t>
+build_cnot_schedule(const std::vector<vec2d> &stab_coords,
+                    const std::map<vec2d, size_t> &data_indices,
+                    std::size_t num_data, bool use_col_major_order) {
+  const auto &order = use_col_major_order ? col_major_order : row_major_order;
+  std::vector<std::vector<uint8_t>> rows;
+  rows.reserve(stab_coords.size());
+  for (const auto &sc : stab_coords) {
+    std::vector<uint8_t> row(num_data, 0);
+    for (int step = 0; step < 4; ++step) {
+      vec2d dq(sc.row + order[step][0], sc.col + order[step][1]);
+      auto it = data_indices.find(dq);
+      if (it != data_indices.end())
+        row[it->second] = step + 1;
+    }
+    rows.push_back(std::move(row));
+  }
+
+  // Match the row order of to_parity_matrix(): within one stabilizer type the
+  // sort comparator orders rows by the index of the first supported data
+  // qubit (no two same-type surface-code stabilizers share that index, so
+  // this order is total and deterministic).
+  auto first_support = [](const std::vector<uint8_t> &row) {
+    return std::find_if(row.begin(), row.end(),
+                        [](uint8_t v) { return v != 0; }) -
+           row.begin();
+  };
+  std::sort(rows.begin(), rows.end(),
+            [&](const std::vector<uint8_t> &a, const std::vector<uint8_t> &b) {
+              return first_support(a) < first_support(b);
+            });
+
+  cudaqx::tensor<uint8_t> t({rows.size(), num_data});
+  for (std::size_t r = 0; r < rows.size(); ++r)
+    for (std::size_t c = 0; c < num_data; ++c)
+      t.at({r, c}) = rows[r][c];
+  return t;
+}
+
+} // namespace
+
+cudaqx::tensor<uint8_t> stabilizer_grid::get_cnot_schedule_x() const {
+  // A fault on the ancilla mid-round propagates onto the data qubits of the
+  // CNOTs that have not executed yet ("hook error"): an X⊗X pair on the last
+  // two data qubits in the schedule. If the X logical runs along the top row
+  // (horizontal), that pair must be vertical (column-major order) so hook
+  // chains run against the logical instead of along it; otherwise the pair
+  // must be horizontal (row-major order).
+  const bool x_logical_on_top_row =
+      orientation_ == sc_orientation::XV || orientation_ == sc_orientation::ZH;
+  return build_cnot_schedule(x_stab_coords, data_indices, distance * distance,
+                             /*use_col_major_order=*/x_logical_on_top_row);
+}
+
+cudaqx::tensor<uint8_t> stabilizer_grid::get_cnot_schedule_z() const {
+  // Same reasoning as get_cnot_schedule_x() for Z⊗Z hook pairs versus the Z
+  // logical, which runs perpendicular to the X logical: the Z plaquettes use
+  // the transposed order. The two orders also form a conflict-free pair if
+  // the X and Z timesteps are ever interleaved.
+  const bool x_logical_on_top_row =
+      orientation_ == sc_orientation::XV || orientation_ == sc_orientation::ZH;
+  return build_cnot_schedule(z_stab_coords, data_indices, distance * distance,
+                             /*use_col_major_order=*/!x_logical_on_top_row);
+}
+
 std::vector<cudaq::spin_op_term>
 stabilizer_grid::get_spin_op_observables() const {
   std::vector<cudaq::spin_op_term> spin_op_obs;
@@ -478,6 +559,14 @@ std::size_t surface_code::get_num_x_stabilizers() const {
 
 std::size_t surface_code::get_num_z_stabilizers() const {
   return (distance * distance - 1) / 2;
+}
+
+cudaqx::tensor<uint8_t> surface_code::get_stabilizer_schedule_x() const {
+  return grid.get_cnot_schedule_x();
+}
+
+cudaqx::tensor<uint8_t> surface_code::get_stabilizer_schedule_z() const {
+  return grid.get_cnot_schedule_z();
 }
 
 /// @brief Register the surace_code type

--- a/libs/qec/lib/codes/surface_code_device.cpp
+++ b/libs/qec/lib/codes/surface_code_device.cpp
@@ -49,38 +49,28 @@ __qpu__ void prepm(patch logicalQubit) {
 }
 
 __qpu__ std::vector<cudaq::measure_result>
-stabilizer(patch logicalQubit, const std::vector<std::size_t> &x_stabilizers,
-           const std::vector<std::size_t> &z_stabilizers) {
+stabilizer(patch logicalQubit,
+           const std::vector<std::size_t> &x_stabilizer_schedule,
+           const std::vector<std::size_t> &z_stabilizer_schedule) {
   for (std::size_t i = 0; i < logicalQubit.ancx.size(); i++)
     reset(logicalQubit.ancx[i]);
   for (std::size_t i = 0; i < logicalQubit.ancz.size(); i++)
     reset(logicalQubit.ancz[i]);
 
-  // The stabilizer matrices are CNOT schedules: entry 0 means the ancilla
-  // does not touch that data qubit, entry k >= 1 means the CNOT executes at
-  // timestep k. The X and Z checks share the timesteps, giving one depth-4
-  // extraction round. The order matters twice over: per plaquette it steers
-  // mid-round ancilla (hook) errors perpendicular to the logical operators,
-  // and across the X/Z interleaving it must be a valid schedule pair so the
-  // non-commuting CNOTs still measure the intended stabilizers (see
-  // stabilizer_grid::get_cnot_schedule_x).
-  std::size_t num_steps = 1;
-  for (std::size_t i = 0; i < x_stabilizers.size(); ++i)
-    if (x_stabilizers[i] > num_steps)
-      num_steps = x_stabilizers[i];
-  for (std::size_t i = 0; i < z_stabilizers.size(); ++i)
-    if (z_stabilizers[i] > num_steps)
-      num_steps = z_stabilizers[i];
+  // The X and Z checks share the timesteps, and the surface-code schedule
+  // always fits in one depth-4 extraction round (see
+  // stabilizer_grid::get_cnot_schedule_x), so num_steps is a constant.
+  const std::size_t num_steps = 4;
 
   h(logicalQubit.ancx);
   for (std::size_t step = 1; step <= num_steps; ++step) {
     for (std::size_t xi = 0; xi < logicalQubit.ancx.size(); ++xi)
       for (std::size_t di = 0; di < logicalQubit.data.size(); ++di)
-        if (x_stabilizers[xi * logicalQubit.data.size() + di] == step)
+        if (x_stabilizer_schedule[xi * logicalQubit.data.size() + di] == step)
           cudaq::x<cudaq::ctrl>(logicalQubit.ancx[xi], logicalQubit.data[di]);
     for (std::size_t zi = 0; zi < logicalQubit.ancz.size(); ++zi)
       for (std::size_t di = 0; di < logicalQubit.data.size(); ++di)
-        if (z_stabilizers[zi * logicalQubit.data.size() + di] == step)
+        if (z_stabilizer_schedule[zi * logicalQubit.data.size() + di] == step)
           cudaq::x<cudaq::ctrl>(logicalQubit.data[di], logicalQubit.ancz[zi]);
   }
   h(logicalQubit.ancx);

--- a/libs/qec/lib/codes/surface_code_device.cpp
+++ b/libs/qec/lib/codes/surface_code_device.cpp
@@ -56,18 +56,34 @@ stabilizer(patch logicalQubit, const std::vector<std::size_t> &x_stabilizers,
   for (std::size_t i = 0; i < logicalQubit.ancz.size(); i++)
     reset(logicalQubit.ancz[i]);
 
-  h(logicalQubit.ancx);
-  for (std::size_t xi = 0; xi < logicalQubit.ancx.size(); ++xi)
-    for (std::size_t di = 0; di < logicalQubit.data.size(); ++di)
-      if (x_stabilizers[xi * logicalQubit.data.size() + di] == 1)
-        cudaq::x<cudaq::ctrl>(logicalQubit.ancx[xi], logicalQubit.data[di]);
-  h(logicalQubit.ancx);
+  // The stabilizer matrices are CNOT schedules: entry 0 means the ancilla
+  // does not touch that data qubit, entry k >= 1 means the CNOT executes at
+  // timestep k. The X and Z checks share the timesteps, giving one depth-4
+  // extraction round. The order matters twice over: per plaquette it steers
+  // mid-round ancilla (hook) errors perpendicular to the logical operators,
+  // and across the X/Z interleaving it must be a valid schedule pair so the
+  // non-commuting CNOTs still measure the intended stabilizers (see
+  // stabilizer_grid::get_cnot_schedule_x).
+  std::size_t num_steps = 1;
+  for (std::size_t i = 0; i < x_stabilizers.size(); ++i)
+    if (x_stabilizers[i] > num_steps)
+      num_steps = x_stabilizers[i];
+  for (std::size_t i = 0; i < z_stabilizers.size(); ++i)
+    if (z_stabilizers[i] > num_steps)
+      num_steps = z_stabilizers[i];
 
-  // Now apply z_stabilizer circuit
-  for (size_t zi = 0; zi < logicalQubit.ancz.size(); ++zi)
-    for (size_t di = 0; di < logicalQubit.data.size(); ++di)
-      if (z_stabilizers[zi * logicalQubit.data.size() + di] == 1)
-        cudaq::x<cudaq::ctrl>(logicalQubit.data[di], logicalQubit.ancz[zi]);
+  h(logicalQubit.ancx);
+  for (std::size_t step = 1; step <= num_steps; ++step) {
+    for (std::size_t xi = 0; xi < logicalQubit.ancx.size(); ++xi)
+      for (std::size_t di = 0; di < logicalQubit.data.size(); ++di)
+        if (x_stabilizers[xi * logicalQubit.data.size() + di] == step)
+          cudaq::x<cudaq::ctrl>(logicalQubit.ancx[xi], logicalQubit.data[di]);
+    for (std::size_t zi = 0; zi < logicalQubit.ancz.size(); ++zi)
+      for (std::size_t di = 0; di < logicalQubit.data.size(); ++di)
+        if (z_stabilizers[zi * logicalQubit.data.size() + di] == step)
+          cudaq::x<cudaq::ctrl>(logicalQubit.data[di], logicalQubit.ancz[zi]);
+  }
+  h(logicalQubit.ancx);
 
   // S = (S_X, S_Z), (x flip syndromes, z flip syndromes).
   // x flips are triggered by z-stabilizers (ancz)

--- a/libs/qec/lib/device/memory_circuit.cpp
+++ b/libs/qec/lib/device/memory_circuit.cpp
@@ -10,15 +10,14 @@
 
 namespace cudaq::qec {
 
-__qpu__ void memory_circuit(const code::stabilizer_round &stabilizer_round,
-                            const code::one_qubit_encoding &statePrep,
-                            std::size_t num_data, std::size_t numAncx,
-                            std::size_t numAncz, std::size_t num_rounds,
-                            const std::vector<std::size_t> &x_stabilizers,
-                            const std::vector<std::size_t> &z_stabilizers,
-                            const std::vector<std::size_t> &obs_matrix_flat,
-                            std::size_t num_observables,
-                            bool measure_in_x_basis) {
+__qpu__ void
+memory_circuit(const code::stabilizer_round &stabilizer_round,
+               const code::one_qubit_encoding &statePrep, std::size_t num_data,
+               std::size_t numAncx, std::size_t numAncz, std::size_t num_rounds,
+               const std::vector<std::size_t> &x_stabilizer_schedule,
+               const std::vector<std::size_t> &z_stabilizer_schedule,
+               const std::vector<std::size_t> &obs_matrix_flat,
+               std::size_t num_observables, bool measure_in_x_basis) {
   // Allocate the data and ancilla qubits
   cudaq::qvector data(num_data), xstab_anc(numAncx), zstab_anc(numAncz);
 
@@ -30,7 +29,8 @@ __qpu__ void memory_circuit(const code::stabilizer_round &stabilizer_round,
 
   // The "off-basis" detectors will be non-deterministic after the first
   // stabilizer round.
-  auto final_syndrome = stabilizer_round(logical, x_stabilizers, z_stabilizers);
+  auto final_syndrome =
+      stabilizer_round(logical, x_stabilizer_schedule, z_stabilizer_schedule);
   std::size_t num_fixed_measurements =
       measure_in_x_basis ? xstab_anc.size() : zstab_anc.size();
   std::size_t fixed_offset =
@@ -41,7 +41,8 @@ __qpu__ void memory_circuit(const code::stabilizer_round &stabilizer_round,
 
   // Generate syndrome data
   for (std::size_t round = 1; round < num_rounds; ++round) {
-    auto syndrome = stabilizer_round(logical, x_stabilizers, z_stabilizers);
+    auto syndrome =
+        stabilizer_round(logical, x_stabilizer_schedule, z_stabilizer_schedule);
     cudaq::detectors(final_syndrome, syndrome);
     final_syndrome = syndrome;
   }
@@ -68,16 +69,16 @@ __qpu__ void memory_circuit(const code::stabilizer_round &stabilizer_round,
   }
 
   // For each stabilizer, form detectors from data qubit readout connected with
-  // final stabilizer round.
-  const std::vector<size_t> &stabilizers =
-      measure_in_x_basis ? x_stabilizers : z_stabilizers;
+  // final stabilizer round. Any nonzero schedule entry marks support.
+  const std::vector<size_t> &stabilizer_schedule =
+      measure_in_x_basis ? x_stabilizer_schedule : z_stabilizer_schedule;
 
   for (std::size_t x = 0; x < num_fixed_measurements; ++x) {
     std::size_t row_base = x * num_data;
 
     std::size_t support_weight = 0;
     for (std::size_t q = 0; q < num_data; ++q) {
-      if (stabilizers[row_base + q] != 0) {
+      if (stabilizer_schedule[row_base + q] != 0) {
         support_weight++;
       }
     }
@@ -86,7 +87,7 @@ __qpu__ void memory_circuit(const code::stabilizer_round &stabilizer_round,
     support[0] = final_syndrome[fixed_offset + x];
     std::size_t support_idx = 1;
     for (std::size_t q = 0; q < num_data; ++q) {
-      if (stabilizers[row_base + q] != 0) {
+      if (stabilizer_schedule[row_base + q] != 0) {
         support[support_idx++] = data_results[q];
       }
     }

--- a/libs/qec/lib/device/memory_circuit.h
+++ b/libs/qec/lib/device/memory_circuit.h
@@ -23,19 +23,21 @@ namespace cudaq::qec {
 /// @param numAncx Number of ancilla x qubits in the code
 /// @param numAncz Number of ancilla z qubits in the code
 /// @param numRounds Number of rounds to execute the memory circuit
-/// @param x_stabilizers Vector of indices for X stabilizers
-/// @param z_stabilizers Vector of indices for Z stabilizers
+/// @param x_stabilizer_schedule Row-major flattened X-stabilizer schedule
+///        matrix (see code::get_stabilizer_schedule_x): entry 0 = no support,
+///        entry k >= 1 = interaction at timestep k.
+/// @param z_stabilizer_schedule Row-major flattened Z-stabilizer schedule
+///        matrix (see code::get_stabilizer_schedule_z).
 /// @param obs_matrix_flat Row-major flattened logical observable matrix
 ///        (num_observables × numData entries, values 0/1).
 /// @param num_observables Number of rows in the observable matrix (k).
 /// @param measure_in_x_basis Performing X- or Z-memory circuit
-__qpu__ void memory_circuit(const code::stabilizer_round &stabilizer_round,
-                            const code::one_qubit_encoding &statePrep,
-                            std::size_t numData, std::size_t numAncx,
-                            std::size_t numAncz, std::size_t numRounds,
-                            const std::vector<std::size_t> &x_stabilizers,
-                            const std::vector<std::size_t> &z_stabilizers,
-                            const std::vector<std::size_t> &obs_matrix_flat,
-                            std::size_t num_observables,
-                            bool measure_in_x_basis);
+__qpu__ void
+memory_circuit(const code::stabilizer_round &stabilizer_round,
+               const code::one_qubit_encoding &statePrep, std::size_t numData,
+               std::size_t numAncx, std::size_t numAncz, std::size_t numRounds,
+               const std::vector<std::size_t> &x_stabilizer_schedule,
+               const std::vector<std::size_t> &z_stabilizer_schedule,
+               const std::vector<std::size_t> &obs_matrix_flat,
+               std::size_t num_observables, bool measure_in_x_basis);
 } // namespace cudaq::qec

--- a/libs/qec/lib/experiments.cpp
+++ b/libs/qec/lib/experiments.cpp
@@ -289,18 +289,20 @@ sample_memory_circuit(const code &code, operation statePrep,
   auto &stabRound =
       code.get_operation<code::stabilizer_round>(operation::stabilizer_round);
 
-  auto parity_x = code.get_parity_x();
-  auto parity_z = code.get_parity_z();
+  // Schedule matrices, not plain parity matrices: nonzero entries carry the
+  // per-stabilizer interaction timestep (see code::get_stabilizer_schedule_x).
+  auto sched_x = code.get_stabilizer_schedule_x();
+  auto sched_z = code.get_stabilizer_schedule_z();
   auto numData = code.get_num_data_qubits();
   auto numAncx = code.get_num_ancilla_x_qubits();
   auto numAncz = code.get_num_ancilla_z_qubits();
   auto numXStabs = code.get_num_x_stabilizers();
   auto numZStabs = code.get_num_z_stabilizers();
 
-  std::vector<std::size_t> xVec(parity_x.data(),
-                                parity_x.data() + parity_x.size());
-  std::vector<std::size_t> zVec(parity_z.data(),
-                                parity_z.data() + parity_z.size());
+  std::vector<std::size_t> xVec(sched_x.data(),
+                                sched_x.data() + sched_x.size());
+  std::vector<std::size_t> zVec(sched_z.data(),
+                                sched_z.data() + sched_z.size());
   auto logical_obs =
       is_z_prep ? code.get_observables_z() : code.get_observables_x();
   const std::size_t num_obs = logical_obs.shape()[0];
@@ -461,17 +463,19 @@ dem_from_memory_circuit(const code &code, operation statePrep,
   auto &prep = code.get_operation<code::one_qubit_encoding>(statePrep);
   auto &stabRound =
       code.get_operation<code::stabilizer_round>(operation::stabilizer_round);
-  auto parity_x = code.get_parity_x();
-  auto parity_z = code.get_parity_z();
+  // Schedule matrices, not plain parity matrices: nonzero entries carry the
+  // per-stabilizer interaction timestep (see code::get_stabilizer_schedule_x).
+  auto sched_x = code.get_stabilizer_schedule_x();
+  auto sched_z = code.get_stabilizer_schedule_z();
   auto numData = code.get_num_data_qubits();
   auto numAncx = code.get_num_ancilla_x_qubits();
   auto numAncz = code.get_num_ancilla_z_qubits();
   bool is_z_prep =
       statePrep == operation::prep0 || statePrep == operation::prep1;
-  std::vector<std::size_t> xVec(parity_x.data(),
-                                parity_x.data() + parity_x.size());
-  std::vector<std::size_t> zVec(parity_z.data(),
-                                parity_z.data() + parity_z.size());
+  std::vector<std::size_t> xVec(sched_x.data(),
+                                sched_x.data() + sched_x.size());
+  std::vector<std::size_t> zVec(sched_z.data(),
+                                sched_z.data() + sched_z.size());
 
   auto logical_obs =
       is_z_prep ? code.get_observables_z() : code.get_observables_x();

--- a/libs/qec/python/bindings/py_code.cpp
+++ b/libs/qec/python/bindings/py_code.cpp
@@ -398,6 +398,26 @@ void bindCode(nb::module_ &mod) {
           },
           "Get the Z-type parity check matrix of the code")
       .def(
+          "get_stabilizer_schedule_x",
+          [](code &code) {
+            return copyCodeMatrixToPyArray(code.get_stabilizer_schedule_x(),
+                                           code.get_num_data_qubits());
+          },
+          "Get the X-stabilizer schedule matrix passed to the code's "
+          "stabilizer_round kernel. Entry 0 = no support, entry k >= 1 = "
+          "interaction at timestep k; defaults to the X-type parity check "
+          "matrix (every interaction at timestep 1).")
+      .def(
+          "get_stabilizer_schedule_z",
+          [](code &code) {
+            return copyCodeMatrixToPyArray(code.get_stabilizer_schedule_z(),
+                                           code.get_num_data_qubits());
+          },
+          "Get the Z-stabilizer schedule matrix passed to the code's "
+          "stabilizer_round kernel. Entry 0 = no support, entry k >= 1 = "
+          "interaction at timestep k; defaults to the Z-type parity check "
+          "matrix (every interaction at timestep 1).")
+      .def(
           "get_pauli_observables_matrix",
           [](code &code) {
             return copyCodeMatrixToPyArray(code.get_pauli_observables_matrix(),

--- a/libs/qec/python/bindings/py_code.cpp
+++ b/libs/qec/python/bindings/py_code.cpp
@@ -211,6 +211,77 @@ protected:
   std::size_t get_num_z_stabilizers() const override {
     return nb::cast<std::size_t>(pyCode.attr("get_num_z_stabilizers")());
   }
+
+  /// @brief True if the Python class itself defines this method. A plain
+  /// hasattr won't do: the @qec.code decorator makes the class inherit from
+  /// the bound Code class, which exposes same-named read-only getters.
+  bool has_py_override(const char *methodName) const {
+    nb::handle base = nb::type<qec::code>();
+    for (nb::handle cls : nb::cast<nb::tuple>(pyCode.type().attr("__mro__"))) {
+      if (cls.is(base))
+        break;
+      if (nb::cast<bool>(cls.attr("__dict__").attr("__contains__")(methodName)))
+        return true;
+    }
+    return false;
+  }
+
+  /// @brief Convert a Python-provided stabilizer schedule matrix (any 2D
+  /// sequence of integers in [0, 255]) into a tensor, validating it against
+  /// the corresponding parity matrix.
+  cudaqx::tensor<uint8_t>
+  py_stabilizer_schedule(const char *methodName,
+                         const cudaqx::tensor<uint8_t> &parity) const {
+    std::vector<std::vector<uint8_t>> rows;
+    try {
+      rows = nb::cast<std::vector<std::vector<uint8_t>>>(
+          pyCode.attr(methodName)());
+    } catch (...) {
+      throw std::runtime_error(
+          std::string(methodName) +
+          " must return a 2D array/list of integers in [0, 255].");
+    }
+    if (rows.empty()) {
+      if (parity.size() != 0)
+        throw std::runtime_error(std::string(methodName) +
+                                 " shape does not match the parity matrix.");
+      return parity;
+    }
+    const std::size_t num_cols = rows[0].size();
+    if (parity.rank() != 2 || parity.shape()[0] != rows.size() ||
+        parity.shape()[1] != num_cols)
+      throw std::runtime_error(std::string(methodName) +
+                               " shape does not match the parity matrix.");
+    cudaqx::tensor<uint8_t> schedule({rows.size(), num_cols});
+    for (std::size_t r = 0; r < rows.size(); ++r) {
+      if (rows[r].size() != num_cols)
+        throw std::runtime_error(std::string(methodName) +
+                                 " rows must all have the same length.");
+      for (std::size_t c = 0; c < num_cols; ++c) {
+        // A schedule may reorder interactions but not change which data
+        // qubits each stabilizer touches.
+        if ((rows[r][c] != 0) != (parity.at({r, c}) != 0))
+          throw std::runtime_error(
+              std::string(methodName) +
+              " support pattern does not match the parity matrix.");
+        schedule.at({r, c}) = rows[r][c];
+      }
+    }
+    return schedule;
+  }
+
+public:
+  cudaqx::tensor<uint8_t> get_stabilizer_schedule_x() const override {
+    if (!has_py_override("get_stabilizer_schedule_x"))
+      return code::get_stabilizer_schedule_x();
+    return py_stabilizer_schedule("get_stabilizer_schedule_x", get_parity_x());
+  }
+
+  cudaqx::tensor<uint8_t> get_stabilizer_schedule_z() const override {
+    if (!has_py_override("get_stabilizer_schedule_z"))
+      return code::get_stabilizer_schedule_z();
+    return py_stabilizer_schedule("get_stabilizer_schedule_z", get_parity_z());
+  }
 };
 
 namespace {

--- a/libs/qec/python/bindings/py_surface_code.cpp
+++ b/libs/qec/python/bindings/py_surface_code.cpp
@@ -134,7 +134,37 @@ void bindSurfaceCode(nb::module_ &mod) {
            "Return the stabilizers as a list of cudaq::spin_op_term")
       .def("get_spin_op_observables", &stabilizer_grid::get_spin_op_observables,
            "Return the logical observables as [X, Z] cudaq::spin_op_term "
-           "entries");
+           "entries")
+      .def(
+          "get_cnot_schedule_x",
+          [](const stabilizer_grid &g) {
+            auto t = g.get_cnot_schedule_x();
+            std::vector<std::vector<uint8_t>> rows(
+                t.shape()[0], std::vector<uint8_t>(t.shape()[1]));
+            for (std::size_t r = 0; r < t.shape()[0]; ++r)
+              for (std::size_t c = 0; c < t.shape()[1]; ++c)
+                rows[r][c] = t.at({r, c});
+            return rows;
+          },
+          "Return the X-stabilizer CNOT schedule matrix as a list of rows "
+          "matching the sorted parity-matrix rows. Entry 0 = no support, "
+          "k >= 1 = CNOT timestep, ordered so that ancilla (hook) errors "
+          "land perpendicular to the logical operators.")
+      .def(
+          "get_cnot_schedule_z",
+          [](const stabilizer_grid &g) {
+            auto t = g.get_cnot_schedule_z();
+            std::vector<std::vector<uint8_t>> rows(
+                t.shape()[0], std::vector<uint8_t>(t.shape()[1]));
+            for (std::size_t r = 0; r < t.shape()[0]; ++r)
+              for (std::size_t c = 0; c < t.shape()[1]; ++c)
+                rows[r][c] = t.at({r, c});
+            return rows;
+          },
+          "Return the Z-stabilizer CNOT schedule matrix as a list of rows "
+          "matching the sorted parity-matrix rows. Entry 0 = no support, "
+          "k >= 1 = CNOT timestep, ordered so that ancilla (hook) errors "
+          "land perpendicular to the logical operators.");
 
   qecmod.def("role_to_str", [](surface_role r) {
     switch (r) {

--- a/libs/qec/python/bindings/py_surface_code.cpp
+++ b/libs/qec/python/bindings/py_surface_code.cpp
@@ -7,6 +7,7 @@
  ******************************************************************************/
 
 #include "py_surface_code.h"
+#include "type_casters.h"
 
 #include <nanobind/nanobind.h>
 #include <nanobind/stl/string.h>
@@ -138,33 +139,33 @@ void bindSurfaceCode(nb::module_ &mod) {
       .def(
           "get_cnot_schedule_x",
           [](const stabilizer_grid &g) {
-            auto t = g.get_cnot_schedule_x();
-            std::vector<std::vector<uint8_t>> rows(
-                t.shape()[0], std::vector<uint8_t>(t.shape()[1]));
-            for (std::size_t r = 0; r < t.shape()[0]; ++r)
-              for (std::size_t c = 0; c < t.shape()[1]; ++c)
-                rows[r][c] = t.at({r, c});
-            return rows;
+            return cudaq::python::copyCUDAQXTensorToPyArray(
+                g.get_cnot_schedule_x());
           },
-          "Return the X-stabilizer CNOT schedule matrix as a list of rows "
-          "matching the sorted parity-matrix rows. Entry 0 = no support, "
-          "k >= 1 = CNOT timestep, ordered so that ancilla (hook) errors "
-          "land perpendicular to the logical operators.")
+          "Return the X-stabilizer CNOT schedule matrix as a numpy array "
+          "whose rows match the sorted parity-matrix rows. Entry 0 = no "
+          "support, k >= 1 = CNOT timestep, ordered so that ancilla (hook) "
+          "errors land perpendicular to the logical operators.")
       .def(
           "get_cnot_schedule_z",
           [](const stabilizer_grid &g) {
-            auto t = g.get_cnot_schedule_z();
-            std::vector<std::vector<uint8_t>> rows(
-                t.shape()[0], std::vector<uint8_t>(t.shape()[1]));
-            for (std::size_t r = 0; r < t.shape()[0]; ++r)
-              for (std::size_t c = 0; c < t.shape()[1]; ++c)
-                rows[r][c] = t.at({r, c});
-            return rows;
+            return cudaq::python::copyCUDAQXTensorToPyArray(
+                g.get_cnot_schedule_z());
           },
-          "Return the Z-stabilizer CNOT schedule matrix as a list of rows "
-          "matching the sorted parity-matrix rows. Entry 0 = no support, "
-          "k >= 1 = CNOT timestep, ordered so that ancilla (hook) errors "
-          "land perpendicular to the logical operators.");
+          "Return the Z-stabilizer CNOT schedule matrix as a numpy array "
+          "whose rows match the sorted parity-matrix rows. Entry 0 = no "
+          "support, k >= 1 = CNOT timestep, ordered so that ancilla (hook) "
+          "errors land perpendicular to the logical operators.")
+      .def("get_cnot_schedule_pairs_x",
+           &stabilizer_grid::get_cnot_schedule_pairs_x,
+           "Return the X-stabilizer CNOT schedule as a flat list of "
+           "(stabilizer index, data index) pairs ordered by timestep within "
+           "each stabilizer.")
+      .def("get_cnot_schedule_pairs_z",
+           &stabilizer_grid::get_cnot_schedule_pairs_z,
+           "Return the Z-stabilizer CNOT schedule as a flat list of "
+           "(stabilizer index, data index) pairs ordered by timestep within "
+           "each stabilizer.");
 
   qecmod.def("role_to_str", [](surface_role r) {
     switch (r) {

--- a/libs/qec/python/tests/test_code.py
+++ b/libs/qec/python/tests/test_code.py
@@ -10,6 +10,7 @@ import numpy as np
 import cudaq
 import cudaq_qec as qec
 from cudaq_qec import patch
+from cudaq_qec.plugins.codes import example
 
 
 def test_get_code():
@@ -164,6 +165,125 @@ def test_python_code():
     assert syndromes.shape == (10, 24)
     print(syndromes)
     assert not np.any(syndromes)
+
+
+# A stabilizer_round kernel that honors the schedule entries: the CNOT for a
+# nonzero entry k executes at timestep k (the example plugin's kernel instead
+# tests `== 1`, i.e. plain parity support).
+@cudaq.kernel
+def _scheduled_stabilizer(logicalQubit: patch, x_schedule: list[int],
+                          z_schedule: list[int]) -> list[cudaq.measure_handle]:
+    h(logicalQubit.ancx)
+    for step in range(1, 5):
+        for xi in range(len(logicalQubit.ancx)):
+            for di in range(len(logicalQubit.data)):
+                if x_schedule[xi * len(logicalQubit.data) + di] == step:
+                    x.ctrl(logicalQubit.ancx[xi], logicalQubit.data[di])
+    h(logicalQubit.ancx)
+    for step in range(1, 5):
+        for zi in range(len(logicalQubit.ancz)):
+            for di in range(len(logicalQubit.data)):
+                if z_schedule[zi * len(logicalQubit.data) + di] == step:
+                    x.ctrl(logicalQubit.data[di], logicalQubit.ancz[zi])
+
+    results = mz([*logicalQubit.ancz, *logicalQubit.ancx])
+
+    reset(logicalQubit.ancx)
+    reset(logicalQubit.ancz)
+    return results
+
+
+def _make_scheduled_steane(name, schedule_x, schedule_z):
+    """Register a Python Steane code that provides stabilizer schedules."""
+
+    @qec.code(name)
+    class ScheduledSteane:
+
+        def __init__(self, **kwargs):
+            qec.Code.__init__(self, **kwargs)
+            self.stabilizers = [
+                cudaq.SpinOperator.from_word(w) for w in [
+                    "XXXXIII", "IXXIXXI", "IIXXIXX", "ZZZZIII", "IZZIZZI",
+                    "IIZZIZZ"
+                ]
+            ]
+            self.pauli_observables = [
+                cudaq.SpinOperator.from_word(p) for p in ["IIIIXXX", "IIIIZZZ"]
+            ]
+            self.operation_encodings = {
+                qec.operation.prep0: example.prep0,
+                qec.operation.stabilizer_round: _scheduled_stabilizer
+            }
+
+        def get_num_data_qubits(self):
+            return 7
+
+        def get_num_ancilla_x_qubits(self):
+            return 3
+
+        def get_num_ancilla_z_qubits(self):
+            return 3
+
+        def get_num_ancilla_qubits(self):
+            return 6
+
+        def get_num_x_stabilizers(self):
+            return 3
+
+        def get_num_z_stabilizers(self):
+            return 3
+
+        def get_stabilizer_schedule_x(self):
+            return schedule_x
+
+        def get_stabilizer_schedule_z(self):
+            return schedule_z
+
+    return qec.get_code(name)
+
+
+def test_python_code_stabilizer_schedule():
+    # A Python code may provide schedule matrices: same support as the parity
+    # matrices, with entries giving the interaction timestep.
+    steane = qec.get_code("py-steane-example")
+    parity_x = steane.get_parity_x()
+    parity_z = steane.get_parity_z()
+
+    # Without the optional methods, the schedule defaults to the parity.
+    assert np.array_equal(steane.get_stabilizer_schedule_x(), parity_x)
+    assert np.array_equal(steane.get_stabilizer_schedule_z(), parity_z)
+
+    # Number the interactions within each stabilizer to form a schedule.
+    schedule_x = (np.cumsum(parity_x, axis=1) * parity_x).astype(np.uint8)
+    schedule_z = (np.cumsum(parity_z, axis=1) * parity_z).astype(np.uint8)
+    code = _make_scheduled_steane("py-steane-scheduled", schedule_x, schedule_z)
+    assert np.array_equal(code.get_stabilizer_schedule_x(), schedule_x)
+    assert np.array_equal(code.get_stabilizer_schedule_z(), schedule_z)
+
+    # The schedule must flow through to the sampled memory circuit.
+    syndromes, _ = qec.sample_memory_circuit(code, numShots=10, numRounds=4)
+    assert syndromes.shape == (10, 24)
+    assert not np.any(syndromes)
+
+
+def test_python_code_stabilizer_schedule_invalid():
+    steane = qec.get_code("py-steane-example")
+    parity_x = steane.get_parity_x()
+    parity_z = steane.get_parity_z()
+
+    # Wrong shape.
+    bad = _make_scheduled_steane("py-steane-bad-schedule-shape",
+                                 parity_x[:, :-1], parity_z)
+    with pytest.raises(RuntimeError, match="shape"):
+        bad.get_stabilizer_schedule_x()
+
+    # Support pattern differs from the parity matrix.
+    flipped = parity_x.copy()
+    flipped[0, 0] ^= 1
+    bad = _make_scheduled_steane("py-steane-bad-schedule-support", flipped,
+                                 parity_z)
+    with pytest.raises(RuntimeError, match="support"):
+        bad.get_stabilizer_schedule_x()
 
 
 # stabilizer_round kernels with invalid (non list[cudaq.measure_handle])

--- a/libs/qec/python/tests/test_code.py
+++ b/libs/qec/python/tests/test_code.py
@@ -39,6 +39,27 @@ def test_code_parity_matrices():
     assert parity_z.shape == (3, 7)
 
 
+def test_code_stabilizer_schedule_matrices():
+    # Codes without a schedule override return the plain parity matrices.
+    steane = qec.get_code("steane")
+    assert np.array_equal(steane.get_stabilizer_schedule_x(),
+                          steane.get_parity_x())
+    assert np.array_equal(steane.get_stabilizer_schedule_z(),
+                          steane.get_parity_z())
+
+    # The surface code overrides the schedule: same support pattern as the
+    # parity matrices, entries are CNOT timesteps in [1, 4].
+    surface = qec.get_code("surface_code", distance=3)
+    for schedule, parity in [
+        (surface.get_stabilizer_schedule_x(), surface.get_parity_x()),
+        (surface.get_stabilizer_schedule_z(), surface.get_parity_z())
+    ]:
+        assert isinstance(schedule, np.ndarray)
+        assert schedule.shape == parity.shape
+        assert np.array_equal(schedule != 0, parity != 0)
+        assert schedule.max() <= 4
+
+
 def test_repetition_empty_x_matrices_preserve_rank():
     repetition = qec.get_code("repetition", distance=3)
 

--- a/libs/qec/unittests/backend-specific/stim/test_qec_stim.cpp
+++ b/libs/qec/unittests/backend-specific/stim/test_qec_stim.cpp
@@ -6,8 +6,11 @@
  * the terms of the Apache License 2.0 which accompanies this distribution.    *
  ******************************************************************************/
 
+#include <array>
 #include <cmath>
+#include <deque>
 #include <gtest/gtest.h>
+#include <limits>
 
 #include "cudaq.h"
 
@@ -652,4 +655,87 @@ TEST(QECCodeTester, checkDemFromMemoryCircuit) {
       "............................111"};
   check_matrix_bits("observables_flips_matrix", dem.observables_flips_matrix,
                     expected_observables_flips_matrix_str);
+}
+
+// Shortest undetectable logical error of a graphlike DEM. Detectors are graph
+// nodes (plus one virtual boundary node), each error mechanism with <= 2
+// flipped detectors is an edge labeled with its observable flip, and the
+// effective distance is the shortest boundary-to-boundary walk with an odd
+// number of observable flips (BFS over (node, parity) states). Error
+// mechanisms flipping more than 2 detectors are skipped; that can only
+// overestimate the distance, so the equality assertion below stays sound.
+static std::size_t
+shortest_graphlike_logical_error(const cudaq::qec::detector_error_model &dem) {
+  const std::size_t numDet = dem.num_detectors();
+  const std::size_t numErr = dem.num_error_mechanisms();
+  const std::size_t boundary = numDet;
+  struct Edge {
+    std::size_t to;
+    bool obs;
+  };
+  std::vector<std::vector<Edge>> adj(numDet + 1);
+  for (std::size_t e = 0; e < numErr; ++e) {
+    std::vector<std::size_t> dets;
+    for (std::size_t d = 0; d < numDet && dets.size() <= 2; ++d)
+      if (dem.detector_error_matrix.at({d, e}))
+        dets.push_back(d);
+    if (dets.size() > 2)
+      continue;
+    const bool obs = dem.observables_flips_matrix.at({0, e}) != 0;
+    const std::size_t u = dets.empty() ? boundary : dets[0];
+    const std::size_t v = dets.size() == 2 ? dets[1] : boundary;
+    adj[u].push_back({v, obs});
+    if (u != v)
+      adj[v].push_back({u, obs});
+  }
+  std::vector<std::array<long, 2>> dist(numDet + 1, {-1, -1});
+  std::deque<std::pair<std::size_t, int>> queue;
+  dist[boundary][0] = 0;
+  queue.push_back({boundary, 0});
+  while (!queue.empty()) {
+    auto [u, p] = queue.front();
+    queue.pop_front();
+    for (const auto &edge : adj[u]) {
+      const int np = p ^ (edge.obs ? 1 : 0);
+      if (dist[edge.to][np] < 0) {
+        dist[edge.to][np] = dist[u][p] + 1;
+        queue.push_back({edge.to, np});
+      }
+    }
+  }
+  return dist[boundary][1] < 0 ? std::numeric_limits<std::size_t>::max()
+                               : static_cast<std::size_t>(dist[boundary][1]);
+}
+
+// Under circuit-level (two-qubit gate) noise the surface code only retains
+// its full code distance if the per-plaquette CNOT order steers hook errors
+// perpendicular to the logical operators. A same-order schedule for X and Z
+// plaquettes halves the effective distance of one of the two memory bases.
+TEST(QECCodeTester, checkSurfaceCodeEffectiveDistance) {
+  for (std::size_t distance : {3, 5}) {
+    // Each orientation assigns the two schedule shapes to opposite plaquette
+    // types, so every orientation must retain the full distance in both
+    // memory bases.
+    for (const std::string orientation : {"XV", "XH", "ZV", "ZH"}) {
+      auto code = cudaq::qec::get_code(
+          "surface_code",
+          cudaqx::heterogeneous_map{{"distance", distance},
+                                    {"orientation", orientation}});
+      for (auto prep :
+           {cudaq::qec::operation::prep0, cudaq::qec::operation::prepp}) {
+        cudaq::noise_model noise;
+        noise.add_all_qubit_channel("x",
+                                    cudaq::qec::two_qubit_depolarization(0.001),
+                                    /*num_controls=*/1);
+        auto dem = cudaq::qec::dem_from_memory_circuit(
+            *code, prep, /*numRounds=*/distance, noise,
+            /*decompose_errors=*/true);
+        ASSERT_EQ(dem.num_observables(), 1);
+        EXPECT_EQ(distance, shortest_graphlike_logical_error(dem))
+            << "distance " << distance << " orientation " << orientation
+            << " statePrep "
+            << (prep == cudaq::qec::operation::prep0 ? "prep0" : "prepp");
+      }
+    }
+  }
 }

--- a/libs/qec/unittests/realtime/app_examples/surface_code-1.cpp
+++ b/libs/qec/unittests/realtime/app_examples/surface_code-1.cpp
@@ -240,22 +240,22 @@ std::vector<size_t> get_stab_cnot_schedule(char stab_type, int distance) {
     throw std::runtime_error(
         "get_stab_cnot_schedule: Invalid stabilizer type. Must be 'X' or 'Z'.");
   }
-  // First get the stabilizers
-  auto stabs = grid.get_spin_op_stabilizers();
-  cudaq::qec::sortStabilizerOps(stabs);
-  std::size_t stab_idx = 0;
+  // Schedule matrix: entry 0 = no support, k >= 1 = CNOT timestep, ordered so
+  // that mid-round ancilla (hook) errors land perpendicular to the logical
+  // operators. Rows match the sorted parity-matrix rows and hence the ancilla
+  // indexing.
+  auto sched = stab_type == 'X' ? grid.get_cnot_schedule_x()
+                                : grid.get_cnot_schedule_z();
   std::vector<size_t> cnot_schedule;
-  for (const auto &stab : stabs) {
-    auto stab_word = stab.get_pauli_word(distance * distance);
-    if (stab_word.find(stab_type) == std::string::npos)
-      continue; // None of the desired stabilizers in this row
-    for (std::size_t d = 0; d < stab_word.size(); ++d) {
-      if (stab_word[d] == stab_type) {
-        cnot_schedule.push_back(stab_idx);
-        cnot_schedule.push_back(d);
+  for (std::size_t s = 0; s < sched.shape()[0]; ++s) {
+    for (uint8_t step = 1; step <= 4; ++step) {
+      for (std::size_t d = 0; d < sched.shape()[1]; ++d) {
+        if (sched.at({s, d}) == step) {
+          cnot_schedule.push_back(s);
+          cnot_schedule.push_back(d);
+        }
       }
     }
-    stab_idx++;
   }
   return cnot_schedule;
 }

--- a/libs/qec/unittests/realtime/app_examples/surface_code-1.cpp
+++ b/libs/qec/unittests/realtime/app_examples/surface_code-1.cpp
@@ -240,24 +240,12 @@ std::vector<size_t> get_stab_cnot_schedule(char stab_type, int distance) {
     throw std::runtime_error(
         "get_stab_cnot_schedule: Invalid stabilizer type. Must be 'X' or 'Z'.");
   }
-  // Schedule matrix: entry 0 = no support, k >= 1 = CNOT timestep, ordered so
-  // that mid-round ancilla (hook) errors land perpendicular to the logical
-  // operators. Rows match the sorted parity-matrix rows and hence the ancilla
-  // indexing.
-  auto sched = stab_type == 'X' ? grid.get_cnot_schedule_x()
-                                : grid.get_cnot_schedule_z();
-  std::vector<size_t> cnot_schedule;
-  for (std::size_t s = 0; s < sched.shape()[0]; ++s) {
-    for (uint8_t step = 1; step <= 4; ++step) {
-      for (std::size_t d = 0; d < sched.shape()[1]; ++d) {
-        if (sched.at({s, d}) == step) {
-          cnot_schedule.push_back(s);
-          cnot_schedule.push_back(d);
-        }
-      }
-    }
-  }
-  return cnot_schedule;
+  // CNOT pairs ordered by timestep within each stabilizer, so that mid-round
+  // ancilla (hook) errors land perpendicular to the logical operators.
+  // Stabilizer indices match the sorted parity-matrix rows and hence the
+  // ancilla indexing.
+  return stab_type == 'X' ? grid.get_cnot_schedule_pairs_x()
+                          : grid.get_cnot_schedule_pairs_z();
 }
 
 void debug_print_syndromes(int64_t syndrome_x_int, int64_t syndrome_z_int) {

--- a/libs/qec/unittests/realtime/app_examples/surface_code-2.cpp
+++ b/libs/qec/unittests/realtime/app_examples/surface_code-2.cpp
@@ -100,24 +100,12 @@ std::vector<size_t> get_stab_cnot_schedule(char stab_type, int distance) {
     throw std::runtime_error(
         "get_stab_cnot_schedule: Invalid stabilizer type. Must be 'X' or 'Z'.");
   }
-  // Schedule matrix: entry 0 = no support, k >= 1 = CNOT timestep, ordered so
-  // that mid-round ancilla (hook) errors land perpendicular to the logical
-  // operators. Rows match the sorted parity-matrix rows and hence the ancilla
-  // indexing.
-  auto sched = stab_type == 'X' ? grid.get_cnot_schedule_x()
-                                : grid.get_cnot_schedule_z();
-  std::vector<size_t> cnot_schedule;
-  for (std::size_t s = 0; s < sched.shape()[0]; ++s) {
-    for (uint8_t step = 1; step <= 4; ++step) {
-      for (std::size_t d = 0; d < sched.shape()[1]; ++d) {
-        if (sched.at({s, d}) == step) {
-          cnot_schedule.push_back(s);
-          cnot_schedule.push_back(d);
-        }
-      }
-    }
-  }
-  return cnot_schedule;
+  // CNOT pairs ordered by timestep within each stabilizer, so that mid-round
+  // ancilla (hook) errors land perpendicular to the logical operators.
+  // Stabilizer indices match the sorted parity-matrix rows and hence the
+  // ancilla indexing.
+  return stab_type == 'X' ? grid.get_cnot_schedule_pairs_x()
+                          : grid.get_cnot_schedule_pairs_z();
 }
 
 void debug_print_syndromes(int64_t syndrome_x_int, int64_t syndrome_z_int) {

--- a/libs/qec/unittests/realtime/app_examples/surface_code-2.cpp
+++ b/libs/qec/unittests/realtime/app_examples/surface_code-2.cpp
@@ -100,22 +100,22 @@ std::vector<size_t> get_stab_cnot_schedule(char stab_type, int distance) {
     throw std::runtime_error(
         "get_stab_cnot_schedule: Invalid stabilizer type. Must be 'X' or 'Z'.");
   }
-  // First get the stabilizers
-  auto stabs = grid.get_spin_op_stabilizers();
-  cudaq::qec::sortStabilizerOps(stabs);
-  std::size_t stab_idx = 0;
+  // Schedule matrix: entry 0 = no support, k >= 1 = CNOT timestep, ordered so
+  // that mid-round ancilla (hook) errors land perpendicular to the logical
+  // operators. Rows match the sorted parity-matrix rows and hence the ancilla
+  // indexing.
+  auto sched = stab_type == 'X' ? grid.get_cnot_schedule_x()
+                                : grid.get_cnot_schedule_z();
   std::vector<size_t> cnot_schedule;
-  for (const auto &stab : stabs) {
-    auto stab_word = stab.get_pauli_word(distance * distance);
-    if (stab_word.find(stab_type) == std::string::npos)
-      continue; // None of the desired stabilizers in this row
-    for (std::size_t d = 0; d < stab_word.size(); ++d) {
-      if (stab_word[d] == stab_type) {
-        cnot_schedule.push_back(stab_idx);
-        cnot_schedule.push_back(d);
+  for (std::size_t s = 0; s < sched.shape()[0]; ++s) {
+    for (uint8_t step = 1; step <= 4; ++step) {
+      for (std::size_t d = 0; d < sched.shape()[1]; ++d) {
+        if (sched.at({s, d}) == step) {
+          cnot_schedule.push_back(s);
+          cnot_schedule.push_back(d);
+        }
       }
     }
-    stab_idx++;
   }
   return cnot_schedule;
 }

--- a/libs/qec/unittests/realtime/app_examples/surface_code-3.cpp
+++ b/libs/qec/unittests/realtime/app_examples/surface_code-3.cpp
@@ -145,24 +145,12 @@ std::vector<size_t> get_stab_cnot_schedule(char stab_type, int distance) {
     throw std::runtime_error(
         "get_stab_cnot_schedule: Invalid stabilizer type. Must be 'X' or 'Z'.");
   }
-  // Schedule matrix: entry 0 = no support, k >= 1 = CNOT timestep, ordered so
-  // that mid-round ancilla (hook) errors land perpendicular to the logical
-  // operators. Rows match the sorted parity-matrix rows and hence the ancilla
-  // indexing.
-  auto sched = stab_type == 'X' ? grid.get_cnot_schedule_x()
-                                : grid.get_cnot_schedule_z();
-  std::vector<size_t> cnot_schedule;
-  for (std::size_t s = 0; s < sched.shape()[0]; ++s) {
-    for (uint8_t step = 1; step <= 4; ++step) {
-      for (std::size_t d = 0; d < sched.shape()[1]; ++d) {
-        if (sched.at({s, d}) == step) {
-          cnot_schedule.push_back(s);
-          cnot_schedule.push_back(d);
-        }
-      }
-    }
-  }
-  return cnot_schedule;
+  // CNOT pairs ordered by timestep within each stabilizer, so that mid-round
+  // ancilla (hook) errors land perpendicular to the logical operators.
+  // Stabilizer indices match the sorted parity-matrix rows and hence the
+  // ancilla indexing.
+  return stab_type == 'X' ? grid.get_cnot_schedule_pairs_x()
+                          : grid.get_cnot_schedule_pairs_z();
 }
 
 void debug_print_syndromes(int64_t syndrome_x_int, int64_t syndrome_z_int) {

--- a/libs/qec/unittests/realtime/app_examples/surface_code-3.cpp
+++ b/libs/qec/unittests/realtime/app_examples/surface_code-3.cpp
@@ -145,21 +145,22 @@ std::vector<size_t> get_stab_cnot_schedule(char stab_type, int distance) {
     throw std::runtime_error(
         "get_stab_cnot_schedule: Invalid stabilizer type. Must be 'X' or 'Z'.");
   }
-  auto stabs = grid.get_spin_op_stabilizers();
-  cudaq::qec::sortStabilizerOps(stabs);
-  std::size_t stab_idx = 0;
+  // Schedule matrix: entry 0 = no support, k >= 1 = CNOT timestep, ordered so
+  // that mid-round ancilla (hook) errors land perpendicular to the logical
+  // operators. Rows match the sorted parity-matrix rows and hence the ancilla
+  // indexing.
+  auto sched = stab_type == 'X' ? grid.get_cnot_schedule_x()
+                                : grid.get_cnot_schedule_z();
   std::vector<size_t> cnot_schedule;
-  for (const auto &stab : stabs) {
-    auto stab_word = stab.get_pauli_word(distance * distance);
-    if (stab_word.find(stab_type) == std::string::npos)
-      continue;
-    for (std::size_t d = 0; d < stab_word.size(); ++d) {
-      if (stab_word[d] == stab_type) {
-        cnot_schedule.push_back(stab_idx);
-        cnot_schedule.push_back(d);
+  for (std::size_t s = 0; s < sched.shape()[0]; ++s) {
+    for (uint8_t step = 1; step <= 4; ++step) {
+      for (std::size_t d = 0; d < sched.shape()[1]; ++d) {
+        if (sched.at({s, d}) == step) {
+          cnot_schedule.push_back(s);
+          cnot_schedule.push_back(d);
+        }
       }
     }
-    stab_idx++;
   }
   return cnot_schedule;
 }

--- a/libs/qec/unittests/realtime/app_examples/surface_code-4-yaml.cpp
+++ b/libs/qec/unittests/realtime/app_examples/surface_code-4-yaml.cpp
@@ -479,36 +479,24 @@ std::vector<size_t> get_stab_cnot_schedule(char stab_type, int distance) {
     throw std::runtime_error(
         "get_stab_cnot_schedule: Invalid stabilizer type. Must be 'X' or 'Z'.");
   }
-  // Schedule matrix: entry 0 = no support, k >= 1 = CNOT timestep, ordered so
-  // that mid-round ancilla (hook) errors land perpendicular to the logical
-  // operators. Rows match the sorted parity-matrix rows and hence the ancilla
-  // indexing.
-  auto sched = stab_type == 'X' ? grid.get_cnot_schedule_x()
-                                : grid.get_cnot_schedule_z();
-  std::vector<size_t> cnot_schedule;
-  for (std::size_t s = 0; s < sched.shape()[0]; ++s) {
-    for (uint8_t step = 1; step <= 4; ++step) {
-      for (std::size_t d = 0; d < sched.shape()[1]; ++d) {
-        if (sched.at({s, d}) == step) {
-          cnot_schedule.push_back(s);
-          cnot_schedule.push_back(d);
-        }
-      }
-    }
-  }
-  return cnot_schedule;
+  // CNOT pairs ordered by timestep within each stabilizer, so that mid-round
+  // ancilla (hook) errors land perpendicular to the logical operators.
+  // Stabilizer indices match the sorted parity-matrix rows and hence the
+  // ancilla indexing.
+  return stab_type == 'X' ? grid.get_cnot_schedule_pairs_x()
+                          : grid.get_cnot_schedule_pairs_z();
 }
 
 // Per-stabilizer data-qubit supports, ordered to match the ancilla measurement
-// order produced by get_stab_cnot_schedule(stab_type, ...). The s-th returned
-// support is the data-qubit support of the s-th `stab_type`-containing
-// stabilizer in the same sorted spin-op traversal that get_stab_cnot_schedule
-// uses, so support[s] lines up with ancilla[s] in se_{x,z}_ft's measurement
-// vector. This is what the Ising MemoryCircuit boundary detectors pair against
-// (a stabilizer's data support XOR-ed with that stabilizer's last ancilla
-// measurement). Returns a flat vector of data-qubit indices plus per-stabilizer
-// offsets (offsets has size num_stabs+1; support s spans [offsets[s],
-// offsets[s+1])), the same flat+offset pattern as cnot_schedZ_flat.
+// order produced by get_stab_cnot_schedule(stab_type, ...). The supports are
+// derived from the same schedule matrix as the CNOT pairs (row s = ancilla s),
+// so support[s] lines up with ancilla[s] in se_{x,z}_ft's measurement vector
+// by construction rather than via a parallel sort. This is what the Ising
+// MemoryCircuit boundary detectors pair against (a stabilizer's data support
+// XOR-ed with that stabilizer's last ancilla measurement). Returns a flat
+// vector of data-qubit indices plus per-stabilizer offsets (offsets has size
+// num_stabs+1; support s spans [offsets[s], offsets[s+1])), the same
+// flat+offset pattern as cnot_schedZ_flat.
 void get_stab_data_supports(char stab_type, int distance,
                             std::vector<std::size_t> &supports_flat,
                             std::vector<std::size_t> &supports_offsets) {
@@ -518,17 +506,14 @@ void get_stab_data_supports(char stab_type, int distance,
     throw std::runtime_error(
         "get_stab_data_supports: Invalid stabilizer type. Must be 'X' or 'Z'.");
   }
-  auto stabs = grid.get_spin_op_stabilizers();
-  cudaq::qec::sortStabilizerOps(stabs);
+  auto sched = stab_type == 'X' ? grid.get_cnot_schedule_x()
+                                : grid.get_cnot_schedule_z();
   supports_flat.clear();
   supports_offsets.clear();
   supports_offsets.push_back(0);
-  for (const auto &stab : stabs) {
-    auto stab_word = stab.get_pauli_word(distance * distance);
-    if (stab_word.find(stab_type) == std::string::npos)
-      continue; // None of the desired stabilizers in this row
-    for (std::size_t d = 0; d < stab_word.size(); ++d) {
-      if (stab_word[d] == stab_type)
+  for (std::size_t s = 0; s < sched.shape()[0]; ++s) {
+    for (std::size_t d = 0; d < sched.shape()[1]; ++d) {
+      if (sched.at({s, d}) != 0)
         supports_flat.push_back(d);
     }
     supports_offsets.push_back(supports_flat.size());

--- a/libs/qec/unittests/realtime/app_examples/surface_code-4-yaml.cpp
+++ b/libs/qec/unittests/realtime/app_examples/surface_code-4-yaml.cpp
@@ -479,22 +479,22 @@ std::vector<size_t> get_stab_cnot_schedule(char stab_type, int distance) {
     throw std::runtime_error(
         "get_stab_cnot_schedule: Invalid stabilizer type. Must be 'X' or 'Z'.");
   }
-  // First get the stabilizers
-  auto stabs = grid.get_spin_op_stabilizers();
-  cudaq::qec::sortStabilizerOps(stabs);
-  std::size_t stab_idx = 0;
+  // Schedule matrix: entry 0 = no support, k >= 1 = CNOT timestep, ordered so
+  // that mid-round ancilla (hook) errors land perpendicular to the logical
+  // operators. Rows match the sorted parity-matrix rows and hence the ancilla
+  // indexing.
+  auto sched = stab_type == 'X' ? grid.get_cnot_schedule_x()
+                                : grid.get_cnot_schedule_z();
   std::vector<size_t> cnot_schedule;
-  for (const auto &stab : stabs) {
-    auto stab_word = stab.get_pauli_word(distance * distance);
-    if (stab_word.find(stab_type) == std::string::npos)
-      continue; // None of the desired stabilizers in this row
-    for (std::size_t d = 0; d < stab_word.size(); ++d) {
-      if (stab_word[d] == stab_type) {
-        cnot_schedule.push_back(stab_idx);
-        cnot_schedule.push_back(d);
+  for (std::size_t s = 0; s < sched.shape()[0]; ++s) {
+    for (uint8_t step = 1; step <= 4; ++step) {
+      for (std::size_t d = 0; d < sched.shape()[1]; ++d) {
+        if (sched.at({s, d}) == step) {
+          cnot_schedule.push_back(s);
+          cnot_schedule.push_back(d);
+        }
       }
     }
-    stab_idx++;
   }
   return cnot_schedule;
 }

--- a/libs/qec/unittests/realtime/app_examples/surface_code_1.py
+++ b/libs/qec/unittests/realtime/app_examples/surface_code_1.py
@@ -110,21 +110,12 @@ def get_stab_cnot_schedule(stab_type: str, distance: int) -> List[int]:
             "get_stab_cnot_schedule: Invalid stabilizer type. Must be 'X' or 'Z'."
         )
 
-    # Schedule matrix: entry 0 = no support, k >= 1 = CNOT timestep, ordered
-    # so that mid-round ancilla (hook) errors land perpendicular to the
-    # logical operators. Rows match the sorted parity-matrix rows and hence
-    # the ancilla indexing.
-    sched = (grid.get_cnot_schedule_x()
-             if stab_type == "X" else grid.get_cnot_schedule_z())
-
-    cnot_schedule: List[int] = []
-    for stab_idx, row in enumerate(sched):
-        for step in range(1, 5):
-            for d, entry in enumerate(row):
-                if entry == step:
-                    cnot_schedule.extend([stab_idx, d])
-
-    return cnot_schedule
+    # CNOT pairs ordered by timestep within each stabilizer, so that mid-round
+    # ancilla (hook) errors land perpendicular to the logical operators.
+    # Stabilizer indices match the sorted parity-matrix rows and hence the
+    # ancilla indexing.
+    return list(grid.get_cnot_schedule_pairs_x() if stab_type ==
+                "X" else grid.get_cnot_schedule_pairs_z())
 
 
 def debug_print_syndromes(syndrome_x_int: int, syndrome_z_int: int) -> None:

--- a/libs/qec/unittests/realtime/app_examples/surface_code_1.py
+++ b/libs/qec/unittests/realtime/app_examples/surface_code_1.py
@@ -42,24 +42,6 @@ def pcm_from_sparse_vec(sparse_vec: Iterable[int], num_rows: int,
     return pcm
 
 
-def sorted_stabilizer_ops_inplace_numpy(ops: List[cudaq.Operator]) -> None:
-    if not ops:
-        return []
-
-    words = np.array([term.get_pauli_word() for term in ops], dtype=str)
-
-    z_idx = np.char.find(words, "Z")
-    x_idx = np.char.find(words, "X")
-
-    # Group 0 if Z exists, else 1
-    group = np.where(z_idx >= 0, 0, 1)
-    # Index: first Z if exists else first X (big sentinel if none)
-    idx = np.where(z_idx >= 0, z_idx, np.where(x_idx >= 0, x_idx, 10**9))
-
-    order = np.lexsort((idx, group)).tolist()
-    ops[:] = [ops[i] for i in order]
-
-
 def save_dem_to_file(dem, dem_filename, numSyndromesPerRound, num_logical):
     multi_config = qec.multi_decoder_config()
     decoders = []
@@ -128,20 +110,19 @@ def get_stab_cnot_schedule(stab_type: str, distance: int) -> List[int]:
             "get_stab_cnot_schedule: Invalid stabilizer type. Must be 'X' or 'Z'."
         )
 
-    stabs = grid.get_spin_op_stabilizers()
-    sorted_stabilizer_ops_inplace_numpy(stabs)
+    # Schedule matrix: entry 0 = no support, k >= 1 = CNOT timestep, ordered
+    # so that mid-round ancilla (hook) errors land perpendicular to the
+    # logical operators. Rows match the sorted parity-matrix rows and hence
+    # the ancilla indexing.
+    sched = (grid.get_cnot_schedule_x()
+             if stab_type == "X" else grid.get_cnot_schedule_z())
 
-    stab_idx = 0
     cnot_schedule: List[int] = []
-
-    for stab in stabs:
-        word = stab.get_pauli_word(distance * distance)
-        if stab_type not in word:
-            continue
-        for d, ch in enumerate(word):
-            if ch == stab_type:
-                cnot_schedule.extend([stab_idx, d])
-        stab_idx += 1
+    for stab_idx, row in enumerate(sched):
+        for step in range(1, 5):
+            for d, entry in enumerate(row):
+                if entry == step:
+                    cnot_schedule.extend([stab_idx, d])
 
     return cnot_schedule
 

--- a/libs/qec/unittests/test_qec.cpp
+++ b/libs/qec/unittests/test_qec.cpp
@@ -1381,6 +1381,11 @@ TEST(SurfaceCodeTester, checkCnotSchedule) {
       for (std::size_t s = 0; s < sched_x.shape()[0]; ++s)
         for (std::size_t d = 0; d < num_data; ++d)
           EXPECT_EQ(code_sched_x.at({s, d}), sched_x.at({s, d})) << label;
+      auto code_sched_z = code->get_stabilizer_schedule_z();
+      ASSERT_EQ(code_sched_z.shape(), sched_z.shape()) << label;
+      for (std::size_t s = 0; s < sched_z.shape()[0]; ++s)
+        for (std::size_t d = 0; d < num_data; ++d)
+          EXPECT_EQ(code_sched_z.at({s, d}), sched_z.at({s, d})) << label;
     }
   }
 }

--- a/libs/qec/unittests/test_qec.cpp
+++ b/libs/qec/unittests/test_qec.cpp
@@ -1268,6 +1268,123 @@ TEST(QECCodeTester, checkStabilizerGrid) {
   }
 }
 
+TEST(SurfaceCodeTester, checkCnotSchedule) {
+  using cudaq::qec::surface_code::stabilizer_grid;
+
+  // Verify a schedule matrix against its parity matrix and the hook-error
+  // requirement: the pair of data qubits touched by the two *last* CNOTs of
+  // every weight-4 plaquette must be perpendicular to the same-type logical.
+  auto check_schedule = [](const cudaqx::tensor<uint8_t> &sched,
+                           const cudaqx::tensor<uint8_t> &parity,
+                           uint32_t distance, bool expect_vertical_hook_pair,
+                           const std::string &label) {
+    ASSERT_EQ(sched.shape(), parity.shape()) << label;
+    const auto num_stabs = sched.shape()[0];
+    const auto num_data = sched.shape()[1];
+    for (std::size_t s = 0; s < num_stabs; ++s) {
+      std::vector<std::size_t> support; // data idx per ascending timestep
+      std::vector<bool> steps_seen(5, false);
+      for (std::size_t d = 0; d < num_data; ++d) {
+        auto step = sched.at({s, d});
+        // Support pattern must match the parity-matrix row exactly (this
+        // also pins the row ordering to the sorted parity rows).
+        EXPECT_EQ(step != 0, parity.at({s, d}) != 0)
+            << label << " row " << s << " col " << d;
+        if (step == 0)
+          continue;
+        ASSERT_LE(step, 4) << label << " row " << s;
+        EXPECT_FALSE(steps_seen[step])
+            << label << " row " << s << " duplicate step";
+        steps_seen[step] = true;
+      }
+      for (uint8_t step = 1; step <= 4; ++step)
+        for (std::size_t d = 0; d < num_data; ++d)
+          if (sched.at({s, d}) == step)
+            support.push_back(d);
+      ASSERT_TRUE(support.size() == 2 || support.size() == 4)
+          << label << " row " << s;
+      if (support.size() == 4) {
+        // Hook errors on the ancilla propagate to the data qubits of the two
+        // remaining CNOTs; that pair must run against the logical direction.
+        auto a = support[2], b = support[3];
+        int row_a = a / distance, col_a = a % distance;
+        int row_b = b / distance, col_b = b % distance;
+        if (expect_vertical_hook_pair) {
+          EXPECT_EQ(col_a, col_b) << label << " row " << s;
+          EXPECT_EQ(1, std::abs(row_a - row_b)) << label << " row " << s;
+        } else {
+          EXPECT_EQ(row_a, row_b) << label << " row " << s;
+          EXPECT_EQ(1, std::abs(col_a - col_b)) << label << " row " << s;
+        }
+      }
+    }
+  };
+
+  for (uint32_t distance : {3u, 5u, 7u}) {
+    for (auto orientation : {sc_orientation::XV, sc_orientation::XH,
+                             sc_orientation::ZV, sc_orientation::ZH}) {
+      stabilizer_grid grid(distance, orientation);
+      auto stabs = grid.get_spin_op_stabilizers();
+      auto parity_x =
+          cudaq::qec::to_parity_matrix(stabs, cudaq::qec::stabilizer_type::X);
+      auto parity_z =
+          cudaq::qec::to_parity_matrix(stabs, cudaq::qec::stabilizer_type::Z);
+      auto sched_x = grid.get_cnot_schedule_x();
+      auto sched_z = grid.get_cnot_schedule_z();
+
+      const std::string label =
+          "d=" + std::to_string(distance) +
+          " orientation=" + std::to_string(static_cast<int>(orientation));
+
+      // XV/ZH place the X logical along the top data row (horizontal), so X
+      // hook pairs must be vertical and Z hook pairs horizontal; XH/ZV swap
+      // the logicals and hence the requirement.
+      const bool x_logical_horizontal = orientation == sc_orientation::XV ||
+                                        orientation == sc_orientation::ZH;
+      check_schedule(sched_x, parity_x, distance,
+                     /*expect_vertical_hook_pair=*/x_logical_horizontal,
+                     label + " X");
+      check_schedule(sched_z, parity_z, distance,
+                     /*expect_vertical_hook_pair=*/!x_logical_horizontal,
+                     label + " Z");
+
+      // The X and Z schedules must also be conflict-free if interleaved: no
+      // data qubit is touched by two CNOTs in the same timestep.
+      const auto num_data = distance * distance;
+      for (uint8_t step = 1; step <= 4; ++step) {
+        std::vector<int> touches(num_data, 0);
+        for (std::size_t s = 0; s < sched_x.shape()[0]; ++s)
+          for (std::size_t d = 0; d < num_data; ++d)
+            if (sched_x.at({s, d}) == step)
+              touches[d]++;
+        for (std::size_t s = 0; s < sched_z.shape()[0]; ++s)
+          for (std::size_t d = 0; d < num_data; ++d)
+            if (sched_z.at({s, d}) == step)
+              touches[d]++;
+        for (std::size_t d = 0; d < num_data; ++d)
+          EXPECT_LE(touches[d], 1)
+              << label << " step " << int(step) << " data " << d;
+      }
+
+      // The surface_code plugin must expose the grid schedule.
+      const std::string orientation_str =
+          orientation == sc_orientation::XV   ? "XV"
+          : orientation == sc_orientation::XH ? "XH"
+          : orientation == sc_orientation::ZV ? "ZV"
+                                              : "ZH";
+      auto code = cudaq::qec::get_code(
+          "surface_code", cudaqx::heterogeneous_map{
+                              {"distance", static_cast<std::size_t>(distance)},
+                              {"orientation", orientation_str}});
+      auto code_sched_x = code->get_stabilizer_schedule_x();
+      ASSERT_EQ(code_sched_x.shape(), sched_x.shape()) << label;
+      for (std::size_t s = 0; s < sched_x.shape()[0]; ++s)
+        for (std::size_t d = 0; d < num_data; ++d)
+          EXPECT_EQ(code_sched_x.at({s, d}), sched_x.at({s, d})) << label;
+    }
+  }
+}
+
 TEST(SurfaceCodeTester, checkVec2dOperators) {
   // Test vec2d operators that are used in stabilizer_grid maps
   using cudaq::qec::surface_code::vec2d;


### PR DESCRIPTION
## Description

The surface-code `stabilizer` kernel executed every plaquette's CNOTs in ascending data-qubit index order — the flattened parity matrices it receives carry no ordering information, so an optimized schedule could not even be expressed. With the same row-major order on both X and Z plaquettes, a mid-round ancilla fault ("hook error", Dennis et al., [arXiv:quant-ph/0110143](https://arxiv.org/abs/quant-ph/0110143)) propagates onto a data-qubit pair aligned *with* one of the logical operators, halving the effective circuit-level distance of one memory basis.

**Measured impact (before this PR, ZH orientation, `prep0`):** effective distance 2 instead of 3 at d=3, and 3 instead of 5 at d=5. Which basis is damaged depends on the code orientation; `prepp` was coincidentally unaffected for ZH.

This PR gives the surface code the standard zigzag CNOT schedule (Tomita & Svore, [arXiv:1404.3747](https://arxiv.org/abs/1404.3747)), selected per orientation so hook pairs land perpendicular to the same-type logical, and executes the X and Z checks interleaved over four shared timesteps (one depth-4 extraction round).

Design, with no breaking interface changes:

- `stabilizer_grid::get_cnot_schedule_x/z()`: schedule matrices with the same shape/support as the parity matrices; entry 0 = no support, k ∈ 1..4 = CNOT timestep. Rows match the sorted parity-matrix rows (enforced: a first-support tie throws instead of silently misaligning ancilla wiring). `get_cnot_schedule_pairs_x/z()` provides the flat (stabilizer, data) pair-list form used by the realtime examples.
- `code::get_stabilizer_schedule_x/z()`: new virtuals defaulting to the parity matrices, so the `stabilizer_round` kernel signature is untouched and repetition/Steane receive byte-identical inputs. The memory-circuit drivers pass these to the kernel.
- The surface kernel executes CNOTs timestep-major with X and Z checks interleaved; the zigzag pair is conflict-free and commutation-valid under interleaving (proven by the DEM tests — stim rejects non-deterministic detectors).
- The four realtime C++ app examples and the Python example consume the grid API instead of five copy-pasted ascending-order schedule builders; Python bindings return the schedule as numpy arrays consistent with `get_parity_x/z()`.
- Docs: the QEC introduction page documents the schedule-matrix kernel contract and the surface-code CNOT schedule, cross-referencing the Doxygen API docs as the single source of truth for the encoding.

Validation:

- New effective-distance test (`test_qec_stim`): builds the DEM from the actual kernel under two-qubit depolarizing noise and asserts the shortest undetectable logical error has weight d, for d=3,5 × both bases × all four orientations. Fails with weight ⌈d/2⌉ against the previous ordering.
- New schedule-property test (`test_qec`): d=3,5,7 × all orientations — parity-row alignment, valid distinct timesteps, hook-pair perpendicularity, no data qubit touched twice per timestep.
- The schedule matches ising-decoding's up to a left–right mirror (theirs starts each plaquette at NE, ours at NW) — same hook orientation and validity class; flipping the corner order is a one-line change if exact equivalence with predecoder training circuits is ever needed.

## Runtime / performance impact

Monte Carlo (pymatching, CX depolarizing noise, 100k shots, rounds = d): at p=0.002 the `prep0` logical error rate improves **14×** at d=3 (0.030 → 0.0018) and **5.8×** at d=5 (0.0057 → 0.00098); `prepp` is statistically unchanged and the two bases are balanced after the fix. The pre-fix DEM also contained parallel edges with identical detector signatures but different observable effects — fundamentally undecodable mechanisms that pymatching's default merge strategy rejects outright; these disappear with the fix.

Build/test-time cost: the new tests add ~50 ms to the two unit-test binaries. Kernel classical overhead adds a constant-factor scan per stabilizer round (negligible on stim, which traces the kernel once).

## Self-review checklist

### Before requesting review
- [x] I reviewed my own full diff in GitHub or my editor.
- [x] PR is in Draft if it is not yet ready for review.
- [x] Temporary / debugging changes have been removed.
- [x] Local test logs reviewed; no unexplained warnings or errors.
- [ ] CI logs reviewed; no unexplained warnings or errors.
- [ ] Full CI has been run.

### Scope and size
- [x] PR is under ~1000 lines, or an exception is justified in the description.
- [x] Refactoring-only changes are isolated in their own PR(s). *(the self-review hardening/dedup is a separate commit within this PR)*
- [x] No existing tests were disabled or modified just to make this PR pass.

### Tests
- [x] New functionality has new tests.
- [x] Tests fail if the new functionality is broken (including crashes), not just when it is missing. *(effective-distance test verified to fail against the previous ordering)*
- [ ] ~~Negative tests added where exceptions are expected.~~ The new no-tie guard in `build_cnot_schedule` is unreachable for any valid rotated surface code by construction (geometric argument in the code comment), so it cannot be exercised without an artificial grid; existing invalid-orientation/invalid-distance exception tests still cover the public entry points.
- [x] Truth data added where simple `EXPECT_*` / `assert` checks are insufficient for algorithmic correctness. *(effective distance == d via graphlike-DEM shortest-error search; Monte Carlo numbers above)*
- [x] CI runtime impact considered; team notified if significant. *(~50 ms added)*

### Documentation
- [x] Public-facing APIs have Doxygen docs.
- [x] User-visible behavior changes have public docs. *(QEC introduction page updated; full docs build verified locally — zero new warnings, new cross-references resolve)*

### Code style
- [x] Naming follows the existing convention (`snake_case`) for the area being modified.

### Dependencies
- [x] No new third-party dependencies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
