### PR TITLE
Make trt throw if fails to do inference

### DIFF
--- a/libs/qec/lib/decoders/plugins/trt_decoder/trt_decoder.cpp
+++ b/libs/qec/lib/decoders/plugins/trt_decoder/trt_decoder.cpp
@@ -167,7 +167,8 @@ struct TraditionalExecutor {
                               input_buffer);
     context->setTensorAddress(engine->getIOTensorName(output_index),
                               output_buffer);
-    context->enqueueV3(stream);
+    if (!context->enqueueV3(stream))
+      throw std::runtime_error("TensorRT enqueueV3 failed");
     HANDLE_CUDA_ERROR(cudaStreamSynchronize(stream));
   }
 };
@@ -399,9 +400,6 @@ private:
   struct Impl;
   std::unique_ptr<Impl> impl_;
 
-  // True when decoder is fully configured and ready for inference
-  bool decoder_ready_ = false;
-
   // Batch dimension from TensorRT model (first dimension of input tensor)
   size_t model_batch_size_ = 1;
 
@@ -442,8 +440,6 @@ private:
   void check_cuda();
 
   /// Size to use for failed placeholder results. This preserves the
-  /// decode_batch contract even when inference fails before producing output.
-  size_t failure_result_size() const;
 
   /// Typed decode_batch: input and output dtypes are selected independently
   /// from the TensorRT engine metadata (currently float or uint8_t).
@@ -541,7 +537,7 @@ struct trt_decoder::Impl {
 
 trt_decoder::trt_decoder(const cudaq::qec::sparse_binary_matrix &H,
                          const cudaqx::heterogeneous_map &params)
-    : decoder(H), decoder_ready_(false) {
+    : decoder(H) {
 
   impl_ = std::make_unique<Impl>();
 
@@ -825,12 +821,12 @@ trt_decoder::trt_decoder(const cudaq::qec::sparse_binary_matrix &H,
                     num_observables_);
     }
 
-    // Decoder is now fully configured and ready for inference
-    decoder_ready_ = true;
-
   } catch (const std::exception &e) {
-    CUDA_QEC_WARN("TensorRT initialization failed: {}", e.what());
-    decoder_ready_ = false;
+    // Fail fast: a decoder that cannot infer must not exist. Callers
+    // (decoder::get, configure_decoders, the decoding server) all propagate
+    // or map this to their error channel.
+    throw std::runtime_error(std::string("TensorRT initialization failed: ") +
+                             e.what());
   }
 }
 
@@ -863,27 +859,12 @@ decoder_result trt_decoder::decode(const std::vector<float_t> &syndrome) {
       padded_batch.push_back(zero_syndrome);
     }
 
-    auto results = decode_batch(padded_batch);
-    if (results.empty()) {
-      decoder_result result;
-      result.converged = false;
-      result.result.resize(failure_result_size(), 0.0f);
-      return result;
-    }
-
     // Return only the first result (the real syndrome)
-    return results[0];
+    return decode_batch(padded_batch)[0];
   }
 
   // For batch_size == 1, directly delegate to decode_batch
-  auto results = decode_batch({syndrome});
-  if (results.empty()) {
-    decoder_result result;
-    result.converged = false;
-    result.result.resize(failure_result_size(), 0.0f);
-    return result;
-  }
-  return results[0];
+  return decode_batch({syndrome})[0];
 }
 
 std::vector<decoder_result>
@@ -903,23 +884,6 @@ trt_decoder::decode_batch(const std::vector<std::vector<float_t>> &syndromes) {
     }
   }
 
