### PR TITLE
Work around CUDA 12 GCC 12 BF16 headers in realtime builds

### DIFF
--- a/.github/actions/build-lib/build_qec.sh
+++ b/.github/actions/build-lib/build_qec.sh
@@ -2,6 +2,7 @@
 set -e
 
 . "$(dirname "$0")/setup_custabilizer.sh"
+. "$(dirname "$0")/../../../scripts/cudaq_realtime_cmake_flags.sh"
 
 build_dir=$1
 install_prefix=$2
@@ -100,7 +101,9 @@ if [ -z "$CUDAQ_REALTIME_ROOT" ]; then
   # which produces libcudaq-realtime-bridge-hololink.so needed by the bridge.
   cd /tmp/cudaq-realtime-src/realtime
   mkdir -p build && cd build
+
   cmake -G Ninja -DCMAKE_INSTALL_PREFIX="$CUDAQ_REALTIME_ROOT" \
+    -DCMAKE_CUDA_FLAGS="$(cudaq_realtime_cmake_cuda_flags)" \
     -DCUDAQ_REALTIME_ENABLE_HOLOLINK_TOOLS=ON \
     -DHOLOSCAN_SENSOR_BRIDGE_SOURCE_DIR=$HSB_ROOT \
     -DHOLOSCAN_SENSOR_BRIDGE_BUILD_DIR=$HSB_BUILD \

