### PR TITLE
Update to pyproject.toml files to latest cuda-quantum version

### DIFF
--- a/.github/actions/get-cudaq-wheels/action.yaml
+++ b/.github/actions/get-cudaq-wheels/action.yaml
@@ -126,7 +126,7 @@ runs:
         file: ./cudaq/docker/release/cudaq.wheel.Dockerfile
         build-args: |
           base_image=ghcr.io/nvidia/cuda-quantum-devdeps:manylinux-${{ inputs.platform }}-cu${{ inputs.cuda_version }}-gcc12-main
-          release_version=0.14.99
+          release_version=0.15.99
           python_version=3.11
         outputs: /cudaq-wheels
 
@@ -138,7 +138,7 @@ runs:
         file: ./cudaq/docker/release/cudaq.wheel.Dockerfile
         build-args: |
           base_image=ghcr.io/nvidia/cuda-quantum-devdeps:manylinux-${{ inputs.platform }}-cu${{ inputs.cuda_version }}-gcc12-main
-          release_version=0.14.99
+          release_version=0.15.99
           python_version=3.12
         outputs: /cudaq-wheels
 
@@ -150,7 +150,7 @@ runs:
         file: ./cudaq/docker/release/cudaq.wheel.Dockerfile
         build-args: |
           base_image=ghcr.io/nvidia/cuda-quantum-devdeps:manylinux-${{ inputs.platform }}-cu${{ inputs.cuda_version }}-gcc12-main
-          release_version=0.14.99
+          release_version=0.15.99
           python_version=3.13
         outputs: /cudaq-wheels
 

--- a/.github/workflows/build_dev.yaml
+++ b/.github/workflows/build_dev.yaml
@@ -160,7 +160,7 @@ jobs:
         file: cudaq/docker/release/cudaq.wheel.Dockerfile
         build-args: |
           base_image=ghcr.io/nvidia/cuda-quantum-devdeps:manylinux-${{ matrix.platform }}-cu${{ matrix.cuda_version }}-gcc12-main
-          release_version=0.14.99
+          release_version=0.15.99
           python_version=${{ matrix.python }}
           cuda_version=${{ matrix.cuda_version }}
         outputs: type=local,dest=/tmp/wheels

--- a/.github/workflows/build_wheels.yaml
+++ b/.github/workflows/build_wheels.yaml
@@ -13,7 +13,7 @@ on:
         - 'Debug'
       version:
         type: string
-        description: Version number to create wheels with (e.g. 0.2.0). Defaults to 0.14.99 if unspecified
+        description: Version number to create wheels with (e.g. 0.2.0). Defaults to 0.15.99 if unspecified
         required: false
       cudaq_wheels:
         type: choice
@@ -220,7 +220,7 @@ jobs:
               --build-type ${{ inputs.build_type }} \
               --python-version ${{ matrix.python }} \
               --tensorrt-path /trt_download/TensorRT-${{ steps.config.outputs.tensorrt_version }} \
-              --version ${{ inputs.version || '0.14.99' }}
+              --version ${{ inputs.version || '0.15.99' }}
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
@@ -252,7 +252,7 @@ jobs:
       - name: Build CUDA-QX Meta Packages
         shell: bash
         run: |
