### PR TITLE
Move nv-qldpc-decoder schema registration into its plugin

### DIFF
--- a/libs/qec/lib/decoder_config_schema.cpp
+++ b/libs/qec/lib/decoder_config_schema.cpp
@@ -410,64 +410,11 @@ bool custom_args_maps_equal(const cudaqx::heterogeneous_map &a,
   return true;
 }
 
-// ---------------------------------------------------------------------------
-// Hosted decoder schemas
-//
 // Decoder schemas are registered by the shared library that ships the
 // decoder: lut.cpp and sliding_window.cpp register theirs in this library,
-// and the pymatching / chromobius / trt_decoder plugins register theirs from
-// their own .so. The nv-qldpc-decoder schema is hosted here temporarily: the
-// decoder is a proprietary out-of-tree plugin, and its schema (plus the
-// srelay_bp subschema it references) moves into that plugin once it links
-// against this registry. Third-party decoders register their schema from
-// their own plugin library instead of editing this file.
-// ---------------------------------------------------------------------------
-
-namespace {
-
-struct hosted_schema_registrar {
-  hosted_schema_registrar() {
-    using k = param_kind;
-
-    register_decoder_schema({"srelay_bp",
-                             {
-                                 {"pre_iter", k::uint64},
-                                 {"num_sets", k::uint64},
-                                 {"stopping_criterion", k::string},
-                                 {"stop_nconv", k::uint64},
-                             }});
-
-    register_decoder_schema(
-        {"nv-qldpc-decoder",
-         {
-             {"use_sparsity", k::boolean},
-             {"error_rate", k::f64},
-             {"error_rate_vec", k::f64_vec},
-             {"max_iterations", k::int32},
-             {"n_threads", k::int32},
-             {"use_osd", k::boolean},
-             {"osd_method", k::int32},
-             {"osd_order", k::int32},
-             {"bp_batch_size", k::int32},
-             {"osd_batch_size", k::int32},
-             {"iter_per_check", k::int32},
-             {"clip_value", k::f64},
-             {"bp_method", k::int32},
-             {"scale_factor", k::f64},
-             {"proc_float", k::string},
-             {"gamma0", k::f64},
-             {"gamma_dist", k::f64_vec},
-             {"explicit_gammas", k::f64_matrix},
-             {"bp_seed", k::int32},
-             {"srelay_config", k::subschema, false, "srelay_bp"},
-             {"composition", k::int32},
-             {"repeatable", k::boolean},
-         }});
-  }
-};
-
-hosted_schema_registrar hosted_schemas;
-
-} // namespace
+// and the decoder plugins (pymatching, chromobius, trt_decoder,
+// nv-qldpc-decoder, ...) register theirs from their own .so. Third-party
+// decoders register their schema from their own plugin library instead of
+// editing this file.
 
 } // namespace cudaq::qec::decoding::config

--- a/libs/qec/python/tests/test_decoding_config.py
+++ b/libs/qec/python/tests/test_decoding_config.py
@@ -16,6 +16,8 @@ import cudaq_qec as qec
 # Decoder custom args are plain dicts. Their keys are governed by the
 # parameter schema each decoder registers (see qec.decoder_param_schema).
 