-  if (!decoder_ready_) {
-    // Return unconverged results if decoder is not ready
-    CUDA_QEC_WARN(
-        "Decoder not ready for inference, returning {} unconverged results. "
-        "Check decoder initialization logs for errors.",
-        syndromes.size());
-
-    std::vector<decoder_result> results(syndromes.size());
-    const size_t result_size =
-        decode_to_observables_ ? num_observables_ : output_size_per_sample_;
-    for (auto &result : results) {
-      result.converged = false;
-      result.result.resize(result_size, 0.0);
-    }
-    return results;
-  }
-
   // Dispatch on the actual engine I/O dtypes independently.
   if (impl_->input_dtype == nvinfer1::DataType::kUINT8) {
     if (impl_->output_dtype == nvinfer1::DataType::kUINT8)
@@ -929,14 +893,6 @@ trt_decoder::decode_batch(const std::vector<std::vector<float_t>> &syndromes) {
   if (impl_->output_dtype == nvinfer1::DataType::kUINT8)
     return decode_batch_impl<float, uint8_t>(syndromes);
   return decode_batch_impl<float, float>(syndromes);
-}
-
-size_t trt_decoder::failure_result_size() const {
-  if (decode_to_observables_)
-    return num_observables_;
-  if (global_decoder_)
-    return global_decoder_->get_block_size();
-  return output_size_per_sample_;
 }
 
 template <typename InputType, typename OutputType>
@@ -1084,17 +1040,10 @@ std::vector<decoder_result> trt_decoder::decode_batch_impl(
     }
 
   } catch (const std::exception &e) {
-    CUDA_QEC_WARN("TensorRT batch inference failed: {}", e.what());
-    // Mark all results as unconverged
-    for (auto &result : results) {
-      result.converged = false;
-    }
-    while (results.size() < syndromes.size()) {
-      decoder_result result;
-      result.converged = false;
-      result.result.resize(failure_result_size(), 0.0f);
-      results.push_back(std::move(result));
-    }
+    // Fail fast: an inference failure is an error, not a non-converged
+    // decode. Never fabricate results for syndromes that were not decoded.
+    throw std::runtime_error(std::string("TensorRT batch inference failed: ") +
+                             e.what());
   }
 
   return results;

--- a/libs/qec/lib/decoders/plugins/trt_decoder/trt_decoder.cpp
+++ b/libs/qec/lib/decoders/plugins/trt_decoder/trt_decoder.cpp
@@ -439,8 +439,6 @@ public:
 private:
   void check_cuda();
 
-  /// Size to use for failed placeholder results. This preserves the
-
   /// Typed decode_batch: input and output dtypes are selected independently
   /// from the TensorRT engine metadata (currently float or uint8_t).
   template <typename InputType, typename OutputType>
