### PR TITLE
fix: To correct the ADAPT-VQE default return energy to the initial state energy

### DIFF
--- a/libs/solvers/lib/adapt/adapt_simulator.cpp
+++ b/libs/solvers/lib/adapt/adapt_simulator.cpp
@@ -33,7 +33,6 @@ simulator::run(const cudaq::qkernel<void(cudaq::qvector<> &)> &initialState,
   std::vector<double> thetas, coefficients;
   std::vector<std::size_t> poolIndices;
   std::vector<cudaq::spin_op> chosenOps;
-  double latestEnergy = std::numeric_limits<double>::max();
   double ediff = std::numeric_limits<double>::max();
 
   int maxIter = options.get<int>("max_iter", 30);
@@ -51,7 +50,7 @@ simulator::run(const cudaq::qkernel<void(cudaq::qvector<> &)> &initialState,
   std::size_t numRanks =
       cudaq::mpi::is_initialized() ? cudaq::mpi::num_ranks() : 1;
   std::size_t rank = cudaq::mpi::is_initialized() ? cudaq::mpi::rank() : 0;
-  double energy = 0.0, lastNorm = std::numeric_limits<double>::max();
+  double lastNorm = std::numeric_limits<double>::max();
 
   // poolList is split into numRanks chunks, and each chunk can be
   // further parallelized across numQpus.
@@ -94,6 +93,9 @@ simulator::run(const cudaq::qkernel<void(cudaq::qvector<> &)> &initialState,
   // Start of with the initial |psi_n>
   cudaq::state state = get_state(adapt_kernel, numQubits, initialState, thetas,
                                  coefficients, pauliWords, poolIndices);
+  // Initialise the result and convergence baseline from the initial state.
+  double energy = observe(prepare_state, H, state).expectation();
+  double latestEnergy = energy;
 
   int step = 0;
   while (true) {

--- a/libs/solvers/python/tests/test_adapt.py
+++ b/libs/solvers/python/tests/test_adapt.py
@@ -94,5 +94,29 @@ def test_adapt_empty_gradients():
         x(q[1])
 
     energy, thetas, ops = solvers.adapt_vqe(initState, H, pool)
-    # Should return without crashing; no operators selected
+    # |11> has <Z0 Z1> = +1, which must be retained without optimisation.
+    assert energy == pytest.approx(1.0)
+    # All commutators vanish, so no operator should be selected.
+    assert len(ops) == 0
+
+
+def test_adapt_converged_initial_energy():
+    # [Z0 Z1, X0] is nonzero but has zero expectation on the initial |11>.
+    H = spin.z(0) * spin.z(1)
+    pool = [spin.x(0)]
+
+    @cudaq.kernel
+    def initState(q: cudaq.qview):
+        x(q[0])
+        x(q[1])
+
+    energy, thetas, ops = solvers.adapt_vqe(initState,
+                                            H,
+                                            pool,
+                                            grad_norm_tolerance=1e-3)
+    # The converged initial |11> has <Z0 Z1> = +1.
+    assert energy == pytest.approx(1.0)
+    # First-step convergence must not add a variational parameter.
+    assert len(thetas) == 0
+    # Without a parameter, no pool operator should be selected.
     assert len(ops) == 0

--- a/libs/solvers/unittests/test_adapt.cpp
+++ b/libs/solvers/unittests/test_adapt.cpp
@@ -511,6 +511,39 @@ TEST_F(SolversTester, checkAdaptEmptyGradients) {
   auto [energy, thetas, ops] = cudaq::solvers::adapt_vqe(
       hartreeFock2Electrons, H, pool,
       {{"grad_norm_tolerance", 1e-3}, {"max_iter", 5}});
+  // |11> has <Z0 Z1> = +1, which must be retained without optimisation.
+  EXPECT_DOUBLE_EQ(energy, 1.0);
   // No operators should be selected since all commutators are zero
+  EXPECT_TRUE(ops.empty());
+}
+
+// adapt_vqe must return the initial energy when its first gradient has
+// converged.
+TEST_F(SolversTester, checkAdaptConvergedInitialEnergy) {
+  auto H = cudaq::spin::z(0) * cudaq::spin::z(1);
+  std::vector<cudaq::spin_op> pool = {cudaq::spin::x(0)};
+
+  auto [energy, thetas, ops] = cudaq::solvers::adapt_vqe(
+      hartreeFock2Electrons, H, pool, {{"grad_norm_tolerance", 1e-3}});
+  // <[Z0 Z1, X0]> is zero on |11>, so its unchanged energy must be +1.
+  EXPECT_DOUBLE_EQ(energy, 1.0);
+  // First-step convergence must not add a variational parameter.
+  EXPECT_TRUE(thetas.empty());
+  // Without a variational parameter, no pool operator may be selected.
+  EXPECT_TRUE(ops.empty());
+}
+
+// adapt_vqe with no allowed iterations must still report the initial energy.
+TEST_F(SolversTester, checkAdaptZeroIterationsInitialEnergy) {
+  auto H = cudaq::spin::z(0) * cudaq::spin::z(1);
+  std::vector<cudaq::spin_op> pool = {cudaq::spin::x(0)};
+
+  auto [energy, thetas, ops] = cudaq::solvers::adapt_vqe(
+      hartreeFock2Electrons, H, pool, {{"max_iter", 0}});
+  // Zero iterations leave |11> unchanged, whose <Z0 Z1> energy is +1.
+  EXPECT_DOUBLE_EQ(energy, 1.0);
+  // Zero allowed iterations must leave the ansatz parameter-free.
+  EXPECT_TRUE(thetas.empty());
+  // A parameter-free result must not contain a selected pool operator.
   EXPECT_TRUE(ops.empty());
 }


### PR DESCRIPTION
This PR tries to fix [[B] 6445945](https://nvbugspro.nvidia.com/bug/6445945) .
It also adds some tests to expose this bug and verify the fix.
Thanks for looking this PR.

This suggested fix computes `energy` from `observe(prepare_state, H, state).expectation()` immediately after preparing the initial state, and initialises `latestEnergy` from the same value.
In this case, all early exits return the correct energy and energy-difference convergence uses a valid baseline.