+nv_qldpc_schema_missing = qec.decoder_param_schema("nv-qldpc-decoder") is None
+
 
 def is_nv_qldpc_decoder_available():
     """
@@ -34,7 +36,10 @@ def is_nv_qldpc_decoder_available():
 # Schema introspection tests
 
 
-def test_decoder_param_schema_introspection():
+@pytest.mark.skipif(
+    nv_qldpc_schema_missing,
+    reason="nv-qldpc-decoder plugin (and its parameter schema) not available")
+def test_nv_qldpc_decoder_param_schema_introspection():
     schema = qec.decoder_param_schema("nv-qldpc-decoder")
     assert schema is not None
     by_key = {entry["key"]: entry for entry in schema}
@@ -43,6 +48,8 @@ def test_decoder_param_schema_introspection():
     assert by_key["srelay_config"]["kind"] == "subschema"
     assert by_key["srelay_config"]["subschema"] == "srelay_bp"
 
+
+def test_decoder_param_schema_introspection():
     sw_schema = qec.decoder_param_schema("sliding_window")
     assert sw_schema is not None
     by_key = {entry["key"]: entry for entry in sw_schema}
@@ -72,6 +79,9 @@ def test_decoder_custom_args_is_a_dict():
     assert dc.decoder_custom_args == {"lut_error_depth": 3}
 
 
+@pytest.mark.skipif(
+    nv_qldpc_schema_missing,
+    reason="nv-qldpc-decoder plugin (and its parameter schema) not available")
 def test_decoder_config_yaml_roundtrip_and_custom_args():
     dc = qec.decoder_config()
     dc.id = 0
@@ -178,6 +188,9 @@ def test_validate_custom_args_checks_dict_built_configs():
         mdc.validate_custom_args()
 
 
+@pytest.mark.skipif(
+    nv_qldpc_schema_missing,
+    reason="nv-qldpc-decoder plugin (and its parameter schema) not available")
 def test_custom_args_dict_values_convert_to_schema_types():
     # The setter converts dict values to the canonical types the registered
     # schema declares: Python ints are accepted for f64 params and negative
@@ -401,6 +414,9 @@ def test_trt_decoder_default_global_params_materialized():
     assert mdc2.to_yaml_str() == first
 
 
+@pytest.mark.skipif(
+    nv_qldpc_schema_missing,
+    reason="nv-qldpc-decoder plugin (and its parameter schema) not available")
 def test_validate_custom_args_checks_value_kinds():
     # A dict assigned before `type` is set takes the generic conversion
     # (ints stored as size_t), which an f64 param cannot read back at
@@ -474,6 +490,9 @@ decoders:
 # multi_decoder_config tests
 
 
+@pytest.mark.skipif(
+    nv_qldpc_schema_missing,
+    reason="nv-qldpc-decoder plugin (and its parameter schema) not available")
 def test_multi_decoder_config_yaml_roundtrip():
     d1 = qec.decoder_config()
     d1.id = 0
@@ -539,6 +558,8 @@ def test_configure_decoders_from_str_smoke():
     assert isinstance(status, int)
     qec.finalize_decoders()
 
+    if nv_qldpc_schema_missing:
+        return
     decoder_config = qec.decoder_config()
     decoder_config.id = 0
     decoder_config.type = "nv-qldpc-decoder"

--- a/libs/qec/python/tests/test_decoding_config_deprecated.py
+++ b/libs/qec/python/tests/test_decoding_config_deprecated.py
@@ -31,6 +31,7 @@ pytestmark = pytest.mark.filterwarnings("ignore::DeprecationWarning")
 
 trt_schema_missing = qec.decoder_param_schema("trt_decoder") is None
 chromobius_schema_missing = qec.decoder_param_schema("chromobius") is None
+nv_qldpc_schema_missing = qec.decoder_param_schema("nv-qldpc-decoder") is None
 
 
 def is_nv_qldpc_decoder_available():
@@ -70,6 +71,9 @@ def test_deprecated_typed_configs_warn_on_construction():
             cls()
 
 
+@pytest.mark.skipif(
+    nv_qldpc_schema_missing,
+    reason="nv-qldpc-decoder plugin (and its parameter schema) not available")
 def test_deprecated_config_matches_dict_built_yaml():
     cfg = qec.nv_qldpc_decoder_config()
     cfg.use_sparsity = True
@@ -264,6 +268,9 @@ def test_nv_qldpc_decoder_config_set_and_get_each_optional(name, meta):
     assert getattr(nv, name) is None
 
 
+@pytest.mark.skipif(
+    nv_qldpc_schema_missing,
+    reason="nv-qldpc-decoder plugin (and its parameter schema) not available")
 def test_nv_qldpc_decoder_config_setting_wrong_types_raises_typeerror():
     nv = qec.nv_qldpc_decoder_config()
 
@@ -662,6 +669,9 @@ def test_trt_decoder_chromobius_global_config_yaml_roundtrip():
 # decoder_config tests
 
 
+@pytest.mark.skipif(
+    nv_qldpc_schema_missing,
+    reason="nv-qldpc-decoder plugin (and its parameter schema) not available")
 def test_decoder_config_yaml_roundtrip_and_custom_args():
     # Build NV config and embed into DecoderConfig via helper
     nv = qec.nv_qldpc_decoder_config()
@@ -702,6 +712,9 @@ def test_decoder_config_yaml_roundtrip_and_custom_args():
 # multi_decoder_config tests
 
 
+@pytest.mark.skipif(
+    nv_qldpc_schema_missing,
+    reason="nv-qldpc-decoder plugin (and its parameter schema) not available")
 def test_multi_decoder_config_yaml_roundtrip():
     # Build NV config and embed into DecoderConfig via helper
     nv = qec.nv_qldpc_decoder_config()
@@ -749,6 +762,8 @@ def test_configure_decoders_from_str_smoke():
     assert isinstance(status, int)
     qec.finalize_decoders()
 
+    if nv_qldpc_schema_missing:
+        return
     nv = qec.nv_qldpc_decoder_config()
     nv.error_rate_vec = [0.1, 0.2, 0.3, 0.1, 0.2, 0.3, 0.1, 0.2, 0.3, 0.1]
 

--- a/libs/qec/unittests/realtime/app_examples/CMakeLists.txt
+++ b/libs/qec/unittests/realtime/app_examples/CMakeLists.txt
@@ -990,13 +990,13 @@ _sc4_reject(p-spam-zero-generation "--p_spam must be > 0 to generate"
   --distance 3 --num_rounds 3 --p_spam 0 --decoder_type pymatching
   --save_dem ${_sc4_neg_dir}/ps0.yml)
 
-# Dual-parse pin, plugin-free: generation instantiates no decoder, so this
-# runs everywhere. Structural check (always): the BP entry carries the
-# undecomposed hyperedge H -- strictly fewer columns than the matching entry's
-# decomposed H. Full check (python3 available): the mixed-list BP entry's
-# column multiset of (detector support, observable support, probability) is
-# IDENTICAL to a directly generated undecomposed reference config at the same
-# geometry.
+# Dual-parse pin: generation instantiates no decoder, but YAML emission
+# requires the nv-qldpc-decoder parameter schema (registered by the plugin).
+# Structural check: the BP entry carries the undecomposed hyperedge H --
+# strictly fewer columns than the matching entry's decomposed H.
+# Full check (python3 available): the mixed-list BP entry's column multiset
+# of (detector support, observable support, probability) is IDENTICAL to a
+# directly generated undecomposed reference config at the same geometry.
 function(_sc4_dual_parse_test distance num_rounds)
   add_test(NAME app_examples.surface_code-4-yaml-dual-parse-gen-d${distance}
     COMMAND bash -c [==[
@@ -1081,8 +1081,12 @@ fi
   set_tests_properties(app_examples.surface_code-4-yaml-dual-parse-gen-d${distance}
     PROPERTIES ENVIRONMENT "${_sc4_neg_env}")
 endfunction()
-_sc4_dual_parse_test(3 3)
-_sc4_dual_parse_test(5 5)
+if(TARGET cudaq-qec-nv-qldpc-decoder
+   OR QEC_EXTERNAL_DECODERS
+   OR DEFINED ENV{QEC_EXTERNAL_DECODERS})
+  _sc4_dual_parse_test(3 3)
+  _sc4_dual_parse_test(5 5)
+endif()
 
 # X-basis Ising bundle rejected (basis must be Z). Fabricate just the
 # metadata.txt the loader inspects; the dummy ONNX is never opened because the

--- a/libs/qec/unittests/test_decoders_yaml.cpp
+++ b/libs/qec/unittests/test_decoders_yaml.cpp
@@ -205,6 +205,12 @@ bool is_trt_decoder_schema_available() {
          nullptr;
 }
 
+// The nv-qldpc-decoder schema is registered by the proprietary plugin.
+bool is_nv_qldpc_schema_available() {
+  return cudaq::qec::decoding::config::find_decoder_schema(
+             "nv-qldpc-decoder") != nullptr;
+}
+
 bool is_nv_qldpc_decoder_available() {
   try {
     std::size_t block_size = 7;
@@ -595,13 +601,15 @@ TEST(DecoderYAMLTest, SlidingWindowInnerDecoderVariantRoundTrips) {
   single_lut_sw.insert("inner_decoder_name", "single_error_lut");
   check_roundtrip(single_lut_sw);
 
-  auto nv_sw = single_lut_sw;
-  nv_sw.insert("inner_decoder_name", "nv-qldpc-decoder");
-  cudaqx::heterogeneous_map nv_inner;
-  nv_inner.insert("max_iterations", 5);
-  nv_inner.insert("error_rate_vec", std::vector<double>(6, 0.1));
-  nv_sw.insert("inner_decoder_params", nv_inner);
-  check_roundtrip(nv_sw);
+  if (is_nv_qldpc_schema_available()) {
+    auto nv_sw = single_lut_sw;
+    nv_sw.insert("inner_decoder_name", "nv-qldpc-decoder");
+    cudaqx::heterogeneous_map nv_inner;
+    nv_inner.insert("max_iterations", 5);
+    nv_inner.insert("error_rate_vec", std::vector<double>(6, 0.1));
+    nv_sw.insert("inner_decoder_params", nv_inner);
+    check_roundtrip(nv_sw);
+  }
 }
 
 TEST(DecoderConfigTest, ConfigureRejectsDuplicateAndNegativeIds) {
@@ -1159,6 +1167,9 @@ TEST(DecoderYAMLTest, PrepareDecoderParamsSurfacesCudaDeviceId) {
 }
 
 TEST(DecoderYAMLTest, ValidateCustomArgsChecksValueKinds) {
+  if (!is_nv_qldpc_schema_available())
+    GTEST_SKIP() << "nv-qldpc-decoder plugin (and its parameter schema) not "
+                    "available";
   // A validated map is guaranteed to serialize: every value must be readable
   // as its schema kind's canonical storage type, not just have a known key.
   using cudaq::qec::decoding::config::decoder_config;


### PR DESCRIPTION
## Summary

The `nv-qldpc-decoder` and `srelay_bp` parameter schemas were temporarily hosted in `decoder_config_schema.cpp` (the base library) while the proprietary plugin was being wired up to the schema registry. This PR completes that migration: the schemas are removed from the base library and will be registered by the plugin itself on load, exactly as `trt_decoder`, `pymatching`, and `chromobius` already do.

## Changes

- **`libs/qec/lib/decoder_config_schema.cpp`**: Remove the `hosted_schema_registrar` static initializer that registered `nv-qldpc-decoder` and `srelay_bp`. Update the comment to reflect the current (fully pluggable) registration model.

- **`libs/qec/python/tests/test_decoding_config.py`**: Add `nv_qldpc_schema_missing` flag (mirrors the existing `trt_schema_missing` pattern). Split `test_decoder_param_schema_introspection` so the always-available `sliding_window`/`registered_decoder_schemas` assertions keep running unconditionally; guard the nv-qldpc-specific assertions in a new `test_nv_qldpc_decoder_param_schema_introspection`. Add `@pytest.mark.skipif(nv_qldpc_schema_missing, ...)` to the four other tests that require the schema (`yaml_roundtrip_and_custom_args`, `custom_args_dict_values_convert_to_schema_types`, `validate_custom_args_checks_value_kinds`, `multi_decoder_config_yaml_roundtrip`). Add an early `if nv_qldpc_schema_missing: return` in `test_configure_decoders_from_str_smoke` before the `to_yaml_str()` call that precedes the existing decoder-availability guard.

- **`libs/qec/python/tests/test_decoding_config_deprecated.py`**: Same `nv_qldpc_schema_missing` flag. Guard `test_deprecated_config_matches_dict_built_yaml`, `test_nv_qldpc_decoder_config_setting_wrong_types_raises_typeerror` (expects `TypeError` from schema type-checking that silently no-ops without the schema), `test_decoder_config_yaml_roundtrip_and_custom_args`, and `test_multi_decoder_config_yaml_roundtrip`. Early-exit the nv-qldpc section of `test_configure_decoders_from_str_smoke`.

- **`libs/qec/unittests/test_decoders_yaml.cpp`**: Add `is_nv_qldpc_schema_available()` (a cheap registry lookup, analogous to `is_trt_decoder_schema_available()`). Add `GTEST_SKIP` to `ValidateCustomArgsChecksValueKinds` when the schema is absent. Wrap the nv-qldpc inner-decoder branch of `SlidingWindowInnerDecoderVariantRoundTrips` in an `if (is_nv_qldpc_schema_available())` block so the `single_error_lut` branch still exercises the discriminated roundtrip unconditionally.

## Test plan

- [ ] Public-repo CI passes: all nv-qldpc-dependent tests skip gracefully when the plugin is not present
- [ ] With the proprietary nv-qldpc-decoder plugin loaded, schemas self-register and all guarded tests run as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)