### PR TITLE
Create new workflow for multi-platform decoding server image

### DIFF
--- a/.github/workflows/build_decoding_server_docker.yaml
+++ b/.github/workflows/build_decoding_server_docker.yaml
@@ -6,7 +6,7 @@ on:
       image_name:
         type: string
         description: GHCR image name, without a tag
-        default: ghcr.io/nvidia/private/cudaqx-decoding-server
+        default: ghcr.io/nvidia/private/cudaq-decoders
         required: true
       image_tag:
         type: string

--- a/.github/workflows/build_decoding_server_docker.yaml
+++ b/.github/workflows/build_decoding_server_docker.yaml
@@ -1,0 +1,142 @@
+name: Build decoding-server image
+
+on:
+  workflow_dispatch:
+    inputs:
+      image_name:
+        type: string
+        description: GHCR image name, without a tag
+        default: ghcr.io/nvidia/private/cudaqx-decoding-server
+        required: true
+      image_tag:
+        type: string
+        description: Base tag; defaults to wiring-<run number>, with -cu<version> added
+        required: false
+
+jobs:
+  build:
+    name: Build decoding-server image (${{ matrix.platform }}, CUDA ${{ matrix.cuda_version }})
+    if: ${{ github.repository == 'NVIDIA/cudaqx' }}
+    runs-on: linux-${{ matrix.platform }}-cpu8
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        platform: [amd64, arm64]
+        cuda_version: ['12.6', '13.0']
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up context for buildx
+        run: docker context create builder_context
+
+      - name: Set up buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          endpoint: builder_context
+          version: v0.19.0
+          driver-opts: |
+            network=host
+            image=moby/buildkit:v0.19.0
+
+      - name: Log in to GitHub CR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+
+      - name: Build and push image by digest
+        id: docker-build
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: docker/decoding-server/Dockerfile
+          platforms: linux/${{ matrix.platform }}
+          build-args: |
+            CUDA_VERSION=${{ matrix.cuda_version }}
+          labels: |
+            org.opencontainers.image.source=${{ github.repositoryUrl }}
+            org.opencontainers.image.revision=${{ github.sha }}
+          outputs: type=image,name=${{ inputs.image_name }},push-by-digest=true,name-canonical=true,push=true
+
+      - name: Export image digest
+        env:
+          IMAGE_DIGEST: ${{ steps.docker-build.outputs.digest }}
+        run: |
+          set -euo pipefail
+
+          mkdir -p /tmp/digests
+          touch "/tmp/digests/${IMAGE_DIGEST#sha256:}"
+
+      - name: Upload image digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: decoding-server-digest-cu${{ matrix.cuda_version }}-${{ matrix.platform }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  publish:
+    name: Publish decoding-server multi-platform image (CUDA ${{ matrix.cuda_version }})
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        cuda_version: ['12.6', '13.0']
+    steps:
+      - name: Set up buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub CR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+
+      - name: Download image digests
+        uses: actions/download-artifact@v4
+        with:
+          path: /tmp/digests
+          pattern: decoding-server-digest-cu${{ matrix.cuda_version }}-*
+          merge-multiple: true
+
+      - name: Create and verify multi-platform image
+        env:
+          IMAGE_NAME: ${{ inputs.image_name }}
+          IMAGE_TAG: ${{ inputs.image_tag || format('wiring-{0}', github.run_number) }}
+          CUDA_VERSION: ${{ matrix.cuda_version }}
+        run: |
+          set -euo pipefail
+
+          cd /tmp/digests
+          image_ref="${IMAGE_NAME}:${IMAGE_TAG}-cu${CUDA_VERSION}"
+          mapfile -t digests < <(find . -maxdepth 1 -type f -printf '%f\n' | sort)
+          if [[ "${#digests[@]}" != 2 ]]; then
+            echo "::error::Expected 2 image digests, found ${#digests[@]}"
+            exit 1
+          fi
+
+          refs=()
+          for digest in "${digests[@]}"; do
+            refs+=("${IMAGE_NAME}@sha256:${digest}")
+          done
+
+          docker buildx imagetools create --tag "$image_ref" "${refs[@]}"
+
+          manifest=$(docker buildx imagetools inspect --raw "$image_ref")
+          for architecture in amd64 arm64; do
+            jq -e \
+              --arg architecture "$architecture" \
+              '.manifests[] | select(.platform.os == "linux" and .platform.architecture == $architecture)' \
+              <<< "$manifest" > /dev/null
+          done
+
+          docker buildx imagetools inspect "$image_ref"

--- a/docker/decoding-server/Dockerfile
+++ b/docker/decoding-server/Dockerfile
@@ -1,0 +1,22 @@
+# ============================================================================ #
+# Copyright (c) 2025 - 2026 NVIDIA Corporation & Affiliates.                   #
+# All rights reserved.                                                         #
+#                                                                              #
+# This source code and the accompanying materials are made available under     #
+# the terms of the Apache License 2.0 which accompanies this distribution.     #
+# ============================================================================ #
+
+# This is a temporary, minimal image used to validate the decoding-server
+# multi-platform publication workflow while getting the CI wiring in place.
+FROM ubuntu:24.04
+
+ARG TARGETARCH
+ARG CUDA_VERSION
+
+RUN printf '%s\n' \
+      'CUDA-QX decoding-server image wiring test' \
+      "architecture=${TARGETARCH}" \
+      "cuda=${CUDA_VERSION}" \
+      > /etc/cudaqx-decoding-server-image
+
+CMD ["cat", "/etc/cudaqx-decoding-server-image"]


### PR DESCRIPTION
<!--
Thanks for contributing to CUDA-Q Libraries!

Please read the full Pull Request Guidelines in Contributing.md:
https://github.com/NVIDIA/cudaqx/blob/main/Contributing.md#pull-request-guidelines
-->

## Description

<!-- What does this PR change, and why? Link related issues. -->
This adds initial CI wiring to build and publish a multi-platform decoding server image. Currently it uses a placeholder Ubuntu image. The purpose of this PR is to get the workflow defined on `main`, so that it can be run and further iterated on in a test branch. A separate PR will be opened for the decoding server image.

This workflow builds the current amd64/arm64 and CUDA 12.6/13.0 matrix on separate native runners and publishes each platform image to GHCR. It then combines the amd64 and arm64 images into a multi-platform image for each CUDA version that is also published to GHCR.

## Runtime / performance impact

<!--
If this change affects performance, paste benchmark numbers here.
Otherwise write "N/A".
-->

## Self-review checklist

Please confirm each item before requesting review. Check `[x]` or strike
through and explain.

### Before requesting review
- [x] I reviewed my own full diff in GitHub or my editor.
- [x] PR is in Draft if it is not yet ready for review.
- [x] Temporary / debugging changes have been removed.
- [x] Local test logs reviewed; no unexplained warnings or errors.
- [x] CI logs reviewed; no unexplained warnings or errors.
- [x] Full CI has been run.

### Scope and size
- [x] PR is under ~1000 lines, or an exception is justified in the description.
- [x] Refactoring-only changes are isolated in their own PR(s).
- [x] No existing tests were disabled or modified just to make this PR pass
      (if so, an issue has been raised).

### Tests
- [x] New functionality has new tests.
- [x] Tests fail if the new functionality is broken (including crashes), not
      just when it is missing.
- [x] Negative tests added where exceptions are expected.
- [x] Truth data added where simple `EXPECT_*` / `assert` checks are
      insufficient for algorithmic correctness.
- [x] CI runtime impact considered; team notified if significant.

### Documentation
- [x] Public-facing APIs have Doxygen docs.
- [x] User-visible behavior changes have public docs, or a follow-up is
      tracked.

### Code style
- [x] Naming follows the existing convention (`snake_case` vs `camelCase`) for
      the area being modified.

### Dependencies
- [x] No new third-party dependencies, **or** the team has been notified and
      OSRB tickets filed.
