### PR TITLE
Docs: Set warnings as errors

### DIFF
--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -101,12 +101,11 @@ configure_file(${SPHINX_CONF_IN} ${SPHINX_CONF} @ONLY)
 # - Doxygen has rerun
 # - Our doc files have been updated
 # - The Sphinx config has been updated
-# TODO: set warning as error (-W flag)
 add_custom_command(
   OUTPUT ${SPHINX_INDEX_FILE}
   COMMAND ${CMAKE_COMMAND} -E env
           LD_LIBRARY_PATH=${CUDAQ_LIBRARY_DIR}:$ENV{LD_LIBRARY_PATH}
-          ${SPHINX_EXECUTABLE} -v -n --keep-going -b html
+          ${SPHINX_EXECUTABLE} -v -n -W --keep-going -b html
           -c ${CMAKE_CURRENT_BINARY_DIR}
           -Dbreathe_projects.cudaqx=${DOXYGEN_OUTPUT_DIR}/xml
           ${SPHINX_SOURCE} ${SPHINX_BUILD}

--- a/docs/Doxyfile.in
+++ b/docs/Doxyfile.in
@@ -21,6 +21,12 @@ EXTRACT_PRIVATE        = YES
 EXTRACT_STATIC         = YES
 
 #---------------------------------------------------------------------------
+# Configuration options related to warning and progress messages
+#---------------------------------------------------------------------------
+
+WARN_AS_ERROR          = FAIL_ON_WARNINGS
+
+#---------------------------------------------------------------------------
 # Configuration options related to the preprocessor
 #---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Description

Update Doxygen and Sphinx options to output warnings as errors to ensure docs stay up to date with each PR.

## Runtime / performance impact
N/A

## Self-review checklist

Please confirm each item before requesting review. Check `[x]` or strike
through and explain.

### Before requesting review
- [x] I reviewed my own full diff in GitHub or my editor.
- [x] PR is in Draft if it is not yet ready for review.
- [x] Temporary / debugging changes have been removed.
- [x] Local test logs reviewed; no unexplained warnings or errors.
- [x] CI logs reviewed; no unexplained warnings or errors.
- [x] Full CI has been run.

### Scope and size
- [x] PR is under ~1000 lines, or an exception is justified in the description.
- [x] Refactoring-only changes are isolated in their own PR(s).
- [x] No existing tests were disabled or modified just to make this PR pass
      (if so, an issue has been raised).

### Tests
- [x] New functionality has new tests.
- [x] Tests fail if the new functionality is broken (including crashes), not
      just when it is missing.
- [x] Negative tests added where exceptions are expected.
- [x] Truth data added where simple `EXPECT_*` / `assert` checks are
      insufficient for algorithmic correctness.
- [x] CI runtime impact considered; team notified if significant.

### Documentation
- [x] Public-facing APIs have Doxygen docs.
- [x] User-visible behavior changes have public docs, or a follow-up is
      tracked.

### Code style
- [x] Naming follows the existing convention (`snake_case` vs `camelCase`) for
      the area being modified.

### Dependencies
- [x] No new third-party dependencies, **or** the team has been notified and
      OSRB tickets filed.
