### PR TITLE
Fix non-physical TensorNetworkDecoder posteriors

### DIFF
--- a/docs/sphinx/api/qec/tensor_network_decoder_api.rst
+++ b/docs/sphinx/api/qec/tensor_network_decoder_api.rst
@@ -68,7 +68,7 @@
     :param logical_inds: (optional) List of logical index names
     :param logical_tags: (optional) List of logical tags
     :param contract_noise_model: (bool, optional) Whether to contract the noise model at initialization (default: True)
-    :param dtype: (str, optional) Data type for tensors (default: "float32")
+    :param dtype: (str, optional) Data type for tensors (default: "float64")
     :param device: (str, optional) Device for tensor operations ("cpu", "cuda", or "cuda:X", default: "cuda")
 
     **Methods**

--- a/libs/qec/python/cudaq_qec/plugins/decoders/tensor_network_decoder.py
+++ b/libs/qec/python/cudaq_qec/plugins/decoders/tensor_network_decoder.py
@@ -22,6 +22,32 @@ from .tensor_network_utils.tensor_network_factory import (
     tensor_network_from_syndrome_batch, tensor_network_from_logical_observable)
 
 
+def _safe_posterior(mass0, mass1, dtype: str) -> tuple[float, bool]:
+    """Validate contraction masses and compute the posterior P(logical flip).
+
+    Tiny negative values within floating-point round-off of zero are normalized
+    to zero. On any materially non-physical input (negative, NaN, infinite, or
+    zero-sum masses), return ``(0.5, False)`` so callers can mark the result
+    unconverged rather than silently propagating a bad value.
+    """
+    m0, m1 = float(mass0), float(mass1)
+    if not np.isfinite(m0) or not np.isfinite(m1):
+        return 0.5, False
+
+    scale = max(abs(m0), abs(m1))
+    tolerance = 64.0 * np.finfo(np.dtype(dtype)).eps * scale
+    if m0 < -tolerance or m1 < -tolerance:
+        return 0.5, False
+
+    # Signed contractions can leave an exact zero a few ULPs below zero.
+    m0 = max(m0, 0.0)
+    m1 = max(m1, 0.0)
+    denom = m0 + m1
+    if not np.isfinite(denom) or denom == 0.0:
+        return 0.5, False
+    return m1 / denom, True
+
+
 @qec.decoder("tensor_network_decoder")
 class TensorNetworkDecoder:
     r"""A general class for tensor network decoders.
@@ -110,7 +136,7 @@ class TensorNetworkDecoder:
         logical_inds: list[str] | None = None,
         logical_tags: list[str] | None = None,
         contract_noise_model: bool = True,
-        dtype: str = "float32",
+        dtype: str = "float64",
         device: str = "cuda",
     ) -> None:
         """Initialize a sparse representation of a tensor network decoder for an arbitrary code
@@ -406,12 +432,11 @@ class TensorNetworkDecoder:
             device_id=self.contractor_config.device_id,
         )
 
+        posterior, valid = _safe_posterior(contraction_value[0],
+                                           contraction_value[1], self._dtype)
         res = qec.DecoderResult()
-        res.converged = True
-        res.result = [
-            float(contraction_value[1] /
-                  (contraction_value[1] + contraction_value[0]))
-        ]
+        res.converged = valid
+        res.result = [posterior]
         return res
 
     def decode_batch(
@@ -463,10 +488,13 @@ class TensorNetworkDecoder:
         )
 
         probabilities = []
+        converged = []
         for r in range(syndrome_batch.shape[0]):
-            probabilities.append(
-                float(contraction_value[r, 1] /
-                      (contraction_value[r, 1] + contraction_value[r, 0])))
+            posterior, valid = _safe_posterior(contraction_value[r, 0],
+                                               contraction_value[r, 1],
+                                               self._dtype)
+            probabilities.append(posterior)
+            converged.append(valid)
 
         # Python `decode_batch` override: construct a BatchDecoderResult
         # directly, bypassing the native decoder aggregation path. This is