-          bash scripts/ci/build_metapackages.sh ${{ inputs.version || '0.14.99' }}
+          bash scripts/ci/build_metapackages.sh ${{ inputs.version || '0.15.99' }}
           find libs -name dist | xargs ls -la
           mkdir -p /metapackages
           mv libs/{qec,solvers}/python/metapackages/dist/* /metapackages/
@@ -413,8 +413,8 @@ jobs:
              ${{ matrix.python }} \
              ${{ matrix.platform }} \
              ${{ matrix.cuda_version }} \
-             ${{ inputs.cudaq_wheels == 'Custom' && '0.14.99' || 'SKIP' }} \
-             ${{ inputs.version || '0.14.99' }}
+             ${{ inputs.cudaq_wheels == 'Custom' && '0.15.99' || 'SKIP' }} \
+             ${{ inputs.version || '0.15.99' }}
   
   test-wheels-gpu:
     name: Test CUDA-QX wheels (GPU)
@@ -530,8 +530,8 @@ jobs:
              ${{ matrix.python }} \
              ${{ matrix.runner.arch }} \
              ${{ matrix.cuda_version }} \
-             ${{ inputs.cudaq_wheels == 'Custom' && '0.14.99' || 'SKIP' }} \
-             ${{ inputs.version || '0.14.99' }}
+             ${{ inputs.cudaq_wheels == 'Custom' && '0.15.99' || 'SKIP' }} \
+             ${{ inputs.version || '0.15.99' }}
 
       # - name: Upload any core files
       #   if: success() || failure()

--- a/libs/qec/pyproject.toml.cu12
+++ b/libs/qec/pyproject.toml.cu12
@@ -12,7 +12,7 @@ requires-python = ">=3.11"
 readme = "README.md"
 license = "LicenseRef-NVIDIA-Proprietary"
 dependencies = [
-  'cuda-quantum-cu12 == 0.14.*',
+  'cuda-quantum-cu12 == 0.15.*',
   'cuquantum-python-cu12>=26.03.0',
 ]
 classifiers = [

--- a/libs/qec/pyproject.toml.cu12
+++ b/libs/qec/pyproject.toml.cu12
@@ -12,7 +12,7 @@ requires-python = ">=3.11"
 readme = "README.md"
 license = "LicenseRef-NVIDIA-Proprietary"
 dependencies = [
-  'cuda-quantum-cu12 == 0.15.*',
+  'cuda-quantum-cu12 >= 0.15.1, < 0.16',
   'cuquantum-python-cu12>=26.03.0',
 ]
 classifiers = [

--- a/libs/qec/pyproject.toml.cu13
+++ b/libs/qec/pyproject.toml.cu13
@@ -12,7 +12,7 @@ requires-python = ">=3.11"
 readme = "README.md"
 license = "LicenseRef-NVIDIA-Proprietary"
 dependencies = [
-  'cuda-quantum-cu13 == 0.14.*',
+  'cuda-quantum-cu13 == 0.15.*',
   'cuquantum-python-cu13>=26.03.0',
 ]
 classifiers = [

--- a/libs/qec/pyproject.toml.cu13
+++ b/libs/qec/pyproject.toml.cu13
@@ -12,7 +12,7 @@ requires-python = ">=3.11"
 readme = "README.md"
 license = "LicenseRef-NVIDIA-Proprietary"
 dependencies = [
-  'cuda-quantum-cu13 == 0.15.*',
+  'cuda-quantum-cu13 >= 0.15.1, < 0.16',
   'cuquantum-python-cu13>=26.03.0',
 ]
 classifiers = [

--- a/libs/solvers/pyproject.toml.cu12
+++ b/libs/solvers/pyproject.toml.cu12
@@ -12,7 +12,7 @@ requires-python = ">=3.11"
 readme = "README.md"
 license = "Apache-2.0"
 dependencies = [
-  'cuda-quantum-cu12 == 0.15.*',
+  'cuda-quantum-cu12 >= 0.15.1, < 0.16',
   'fastapi',
   'networkx',
   'pyscf',

--- a/libs/solvers/pyproject.toml.cu12
+++ b/libs/solvers/pyproject.toml.cu12
@@ -12,7 +12,7 @@ requires-python = ">=3.11"
 readme = "README.md"
 license = "Apache-2.0"
 dependencies = [
-  'cuda-quantum-cu12 == 0.14.*',
+  'cuda-quantum-cu12 == 0.15.*',
   'fastapi',
   'networkx',
   'pyscf',

--- a/libs/solvers/pyproject.toml.cu13
+++ b/libs/solvers/pyproject.toml.cu13
@@ -12,7 +12,7 @@ requires-python = ">=3.11"
 readme = "README.md"
 license = "Apache-2.0"
 dependencies = [
-  'cuda-quantum-cu13 == 0.15.*',
+  'cuda-quantum-cu13 >= 0.15.1, < 0.16',
   'fastapi',
   'networkx',
   'pyscf',

--- a/libs/solvers/pyproject.toml.cu13
+++ b/libs/solvers/pyproject.toml.cu13
@@ -12,7 +12,7 @@ requires-python = ">=3.11"
 readme = "README.md"
 license = "Apache-2.0"
 dependencies = [
-  'cuda-quantum-cu13 == 0.14.*',
+  'cuda-quantum-cu13 == 0.15.*',
   'fastapi',
   'networkx',
   'pyscf',


### PR DESCRIPTION
<!--
Thanks for contributing to CUDA-Q Libraries!

Please read the full Pull Request Guidelines in Contributing.md:
https://github.com/NVIDIA/cudaqx/blob/main/Contributing.md#pull-request-guidelines
-->

## Description

Update `pyproject.toml` files to latest cuda-quantum version.

<!-- What does this PR change, and why? Link related issues. -->

## Runtime / performance impact

<!--
If this change affects performance, paste benchmark numbers here.
Otherwise write "N/A".
-->

## Self-review checklist

Please confirm each item before requesting review. Check `[x]` or strike
through and explain.

### Before requesting review
- [ ] I reviewed my own full diff in GitHub or my editor.
- [ ] PR is in Draft if it is not yet ready for review.
- [ ] Temporary / debugging changes have been removed.
- [ ] Local test logs reviewed; no unexplained warnings or errors.
- [ ] CI logs reviewed; no unexplained warnings or errors.
- [ ] Full CI has been run.

### Scope and size
- [ ] PR is under ~1000 lines, or an exception is justified in the description.
- [ ] Refactoring-only changes are isolated in their own PR(s).
- [ ] No existing tests were disabled or modified just to make this PR pass
      (if so, an issue has been raised).

### Tests
- [ ] New functionality has new tests.
- [ ] Tests fail if the new functionality is broken (including crashes), not
      just when it is missing.
- [ ] Negative tests added where exceptions are expected.
- [ ] Truth data added where simple `EXPECT_*` / `assert` checks are
      insufficient for algorithmic correctness.
- [ ] CI runtime impact considered; team notified if significant.

### Documentation
- [ ] Public-facing APIs have Doxygen docs.
- [ ] User-visible behavior changes have public docs, or a follow-up is
      tracked.

### Code style
- [ ] Naming follows the existing convention (`snake_case` vs `camelCase`) for
      the area being modified.

### Dependencies
- [ ] No new third-party dependencies, **or** the team has been notified and
      OSRB tickets filed.