--- a/.github/actions/get-cudaq-build/action.yaml
+++ b/.github/actions/get-cudaq-build/action.yaml
@@ -51,6 +51,7 @@ runs:
         to_hash: |
           .github/actions/get-cudaq-build/**
           scripts/build_cudaq_with_realtime.sh
+          scripts/cudaq_realtime_cmake_flags.sh
           .cudaq_version
       run: |
         hash=${{ hashFiles(format('{0}', env.to_hash)) }}

--- a/.github/workflows/all_libs_release.yaml
+++ b/.github/workflows/all_libs_release.yaml
@@ -108,6 +108,7 @@ jobs:
 
       - name: Build cuda-quantum realtime
         run: |
+          source "$GITHUB_WORKSPACE/scripts/cudaq_realtime_cmake_flags.sh"
           CUDAQ_REPO="${{ steps.get-cudaq-version.outputs.repo }}"
           CUDAQ_REF="${{ steps.get-cudaq-version.outputs.ref }}"
           CUDAQ_REALTIME_ROOT=/tmp/cudaq-realtime
@@ -119,7 +120,9 @@ jobs:
           git sparse-checkout set realtime cmake
           git checkout "$CUDAQ_REF"
           cd realtime && mkdir -p build && cd build
-          cmake -G Ninja -DCMAKE_INSTALL_PREFIX=$CUDAQ_REALTIME_ROOT ..
+          cmake -G Ninja -DCMAKE_INSTALL_PREFIX=$CUDAQ_REALTIME_ROOT \
+            -DCMAKE_CUDA_FLAGS="$(cudaq_realtime_cmake_cuda_flags)" \
+            ..
           ninja && ninja install
           echo "CUDAQ_REALTIME_ROOT=$CUDAQ_REALTIME_ROOT" >> $GITHUB_ENV
         shell: bash

--- a/docker/build_env/cudaqx.dev.Dockerfile
+++ b/docker/build_env/cudaqx.dev.Dockerfile
@@ -23,6 +23,7 @@ RUN apt-get update && CUDA_DASH=$(echo $cuda_version | tr '.' '-') \
 
 COPY .cudaq_version /cudaq_version
 COPY scripts/build_cudaq_with_realtime.sh /usr/local/bin/build_cudaq_with_realtime.sh
+COPY scripts/cudaq_realtime_cmake_flags.sh /usr/local/bin/cudaq_realtime_cmake_flags.sh
 
 ENV CUDAQ_INSTALL_PREFIX=/usr/local/cudaq
 

--- a/scripts/build_cudaq_with_realtime.sh
+++ b/scripts/build_cudaq_with_realtime.sh
@@ -23,6 +23,9 @@ set -euo pipefail
 
 log() { printf '\033[1;34m==>\033[0m %s\n' "$*"; }
 
+script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+. "$script_dir/cudaq_realtime_cmake_flags.sh"
+
 BUILD_TYPE=${1:-"Release"}
 CC=${2:-${CC:-"gcc"}}
 CXX=${3:-${CXX:-"g++"}}
@@ -39,6 +42,7 @@ log "Building cudaq-realtime from $CUDAQ_SRC/realtime"
 cmake -G Ninja -S "$CUDAQ_SRC/realtime" -B "$CUDAQ_SRC/realtime/build" \
   -DCMAKE_BUILD_TYPE="$BUILD_TYPE" \
   -DCMAKE_INSTALL_PREFIX="$CUDAQ_INSTALL_PREFIX" \
+  -DCMAKE_CUDA_FLAGS="$(cudaq_realtime_cmake_cuda_flags)" \
   -DCUDAQ_REALTIME_BUILD_TESTS=OFF \
   -DCUDAQ_REALTIME_BUILD_EXAMPLES=OFF \
   -DCUDAQ_REALTIME_ENABLE_HOLOLINK_TOOLS=OFF

--- a/scripts/cudaq_realtime_cmake_flags.sh
+++ b/scripts/cudaq_realtime_cmake_flags.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+# CMake flags required when CUDA-QX builds CUDA-Q's realtime dependency.
+cudaq_realtime_cmake_cuda_flags() {
+  _cudaq_realtime_cuda_flags="${CMAKE_CUDA_FLAGS:-}"
+  _cudaq_realtime_host_cxx="${CXX:-c++}"
+  _cudaq_realtime_host_cxx_major=$("$_cudaq_realtime_host_cxx" -dumpversion 2>/dev/null | cut -d. -f1)
+  _cudaq_realtime_cuda_major=$(nvcc --version 2>/dev/null |
+    sed -n 's/^.*release \([0-9][0-9]*\)\..*$/\1/p')
+
+  # CUDA 12's nvcc frontend cannot parse GCC 12's AVX-512 BF16 intrinsic
+  # headers. CUDA-Q realtime does not use those intrinsics, so defining the
+  # headers' include guards keeps them out of the nvcc parse.
+  if [ "$(uname -m)" = x86_64 ] && [ "$_cudaq_realtime_cuda_major" = 12 ] && \
+    [ "$_cudaq_realtime_host_cxx_major" = 12 ]; then
+    _cudaq_realtime_cuda_flags="${_cudaq_realtime_cuda_flags} -D_AVX512BF16INTRIN_H_INCLUDED -D_AVX512BF16VLINTRIN_H_INCLUDED"
+  fi
+
+  printf '%s' "$_cudaq_realtime_cuda_flags"
+}


### PR DESCRIPTION
CUDA-QX builds CUDA-Q's realtime library from the revision pinned in .cudaq_version. A CUDA-Q devcontainer update started honoring its GCC 12 CXX selection through CUDAHOSTCXX. CUDA 12.6 nvcc then fails while parsing GCC 12's AVX-512 BF16 intrinsic headers, before compiling CUDA-Q realtime's host dispatcher.

Keep the compatibility workaround in CUDA-QX, which orchestrates these dependency builds. Add a small shared helper that appends the two GCC BF16 header guards only when nvcc is CUDA 12, the host is x86-64, and the selected C++ compiler is GCC 12. CUDA-Q realtime does not use those intrinsics, so this prevents nvcc from parsing unsupported builtin declarations without changing CUDA-Q source or replacing the selected host compiler.

Use that helper for the QEC CI dependency build, the All Libs release artifact build, and the documented realtime rebuild script used by the CUDA-Q build action and install helper. Include the helper in the CUDA-Q build-cache key so a compatibility change cannot reuse a stale realtime build. The release Dockerfile only overlays those artifacts, so covering the release build makes the published CUDA 12.6 image complete; normal CUDA-QX source builds in that image use the bundled realtime installation and do not rebuild it.

Verified with shell syntax checks and a container test of all helper gates. The exact CUDA-Q revision pinned by CUDA-QX fails with nine BF16 builtin errors under CUDA 12.6/GCC 12.4 without the definitions and compiles with them. A full CMake configure remains unavailable in PR695 because it has CMake 3.28 while the pinned CUDA-Q revision requires CMake 4.