### PR TITLE
Fix CQR surface-code test to use Relay-BP

### DIFF
--- a/libs/qec/unittests/realtime/app_examples/CMakeLists.txt
+++ b/libs/qec/unittests/realtime/app_examples/CMakeLists.txt
@@ -183,12 +183,16 @@ if(TARGET cudaq-qec-realtime-decoding-server-cqr)
       nvqir nvqir-stim)
   qec_realtime_app_link_options(surface_code-1-cqr)
 
+  set(_surface_code_1_cqr_env CUDAQ_DEVICE_CALL_CHANNEL=host_dispatch)
+  if(TARGET cudaq-qec-realtime-cudevice-proprietary
+     AND (QEC_EXTERNAL_DECODERS OR DEFINED ENV{QEC_EXTERNAL_DECODERS}))
+    list(APPEND _surface_code_1_cqr_env EXTRA_CLI_ARGS=--use-relay-bp)
+  endif()
+
   add_test(
     NAME app_examples.surface_code-1-cqr-test-distance-3
     COMMAND
-      ${CMAKE_COMMAND} -E env
-        CUDAQ_DEVICE_CALL_CHANNEL=host_dispatch
-        EXTRA_CLI_ARGS=--use-relay-bp
+      ${CMAKE_COMMAND} -E env ${_surface_code_1_cqr_env}
       bash "${CMAKE_CURRENT_SOURCE_DIR}/surface_code-1-test.sh"
         ${CMAKE_CURRENT_BINARY_DIR}/surface_code-1-cqr
         ${CMAKE_CURRENT_BINARY_DIR}/surface_code-1-cqr

--- a/libs/qec/unittests/realtime/app_examples/CMakeLists.txt
+++ b/libs/qec/unittests/realtime/app_examples/CMakeLists.txt
@@ -183,9 +183,17 @@ if(TARGET cudaq-qec-realtime-decoding-server-cqr)
       nvqir nvqir-stim)
   qec_realtime_app_link_options(surface_code-1-cqr)
 
+  # Enable Relay-BP only when this build provides nv-qldpc support.
+  set(_surface_code_1_cqr_has_nv_qldpc_decoder FALSE)
+  if(TARGET cudaq-qec-nv-qldpc-decoder
+     OR QEC_EXTERNAL_DECODERS
+     OR DEFINED ENV{QEC_EXTERNAL_DECODERS})
+    set(_surface_code_1_cqr_has_nv_qldpc_decoder TRUE)
+  endif()
+
   set(_surface_code_1_cqr_env CUDAQ_DEVICE_CALL_CHANNEL=host_dispatch)
   if(TARGET cudaq-qec-realtime-cudevice-proprietary
-     AND (QEC_EXTERNAL_DECODERS OR DEFINED ENV{QEC_EXTERNAL_DECODERS}))
+     AND _surface_code_1_cqr_has_nv_qldpc_decoder)
     list(APPEND _surface_code_1_cqr_env EXTRA_CLI_ARGS=--use-relay-bp)
   endif()
 