@@ -474,7 +502,7 @@ class TensorNetworkDecoder:
         # see its docstring for the supported construction surface.
         return qec.BatchDecoderResult(
             np.asarray(probabilities, dtype=np.float64).reshape((-1, 1)),
-            np.ones(syndrome_batch.shape[0], dtype=bool),
+            np.asarray(converged, dtype=bool),
         )
 
     def optimize_path(

--- a/libs/qec/python/tests/test_tensor_network_decoder.py
+++ b/libs/qec/python/tests/test_tensor_network_decoder.py
@@ -62,7 +62,7 @@ def test_decoder_init_and_attributes():
         assert decoder.contractor_config.contractor_name == "torch"
         assert decoder.contractor_config.backend == "torch"
         assert decoder.contractor_config.device == "cpu"
-    assert decoder._dtype == "float32"
+    assert decoder._dtype == "float64"
 
 
 def test_decoder_replace_logical_observable():
@@ -158,8 +158,9 @@ def test_decoder_decode_batch():
     assert res.result.shape == (3, 1)
     assert res.converged.shape == (3,)
     assert np.all(res.converged)
-    assert np.all((0.0 <= np.round(res.result[:, 0])) &
-                  (np.round(res.result[:, 0]) <= 1.0))
+    np.testing.assert_allclose(res.result[:, 0], [1.0, 1.0, 0.0],
+                               atol=1e-12,
+                               rtol=1e-12)
 
 
 def test_decoder_set_contractor_invalid():
@@ -583,6 +584,108 @@ def test_invalid_backend():
 def test_invalid_combo():
     with pytest.raises(ValueError):
         ContractorConfig("torch", "numpy", "cpu")
+
+
+# ---------------------------------------------------------------------------
+# Focused tests for _safe_posterior / mass-validation logic, using a mocked
+# contractor so these run without a GPU and without a real contraction.
+# ContractorConfig is a frozen dataclass; its contractor property reads from
+# the class-level _contractors dict, which is the correct mock surface.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def mock_decoder(monkeypatch):
+    """Fixture that returns a factory for decoders with a mocked contractor.
+
+    Usage:
+        decoder = mock_decoder(np.array([m0, m1]))           # single decode
+        decoder = mock_decoder(np.array([[...],...]), rows=N) # batch decode
+    The factory patches ContractorConfig._contractors for the active backend
+    and pre-sets path_single/path_batch so no path optimisation is triggered.
+    """
+
+    def _make(mock_output, rows=None, dtype="float64"):
+        H, logical, noise = make_simple_code()
+        decoder = qec.get_decoder("tensor_network_decoder",
+                                  H,
+                                  logical_obs=logical,
+                                  noise_model=noise,
+                                  dtype=dtype)
+        decoder.path_single = "auto"
+        decoder.path_batch = "auto"
+        if rows is not None:
+            decoder._batch_size = rows
+        name = decoder.contractor_config.contractor_name
+        monkeypatch.setitem(ContractorConfig._contractors, name,
+                            lambda *a, **kw: mock_output)
+        return decoder
+
+    return _make
+
+
+def test_default_dtype_is_float64():
+    H, logical, noise = make_simple_code()
+    decoder = qec.get_decoder("tensor_network_decoder",
+                              H,
+                              logical_obs=logical,
+                              noise_model=noise)
+    assert decoder._dtype == "float64"
+
+
+_BIG = np.finfo(np.float64).max
+
+
+@pytest.mark.parametrize(
+    "masses",
+    [
+        [-0.1, 1.1],  # negative mass
+        [0.0, 0.0],  # zero denominator
+        [float("nan"), 0.5],  # NaN
+        [float("inf"), 0.5],  # infinite mass
+        [_BIG, _BIG],  # finite masses whose sum overflows to inf
+    ])
+def test_decode_invalid_masses_marks_unconverged(mock_decoder, masses):
+    res = mock_decoder(np.array(masses)).decode([0.0, 0.0])
+    assert not res.converged
+    assert res.result[0] == pytest.approx(0.5)
+
+
+def test_decode_valid_masses_converged(mock_decoder):
+    res = mock_decoder(np.array([0.3, 0.7])).decode([0.0, 0.0])
+    assert res.converged
+    assert res.result[0] == pytest.approx(0.7)
+
+
+@pytest.mark.parametrize("dtype", ["float32", "float64"])
+def test_decode_roundoff_negative_mass_converged(mock_decoder, dtype):
+    eps = np.finfo(np.dtype(dtype)).eps
+    res = mock_decoder(np.array([-eps, 1.0]), dtype=dtype).decode([0.0, 0.0])
+    assert res.converged
+    assert res.result[0] == pytest.approx(1.0)
+
+
+@pytest.mark.parametrize(
+    "bad_row",
+    [
+        [-0.1, 1.1],  # negative mass
+        [float("nan"), 0.5],  # NaN
+        [0.0, 0.0],  # zero denominator
+    ])
+def test_decode_batch_invalid_row_marks_unconverged(mock_decoder, bad_row):
+    mock = np.array([[0.3, 0.7], bad_row])
+    res = mock_decoder(mock, rows=2).decode_batch(np.zeros((2, 2)))
+    assert res.converged[0]
+    assert not res.converged[1]
+    assert res.result[0, 0] == pytest.approx(0.7)
+    assert res.result[1, 0] == pytest.approx(0.5)
+
+
+def test_decode_batch_all_valid_all_converged(mock_decoder):
+    mock = np.array([[0.2, 0.8], [0.6, 0.4], [0.1, 0.9]])
+    res = mock_decoder(mock, rows=3).decode_batch(np.zeros((3, 2)))
+    assert np.all(res.converged)
+    np.testing.assert_allclose(res.result[:, 0], [0.8, 0.4, 0.9])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!--
Thanks for contributing to CUDA-Q Libraries!

Please read the full Pull Request Guidelines in Contributing.md:
https://github.com/NVIDIA/cudaqx/blob/main/Contributing.md#pull-request-guidelines
-->

## Description

Fixes #643.

`TensorNetworkDecoder` documented `float64` as its default dtype but used `float32`. On numerically sensitive, degenerate syndromes, single-precision tensor-network contractions can produce negative coset masses and posteriors outside `[0, 1]`.

This change:

- Changes the default dtype from `float32` to `float64` in `__init__` and the public RST documentation.
- Adds `_safe_posterior()` to validate coset masses before normalization.
- Normalizes tiny, dtype-scaled negative round-off residues to zero.
- Marks materially negative, NaN, infinite, zero-sum, and overflowed masses as unconverged, returning `0.5` as a sentinel instead of exposing a non-physical posterior.
- Applies validation consistently to `decode()` and `decode_batch()`.
- Tracks convergence independently for each row returned by `decode_batch()`.
- Updates the existing default-dtype regression test.
- Strengthens the existing batch test to require convergence and verify the expected posteriors `[1.0, 1.0, 0.0]`.
- Adds parametrized tests covering invalid masses and harmless `float32`/`float64` round-off for single and batch decoding.

## Validation

```text
python3 -m pytest libs/qec/python/tests/test_tensor_network_decoder.py -v

43 passed in 7.63s
```

## Runtime / performance impact

No measurable runtime regression was observed.

## Self-review checklist

### Before requesting review

- [x] I reviewed my own full diff in GitHub or my editor.
- [ ] PR is in Draft if it is not yet ready for review.
- [x] Temporary and debugging changes have been removed.
- [x] Local test logs reviewed; no unexplained warnings or errors.
- [x] CI logs reviewed; no unexplained warnings or errors.
- [x] Full CI has been run.

### Scope and size

- [x] PR is under approximately 1,000 lines, or an exception is justified in the description.
- [x] Refactoring-only changes are isolated in their own PRs.
- [x] No existing tests were disabled or modified merely to make this PR pass.

### Tests

- [x] New functionality has new tests.
- [x] Tests fail if the new functionality is broken, not only when it is missing.
- [x] Invalid-input tests cover negative, NaN, infinite, zero-sum, and overflowed masses.
- [x] Truth data verifies the expected batch posteriors.
- [x] CI runtime impact was considered; the focused suite completes in approximately eight seconds.

### Documentation

- [x] Not applicable—this is a Python-only API and does not require new Doxygen documentation.
- [x] The user-visible default-dtype change is reflected in the public RST documentation.

### Code style

- [x] Naming follows the existing convention for the modified Python code.

### Dependencies

- [x] No new third-party dependencies were added.