### PR TITLE
Fix asset download permissions issue for wheel build

### DIFF
--- a/.github/workflows/build_wheels.yaml
+++ b/.github/workflows/build_wheels.yaml
@@ -34,7 +34,7 @@ on:
         required: false
       artifacts_from_run:
         type: string
-        description: Optional argument to take artifacts from a prior run of this workflow; facilitates rerunning a failed workflow without re-building the artifacts.
+        description: GitHub Actions run ID from a prior run of this workflow. Skips wheel builds and reuses that run's CUDA-QX wheels and metapackages, plus its CUDA-Q wheels when using Custom CUDA-Q wheels.
         required: false
       cache_key_suffix:
         type: string
@@ -90,9 +90,31 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  fetch-assets:
+    name: Fetch release assets
+    if: ${{ !inputs.artifacts_from_run && inputs.assets_repo != '' && inputs.assets_tag != '' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Download release assets
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release download -R "${{ inputs.assets_repo }}" "${{ inputs.assets_tag }}"
+
+      - name: Upload release assets
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-assets
+          path: '*.tar.gz'
+          if-no-files-found: error
+          retention-days: 1
+
   build-cudaqx-wheels:
     name: Build CUDA-QX wheels
-    if: ${{ !inputs.artifacts_from_run }}
+    needs: fetch-assets
+    if: ${{ !cancelled() && !inputs.artifacts_from_run && (needs.fetch-assets.result == 'success' || needs.fetch-assets.result == 'skipped') }}
     runs-on: linux-${{ matrix.platform }}-cpu8
     # CUDAQ requires a highly specialized environment to build. Thus, it is much
     # easier to rely on their's devdeps images to do the building.
@@ -170,18 +192,12 @@ jobs:
         with:
           set-safe-directory: true
 
-      # Do this early to help validate user inputs (if present)
-      - name: Fetch assets
-        env:
-          GH_TOKEN: ${{ github.token }}
-        id: fetch-assets
-        run: |
-          bash .github/workflows/scripts/install_git_cli.sh
-          if [[ -n "${{ inputs.assets_repo }}" ]] && [[ -n "${{ inputs.assets_tag }}" ]]; then
-            # Fetch the assets into this directory
-            gh release download -R "${{ inputs.assets_repo }}" "${{ inputs.assets_tag }}"
-            ls
-          fi
+      - name: Download release assets
+        if: ${{ inputs.assets_repo != '' && inputs.assets_tag != '' }}
+        uses: actions/download-artifact@v4
+        with:
+          name: release-assets
+          path: .
 
       - name: Get required CUDAQ version
         id: get-cudaq-version


### PR DESCRIPTION
<!--
Thanks for contributing to CUDA-Q Libraries!

Please read the full Pull Request Guidelines in Contributing.md:
https://github.com/NVIDIA/cudaqx/blob/main/Contributing.md#pull-request-guidelines
-->

## Description

<!-- What does this PR change, and why? Link related issues. -->
The wheel build currently has `contents: read` permissions. This is inadequate to download draft release artifacts. This adds a new job with elevated `contents: write` permissions to download the release artifacts and make them available to the rest of the build.

Test run that downloads assets: https://github.com/NVIDIA/cudaqx/actions/runs/29961842722

## Runtime / performance impact

<!--
If this change affects performance, paste benchmark numbers here.
Otherwise write "N/A".
-->

N/A

## Self-review checklist

Please confirm each item before requesting review. Check `[x]` or strike
through and explain.

### Before requesting review
- [x] I reviewed my own full diff in GitHub or my editor.
- [x] PR is in Draft if it is not yet ready for review.
- [x] Temporary / debugging changes have been removed.
- [x] Local test logs reviewed; no unexplained warnings or errors.
- [ ] CI logs reviewed; no unexplained warnings or errors.
- [ ] Full CI has been run.

### Scope and size
- [x] PR is under ~1000 lines, or an exception is justified in the description.
- [x] Refactoring-only changes are isolated in their own PR(s).
- [x] No existing tests were disabled or modified just to make this PR pass
      (if so, an issue has been raised).

### Tests
- [x] New functionality has new tests.
- [x] Tests fail if the new functionality is broken (including crashes), not
      just when it is missing.
- [x] Negative tests added where exceptions are expected.
- [x] Truth data added where simple `EXPECT_*` / `assert` checks are
      insufficient for algorithmic correctness.
- [x] CI runtime impact considered; team notified if significant.

### Documentation
- [x] Public-facing APIs have Doxygen docs.
- [x] User-visible behavior changes have public docs, or a follow-up is
      tracked.

### Code style
- [x] Naming follows the existing convention (`snake_case` vs `camelCase`) for
      the area being modified.

### Dependencies
- [x] No new third-party dependencies, **or** the team has been notified and
      OSRB tickets filed.