--- a/libs/qec/unittests/realtime/app_examples/CMakeLists.txt
+++ b/libs/qec/unittests/realtime/app_examples/CMakeLists.txt
@@ -186,7 +186,9 @@ if(TARGET cudaq-qec-realtime-decoding-server-cqr)
   add_test(
     NAME app_examples.surface_code-1-cqr-test-distance-3
     COMMAND
-      ${CMAKE_COMMAND} -E env CUDAQ_DEVICE_CALL_CHANNEL=host_dispatch
+      ${CMAKE_COMMAND} -E env
+        CUDAQ_DEVICE_CALL_CHANNEL=host_dispatch
+        EXTRA_CLI_ARGS=--use-relay-bp
       bash "${CMAKE_CURRENT_SOURCE_DIR}/surface_code-1-test.sh"
         ${CMAKE_CURRENT_BINARY_DIR}/surface_code-1-cqr
         ${CMAKE_CURRENT_BINARY_DIR}/surface_code-1-cqr

--- a/libs/qec/unittests/realtime/app_examples/surface_code-1-test.sh
+++ b/libs/qec/unittests/realtime/app_examples/surface_code-1-test.sh
@@ -162,7 +162,7 @@ SYNDROME_NUM_SHOTS=10  # Use fewer shots for syndrome test
 # Step 1: Run simulation with --save_syndrome to capture syndrome data
 # Use local executable for syndrome capture (works with any platform)
 echo "Step 1: Saving syndromes to $SYNDROME_FILE"
-$EXE_PATH1 --distance $DISTANCE --num_shots $SYNDROME_NUM_SHOTS --load_dem $CONFIG_FILE --num_rounds $NUM_ROUNDS --decoder_window $DECODER_WINDOW --decoder_type $DECODER_TYPE --sw_window_size $SW_WINDOW_SIZE --sw_step_size $SW_STEP_SIZE --save_syndrome $SYNDROME_FILE |& tee save_syndrome-$FULL_SUFFIX.log
+$EXE_PATH1 --distance $DISTANCE --num_shots $SYNDROME_NUM_SHOTS --load_dem $CONFIG_FILE --num_rounds $NUM_ROUNDS --decoder_window $DECODER_WINDOW --decoder_type $DECODER_TYPE --sw_window_size $SW_WINDOW_SIZE --sw_step_size $SW_STEP_SIZE $EXTRA_CLI_ARGS --save_syndrome $SYNDROME_FILE |& tee save_syndrome-$FULL_SUFFIX.log
 
 # Check that the syndrome file was created
 if [[ ! -f "$SYNDROME_FILE" ]]; then
@@ -182,7 +182,7 @@ else
   # Step 2: Replay syndromes with --load_syndrome
   # Use local executable for replay (doesn't need quantum simulation)
   echo "Step 2: Replaying syndromes from $SYNDROME_FILE"
-  $EXE_PATH1 --distance $DISTANCE --num_shots $SYNDROME_NUM_SHOTS --load_dem $CONFIG_FILE --num_rounds $NUM_ROUNDS --decoder_window $DECODER_WINDOW --decoder_type $DECODER_TYPE --sw_window_size $SW_WINDOW_SIZE --sw_step_size $SW_STEP_SIZE --load_syndrome $SYNDROME_FILE |& tee load_syndrome-$FULL_SUFFIX.log
+  $EXE_PATH1 --distance $DISTANCE --num_shots $SYNDROME_NUM_SHOTS --load_dem $CONFIG_FILE --num_rounds $NUM_ROUNDS --decoder_window $DECODER_WINDOW --decoder_type $DECODER_TYPE --sw_window_size $SW_WINDOW_SIZE --sw_step_size $SW_STEP_SIZE $EXTRA_CLI_ARGS --load_syndrome $SYNDROME_FILE |& tee load_syndrome-$FULL_SUFFIX.log
   
   # Check for successful replay
   if grep -q "Replay complete" load_syndrome-$FULL_SUFFIX.log; then


### PR DESCRIPTION
## Description

Fixes `app_examples.surface_code-1-cqr-test-distance-3` for the CQR host-dispatch path when `nv-qldpc-decoder` is used with device-call decoding.

The test already set `CUDAQ_DEVICE_CALL_CHANNEL=host_dispatch`, but the nv-qldpc device-call path now requires Relay-BP (`composition=1`). This PR:

- adds `EXTRA_CLI_ARGS=--use-relay-bp` for the CQR surface-code test when both the proprietary cudevice target and external decoder support are available
- keeps the public/non-external-decoder configuration from forcing Relay-BP
- threads `$EXTRA_CLI_ARGS` through the syndrome save/load phase, so `--save_syndrome` and `--load_syndrome` use the same decoder configuration as the main test path

Validated locally in Docker:
- public-source style build without private decoder assets: targeted CQR test passed
- private cuda-qx build with source-built `cudaq-qec-nv-qldpc-decoder` and `cudaq-qec-realtime-cudevice-proprietary`: targeted CQR test passed with `--use-relay-bp`, `nv-qldpc-decoder`, and syndrome replay verification

## Runtime / performance impact

N/A. Test-only change.

## Self-review checklist

Please confirm each item before requesting review. Check `[x]` or strike
through and explain.

### Before requesting review
- [x] I reviewed my own full diff in GitHub or my editor.
- [ ] PR is in Draft if it is not yet ready for review.
- [x] Temporary / debugging changes have been removed.
- [x] Local test logs reviewed; no unexplained warnings or errors.
- [x] CI logs reviewed; no unexplained warnings or errors.
- [ ] Full CI has been run.

### Scope and size
- [x] PR is under ~1000 lines, or an exception is justified in the description.
- [x] Refactoring-only changes are isolated in their own PR(s).
- [x] No existing tests were disabled or modified just to make this PR pass
      (if so, an issue has been raised).

### Tests
- [x] New functionality has new tests. Test-only fix for an existing CQR test.
- [x] Tests fail if the new functionality is broken (including crashes), not
      just when it is missing.
- [x] ~~Negative tests added where exceptions are expected.~~ N/A; no new exception path.
- [x] ~~Truth data added where simple `EXPECT_*` / `assert` checks are
      insufficient for algorithmic correctness.~~ N/A; existing syndrome replay verification covers this path.
- [x] CI runtime impact considered; team notified if significant.

### Documentation
- [x] ~~Public-facing APIs have Doxygen docs.~~ N/A; no API changes.
- [x] ~~User-visible behavior changes have public docs, or a follow-up is
      tracked.~~ N/A; test-only change.

### Code style
- [x] Naming follows the existing convention (`snake_case` vs `camelCase`) for
      the area being modified.

### Dependencies
- [x] No new third-party dependencies, **or** the team has been notified and
      OSRB tickets filed.