### PR TITLE
Enable docs deployment

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -22,7 +22,7 @@ on:
   workflow_dispatch:
     inputs:
       deploy_docs:
-        description: 'Deploy docs to GitHub Pages. Deployment only runs on main.'
+        description: 'Deploy docs to GitHub Pages. Deployment only runs on releases/vX.Y.Z branches.'
         type: boolean
         default: true
         required: false
@@ -113,24 +113,21 @@ jobs:
         with:
           path: build/docs/build/
 
-  # Disable for now, re-enable closer to release.
-  # deploy:
-  #   name: Deploy latest docs
-  #   if: |
-  #     github.ref == 'refs/heads/main' &&
-  #     (
-  #       github.event_name == 'push' ||
-  #       inputs.deploy_docs == true
-  #     )
-  #   environment:
-  #     name: github-pages
-  #     url: ${{ steps.deployment.outputs.page_url }}
-  #   runs-on: ubuntu-latest
-  #   permissions:
-  #     pages: write
-  #     id-token: write
-  #   needs: build
-  #   steps:
-  #     - name: Deploy to GitHub Pages
-  #       id: deployment
-  #       uses: actions/deploy-pages@v4
+  deploy:
+    name: Deploy latest docs
+    if: |
+      github.event_name == 'workflow_dispatch' &&
+      inputs.deploy_docs == true &&
+      startsWith(github.ref, 'refs/heads/releases/v')
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -41,10 +41,26 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  setup:
+    name: Setup
+    runs-on: ubuntu-latest
+    outputs:
+      container: ${{ steps.set-container.outputs.container }}
+    steps:
+      - name: Set container image
+        id: set-container
+        run: |
+          if [[ "$GITHUB_REF" =~ ^refs/heads/releases/v(.+)$ ]]; then
+            echo "container=ghcr.io/nvidia/cudaqx-dev:${BASH_REMATCH[1]}-amd64-cu12.6" >> $GITHUB_OUTPUT
+          else
+            echo "container=ghcr.io/nvidia/cudaqx-dev:latest-amd64-cu12.6" >> $GITHUB_OUTPUT
+          fi
+
   build:
     name: Build
+    needs: setup
     runs-on: ${{ startsWith(github.repository, 'NVIDIA/cudaqx') && 'linux-amd64-cpu8' || 'ubuntu-latest' }}
-    container: ghcr.io/nvidia/cuda-quantum-devcontainer:amd64-cu12.6-gcc12-main
+    container: ${{ needs.setup.outputs.container }}
     permissions:
       actions: write
       contents: read

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -24,7 +24,7 @@ on:
       deploy_docs:
         description: 'Deploy docs to GitHub Pages. Deployment only runs on releases/vX.Y.Z branches.'
         type: boolean
-        default: true
+        default: false
         required: false
   push:
     branches:


### PR DESCRIPTION
<!--
Thanks for contributing to CUDA-Q Libraries!

Please read the full Pull Request Guidelines in Contributing.md:
https://github.com/NVIDIA/cudaqx/blob/main/Contributing.md#pull-request-guidelines
-->

## Description

<!-- What does this PR change, and why? Link related issues. -->
Enable docs deployment on release branches. Deployment only happens on manual release branch runs which opt-in to deploy.

## Runtime / performance impact

<!--
If this change affects performance, paste benchmark numbers here.
Otherwise write "N/A".
-->

## Self-review checklist

Please confirm each item before requesting review. Check `[x]` or strike
through and explain.

### Before requesting review
- [x] I reviewed my own full diff in GitHub or my editor.
- [x] PR is in Draft if it is not yet ready for review.
- [x] Temporary / debugging changes have been removed.
- [x] Local test logs reviewed; no unexplained warnings or errors.
- [x] CI logs reviewed; no unexplained warnings or errors.
- [x] Full CI has been run.

### Scope and size
- [x] PR is under ~1000 lines, or an exception is justified in the description.
- [x] Refactoring-only changes are isolated in their own PR(s).
- [x] No existing tests were disabled or modified just to make this PR pass
      (if so, an issue has been raised).

### Tests
- [x] New functionality has new tests.
- [x] Tests fail if the new functionality is broken (including crashes), not
      just when it is missing.
- [x] Negative tests added where exceptions are expected.
- [x] Truth data added where simple `EXPECT_*` / `assert` checks are
      insufficient for algorithmic correctness.
- [x] CI runtime impact considered; team notified if significant.

### Documentation
- [x] Public-facing APIs have Doxygen docs.
- [x] User-visible behavior changes have public docs, or a follow-up is
      tracked.

### Code style
- [x] Naming follows the existing convention (`snake_case` vs `camelCase`) for
      the area being modified.

### Dependencies
- [x] No new third-party dependencies, **or** the team has been notified and
      OSRB tickets filed.