@@ -465,7 +463,7 @@ struct trt_decoder::Impl {
   size_t input_elem_size = sizeof(float);
   size_t output_elem_size = sizeof(float);
   void *buffers[2] = {nullptr, nullptr};
-  cudaStream_t stream;
+  cudaStream_t stream = nullptr;
 
   // Dynamic batch: set input shape before each inference (only when dynamic)
   bool has_dynamic_batch_ = false;
@@ -513,12 +511,13 @@ struct trt_decoder::Impl {
     context.reset();
     engine.reset();
 
-    // 4. Free GPU buffers
-    if (buffers[input_index]) {
+    // 4. Free GPU buffers.  The indices are -1 mid-construction (binding
+    // scan), and the constructor can throw there.
+    if (input_index >= 0 && buffers[input_index]) {
       HANDLE_CUDA_ERROR_NO_THROW(cudaFree(buffers[input_index]));
       buffers[input_index] = nullptr;
     }
-    if (buffers[output_index]) {
+    if (output_index >= 0 && buffers[output_index]) {
       HANDLE_CUDA_ERROR_NO_THROW(cudaFree(buffers[output_index]));
       buffers[output_index] = nullptr;
     }
@@ -885,14 +884,24 @@ trt_decoder::decode_batch(const std::vector<std::vector<float_t>> &syndromes) {
   }
 
   // Dispatch on the actual engine I/O dtypes independently.
+  std::vector<decoder_result> results;
   if (impl_->input_dtype == nvinfer1::DataType::kUINT8) {
     if (impl_->output_dtype == nvinfer1::DataType::kUINT8)
-      return decode_batch_impl<uint8_t, uint8_t>(syndromes);
-    return decode_batch_impl<uint8_t, float>(syndromes);
+      results = decode_batch_impl<uint8_t, uint8_t>(syndromes);
+    else
+      results = decode_batch_impl<uint8_t, float>(syndromes);
+  } else if (impl_->output_dtype == nvinfer1::DataType::kUINT8) {
+    results = decode_batch_impl<float, uint8_t>(syndromes);
+  } else {
+    results = decode_batch_impl<float, float>(syndromes);
   }
-  if (impl_->output_dtype == nvinfer1::DataType::kUINT8)
-    return decode_batch_impl<float, uint8_t>(syndromes);
-  return decode_batch_impl<float, float>(syndromes);
+  // One result per input, always: callers index results positionally, and a
+  // misbehaving external global decoder must not turn that into UB.
+  if (results.size() != syndromes.size())
+    throw std::runtime_error(
+        "TensorRT decode_batch produced " + std::to_string(results.size()) +
+        " results for " + std::to_string(syndromes.size()) + " syndromes");
+  return results;
 }
 
 template <typename InputType, typename OutputType>

--- a/libs/qec/lib/decoders/plugins/trt_decoder/trt_decoder.cpp
+++ b/libs/qec/lib/decoders/plugins/trt_decoder/trt_decoder.cpp
@@ -898,9 +898,9 @@ trt_decoder::decode_batch(const std::vector<std::vector<float_t>> &syndromes) {
   // One result per input, always: callers index results positionally, and a
   // misbehaving external global decoder must not turn that into UB.
   if (results.size() != syndromes.size())
-    throw std::runtime_error(
-        "TensorRT decode_batch produced " + std::to_string(results.size()) +
-        " results for " + std::to_string(syndromes.size()) + " syndromes");
+    throw std::runtime_error("TensorRT decode_batch produced " +
+                             std::to_string(results.size()) + " results for " +
+                             std::to_string(syndromes.size()) + " syndromes");
   return results;
 }
 

--- a/libs/qec/lib/realtime/decoding-server-cqr/DecodingServer.cpp
+++ b/libs/qec/lib/realtime/decoding-server-cqr/DecodingServer.cpp
@@ -15,6 +15,7 @@
 
 #include <algorithm>
 #include <fstream>
+#include <iostream>
 #include <iterator>
 #include <stdexcept>
 #include <thread>
@@ -263,6 +264,17 @@ void DecodingServer::run() {
     th.join();
 
   CUDA_QEC_INFO("DecodingServer: all receiver threads exited");
+}
+
+void DecodingServer::print_session_stats() const {
+  for (const auto &[id, session] : registry_.sessions()) {
+    std::cout << "QEC_DECODING_SERVER_DECODER_STATS id=" << id
+              << " decodes=" << session->decode_count.load()
+              << " enqueues=" << session->enqueue_count.load()
+              << " corrections=" << session->get_corrections_count.load()
+              << " resets=" << session->reset_count.load()
+              << " errors=" << session->error_count.load() << std::endl;
+  }
 }
 
 void DecodingServer::stop() {

--- a/libs/qec/lib/realtime/decoding-server-cqr/DecodingServer.h
+++ b/libs/qec/lib/realtime/decoding-server-cqr/DecodingServer.h
@@ -66,6 +66,10 @@ public:
   /// Thread-safe; signals the receive loop to exit after the current frame.
   void stop();
 
+  /// Print one QEC_DECODING_SERVER_DECODER_STATS line per session to stdout
+  /// (test/diagnostic evidence; callers gate on QEC_DECODING_SERVER_STATS).
+  void print_session_stats() const;
+
 private:
   void init(const std::string &config_yaml);
   void register_handlers();

--- a/libs/qec/lib/realtime/decoding-server-cqr/DecodingSession.cpp
+++ b/libs/qec/lib/realtime/decoding-server-cqr/DecodingSession.cpp
@@ -180,6 +180,7 @@ void DecodingSession::on_enqueue(const WorkItem &item) {
         dec->enqueue_syndrome(completed->bits.data(), completed->bits.size());
 
     if (did_decode) {
+      ++decode_count;
       accepted_syndromes = 0;
       shot_state = ShotState::result_ready;
     }

--- a/libs/qec/lib/realtime/decoding-server-cqr/DecodingSession.h
+++ b/libs/qec/lib/realtime/decoding-server-cqr/DecodingSession.h
@@ -87,6 +87,7 @@ struct DecodingSession {
 
   // Per-session metrics (updated atomically by the worker thread).
   std::atomic<uint64_t> enqueue_count{0};
+  std::atomic<uint64_t> decode_count{0};
   std::atomic<uint64_t> get_corrections_count{0};
   std::atomic<uint64_t> reset_count{0};
   std::atomic<uint64_t> error_count{0};

--- a/libs/qec/lib/realtime/decoding-server-cqr/decoding_server_cqr.cpp
+++ b/libs/qec/lib/realtime/decoding-server-cqr/decoding_server_cqr.cpp
@@ -374,6 +374,15 @@ cudaqx_qec_decoding_server_max_concurrent() {
   return cudaq::qec::decoding_server::max_concurrent_busy_sessions();
 }
 
+/// Per-decoder session counters (decodes/enqueues/...), one stdout line per
+/// decoder. Test/diagnostic evidence; callers gate on the
+/// QEC_DECODING_SERVER_STATS environment variable.
+extern "C" __attribute__((visibility("default"))) void
+cudaqx_qec_decoding_server_print_stats() {
+  if (g_server)
+    g_server->print_session_stats();
+}
+
 /// Stop the DecodingServer receive loop and join its thread. The server calls
 /// this before exiting; without it the static g_server_thread would still be
 /// joinable at static destruction (std::terminate).

--- a/libs/qec/python/tests/test_trt_decoder.py
+++ b/libs/qec/python/tests/test_trt_decoder.py
@@ -372,9 +372,9 @@ class TestTRTDecoderParameterValidation(TestTRTDecoderSetup):
         pass
 
     def test_validate_parameters_no_paths_provided(self):
-        """Test that providing no paths creates decoder with warning."""
-        # Decoder is created but logs a warning - it won't be usable for inference
-        # Create the TRT decoder
+        """Providing no model path is an initialization error."""
+        # Initialization failures throw (converged never stands in for
+        # decoder health), so construction without a path raises.
         try:
             decoder = qec.get_decoder('trt_decoder', self.H)
             # If decoder is None or doesn't initialize properly, skip these tests

--- a/libs/qec/tools/decoding-server/decoding_server.cpp
+++ b/libs/qec/tools/decoding-server/decoding_server.cpp
@@ -676,8 +676,9 @@ int main(int argc, char **argv) {
     dispatcher_thread.join();
   if (tp.shutdown)
     tp.shutdown();
-  // Transport is down (no new requests) but the server still exists: emit the
-  // opt-in per-decoder counters before shutdown releases the sessions.
+  // The counters are atomics and the per-shot get_corrections cadence means
+  // they are settled by the time a client-driven run reaches shutdown; print
+  // before cudaqx_qec_decoding_server_shutdown() releases the sessions.
   if (const char *stats = std::getenv("QEC_DECODING_SERVER_STATS");
       stats && stats[0] != '\0')
     cudaqx_qec_decoding_server_print_stats();

--- a/libs/qec/tools/decoding-server/decoding_server.cpp
+++ b/libs/qec/tools/decoding-server/decoding_server.cpp
@@ -89,6 +89,7 @@
 #include <chrono>
 #include <csignal>
 #include <cstdint>
+#include <cstdlib>
 #include <cstring>
 #include <fstream>
 #include <functional>
@@ -100,6 +101,7 @@
 extern "C" void cudaqx_qec_realtime_device_call_service_force_link();
 extern "C" std::uint64_t cudaqx_qec_device_call_dispatch_count();
 extern "C" std::uint64_t cudaqx_qec_decoding_server_max_concurrent();
+extern "C" void cudaqx_qec_decoding_server_print_stats();
 extern "C" void cudaqx_qec_decoding_server_shutdown();
 
 namespace {
@@ -674,6 +676,11 @@ int main(int argc, char **argv) {
     dispatcher_thread.join();
   if (tp.shutdown)
     tp.shutdown();
+  // Transport is down (no new requests) but the server still exists: emit the
+  // opt-in per-decoder counters before shutdown releases the sessions.
+  if (const char *stats = std::getenv("QEC_DECODING_SERVER_STATS");
+      stats && stats[0] != '\0')
+    cudaqx_qec_decoding_server_print_stats();
   // Stop the DecodingServer receive loop and join its thread before the
   // process exits (a still-joinable static thread would std::terminate).
   cudaqx_qec_decoding_server_shutdown();

--- a/libs/qec/unittests/decoders/trt_decoder/test_trt_decoder.cpp
+++ b/libs/qec/unittests/decoders/trt_decoder/test_trt_decoder.cpp
@@ -546,19 +546,16 @@ TEST_F(TRTDecoderTest, PerformanceComparisonCudaGraphVsTraditional) {
       << " μs";
 }
 
-TEST_F(TRTDecoderTest, DecodeUninitializedDecoderReturnsUnconvergedBatch) {
-  // A failed constructor leaves the decoder object present but not ready;
-  // decode_batch should return one unconverged empty result per input syndrome.
+TEST_F(TRTDecoderTest, ConstructionFailureThrows) {
+  // A decoder that cannot infer must not exist: initialization failure
+  // propagates out of decoder::get instead of yielding a half-dead object
+  // that reports converged=false forever (converged is a statement about
+  // the solution of a completed decode, never about decoder health).
   cudaqx::heterogeneous_map params;
   params.insert("engine_load_path",
                 std::string("/no/such/cudaq-qec-test.engine"));
-  auto trt_decoder = decoder::get("trt_decoder", make_identity_h(2), params);
-  ASSERT_NE(trt_decoder, nullptr);
-
-  auto results = trt_decoder->decode_batch({{}});
-  ASSERT_EQ(results.size(), 1u);
-  EXPECT_FALSE(results[0].converged);
-  EXPECT_TRUE(results[0].result.empty());
+  EXPECT_THROW(decoder::get("trt_decoder", make_identity_h(2), params),
+               std::runtime_error);
 }
 
 TEST_F(TRTDecoderTest, EngineSavePathAndEngineLoadPathRoundTrip) {
@@ -706,9 +703,7 @@ TEST_F(TRTDecoderTest, MixedDtypeCopiesOutput) {
   EXPECT_FLOAT_EQ(result.result[2], 1.0);
 }
 
-TEST_F(TRTDecoderTest, BatchFailureKeepsResultCount) {
-  // A post-initialisation failure in decode_batch should preserve one result
-  // per input syndrome so decode() never indexes an empty result vector.
+TEST_F(TRTDecoderTest, BatchFailureThrows) {
   if (!gpu_available())
     GTEST_SKIP() << "No CUDA GPU available";
   auto onnx_path = get_dynamic_onnx_asset_path();
@@ -729,14 +724,11 @@ TEST_F(TRTDecoderTest, BatchFailureKeepsResultCount) {
     GTEST_SKIP() << "Failed to create mismatch TRT decoder: " << e.what();
   }
 
-  auto results = trt_decoder->decode_batch({{1.0, 0.0, 1.0}});
-
-  // The mismatched global decoder forces an exception before any result is
-  // pushed; the fixed path must still return one placeholder for the input.
-  ASSERT_EQ(results.size(), 1u);
-  // The placeholder must be marked failed so callers can distinguish it from a
-  // successful decode without touching out-of-range elements.
-  EXPECT_FALSE(results[0].converged);
+  // The mismatched global decoder forces an exception during inference.
+  // Inference failure is an error, not a non-converged decode: it must
+  // propagate rather than surface as fabricated converged=false results.
+  EXPECT_THROW(trt_decoder->decode_batch({{1.0, 0.0, 1.0}}),
+               std::runtime_error);
 }
 
 TEST_F(TRTDecoderTest, CompositeGlobalDecoderCombinesLogicalFrame) {

--- a/libs/qec/unittests/realtime/app_examples/CMakeLists.txt
+++ b/libs/qec/unittests/realtime/app_examples/CMakeLists.txt
@@ -626,6 +626,14 @@ if(Python_Interpreter_FOUND)
     set(_SC4_TRY_TRT_TEST TRUE)
   endif()
 endif()
+if(NOT _SC4_TRY_TRT_TEST)
+  # A silent skip here once masked a dead test check for a whole release
+  # cycle: without python-onnx none of the trt surface-code tests register,
+  # so their assertions are never exercised.
+  message(WARNING "surface_code-4-yaml: trt_decoder tests NOT registered "
+    "(python module 'onnx' not importable by ${Python_EXECUTABLE}); "
+    "pip install onnx to enable them.")
+endif()
 
 function(add_surface_code_4_yaml_test test_suffix distance num_rounds
          decoder_type num_shots onnx_path)
@@ -732,7 +740,7 @@ if(TARGET surface_code-4-yaml-cqr)
       "pymatching,trt_decoder,pymatching" 200 AUTO)
     set_property(TEST app_examples.surface_code-4-yaml-cqr-happy-path
       APPEND PROPERTY ENVIRONMENT
-        "REQUIRE_TRT_EXECUTION=1")
+        "REQUIRE_SERVER_DECODE_COUNTS=1")
   endif()
 
   # A real-workload skew case: all three patches use PyMatching, but patch 1

--- a/libs/qec/unittests/realtime/app_examples/CMakeLists.txt
+++ b/libs/qec/unittests/realtime/app_examples/CMakeLists.txt
@@ -626,13 +626,21 @@ if(Python_Interpreter_FOUND)
     set(_SC4_TRY_TRT_TEST TRUE)
   endif()
 endif()
-if(NOT _SC4_TRY_TRT_TEST)
-  # A silent skip here once masked a dead test check for a whole release
-  # cycle: without python-onnx none of the trt surface-code tests register,
-  # so their assertions are never exercised.
+# A silent skip here once masked a dead test check for a whole release cycle:
+# the trt surface-code tests register only when BOTH the trt plugin target and
+# python-onnx are available, so name whichever gate actually failed.
+if(NOT TARGET cudaq-qec-trt-decoder)
   message(WARNING "surface_code-4-yaml: trt_decoder tests NOT registered "
-    "(python module 'onnx' not importable by ${Python_EXECUTABLE}); "
-    "pip install onnx to enable them.")
+    "(cudaq-qec-trt-decoder target not built).")
+elseif(NOT _SC4_TRY_TRT_TEST)
+  if(Python_Interpreter_FOUND)
+    message(WARNING "surface_code-4-yaml: trt_decoder tests NOT registered "
+      "(python module 'onnx' not importable by ${Python_EXECUTABLE}); "
+      "pip install onnx to enable them.")
+  else()
+    message(WARNING "surface_code-4-yaml: trt_decoder tests NOT registered "
+      "(no python interpreter found).")
+  endif()
 endif()
 
 function(add_surface_code_4_yaml_test test_suffix distance num_rounds

--- a/libs/qec/unittests/realtime/app_examples/surface_code-4-yaml-test.sh
+++ b/libs/qec/unittests/realtime/app_examples/surface_code-4-yaml-test.sh
@@ -293,8 +293,8 @@ fi
 # but its CQR build deliberately does not construct local decoders.
 SERVER_PORT=""
 if [[ -n "${QEC_DECODING_SERVER:-}" ]]; then
-  if [[ -n "${REQUIRE_TRT_EXECUTION:-}" ]]; then
-    CUDAQ_QEC_TRT_REPORT_INFERENCE_EXECUTIONS=1 \
+  if [[ -n "${REQUIRE_SERVER_DECODE_COUNTS:-}" ]]; then
+    QEC_DECODING_SERVER_STATS=1 \
       "$QEC_DECODING_SERVER" --config="$CONFIG_FILE" --transport=udp --port=0 \
         --timeout=300 >"$SERVER_LOG" 2>&1 &
   else
@@ -505,27 +505,26 @@ if [[ -n "$SERVER_PORT" ]]; then
       return_code=1
     fi
   fi
-  if [[ -n "${REQUIRE_TRT_EXECUTION:-}" ]]; then
-    trt_instances=0
-    for decoder_type_entry in "${DECODER_TYPES[@]}"; do
-      if [[ "$decoder_type_entry" == "trt_decoder" ]]; then
-        trt_instances=$((trt_instances + 1))
+  # Decoder-agnostic execution evidence: the server reports per-session
+  # counters (QEC_DECODING_SERVER_STATS=1); every decoder must have completed
+  # exactly one decode per shot. This replaces the removed trt-internal
+  # QEC_TRT_INFERENCE_EXECUTIONS counter and covers closed-source decoders.
+  if [[ -n "${REQUIRE_SERVER_DECODE_COUNTS:-}" ]]; then
+    stats_lines=$(grep -c '^QEC_DECODING_SERVER_DECODER_STATS ' \
+      "$SERVER_LOG" || true)
+    if [[ "$stats_lines" -ne "${#DECODER_TYPES[@]}" ]]; then
+      echo "FAIL: server reported $stats_lines decoder stats lines; expected ${#DECODER_TYPES[@]}"
+      return_code=1
+    fi
+    for ((i = 0; i < ${#DECODER_TYPES[@]}; i++)); do
+      got_decodes=$(sed -n \
+        "s/^QEC_DECODING_SERVER_DECODER_STATS id=$i decodes=\([0-9][0-9]*\) .*/\1/p" \
+        "$SERVER_LOG" | tail -n1)
+      if [[ "$got_decodes" != "$NUM_SHOTS" ]]; then
+        echo "FAIL: decoder[$i] (${DECODER_TYPES[$i]}) completed '$got_decodes' decodes; expected $NUM_SHOTS"
+        return_code=1
       fi
     done
-    expected_trt_decodes=$((trt_instances * (NUM_SHOTS + 1)))
-    trt_reports=$(grep -c '^QEC_TRT_INFERENCE_EXECUTIONS count=' \
-      "$SERVER_LOG" || true)
-    trt_decodes=$(sed -n \
-      's/^QEC_TRT_INFERENCE_EXECUTIONS count=\([0-9][0-9]*\)$/\1/p' \
-      "$SERVER_LOG" | awk '{sum += $1} END {print sum + 0}')
-    if [[ "$trt_reports" -ne "$trt_instances" ]]; then
-      echo "FAIL: TensorRT reported $trt_reports inference counters; expected $trt_instances"
-      return_code=1
-    fi
-    if [[ "$trt_decodes" -ne "$expected_trt_decodes" ]]; then
-      echo "FAIL: TensorRT decoded $trt_decodes times; expected $expected_trt_decodes"
-      return_code=1
-    fi
   fi
   echo "Server evidence: dispatches=$server_dispatches, max_concurrent=$server_max_concurrent"
 fi


### PR DESCRIPTION
Trt decoder was using `converged` flag to indicate if the decoder is ready. Previously the TensorRT decoder had the following behaviour:

- a failed initialization was swallowed, leaving a decoder object that returned converged=false zero-filled results on every decode
- a failed inference was caught and reported the same way
- a failed enqueueV3 was ignored entirely, which could report stale device buffers as a successful converged decode

Initialization and inference failures now throw. The decoding server already maps worker exceptions to error responses, and the direct path propagates them to the caller, so an inference error and an unconverged decode are now distinct observables end to end.
