### PR TITLE
Decoding Server: Add virtual hooks for decoder plugins to set_D/O_sparse

### DIFF
--- a/libs/qec/include/cudaq/qec/decoder.h
+++ b/libs/qec/include/cudaq/qec/decoder.h
@@ -349,6 +349,18 @@ protected:
   /// before the first enqueue_syndrome().
   void set_result_type(decode_result_type type) { result_type_ = type; }
 
+  /// @brief Hook called by both set_D_sparse overloads after base-class buffer
+  /// setup is complete. Override to react to a new D_sparse without having to
+  /// call the base-class implementation explicitly. The protected D_sparse
+  /// member holds the newly set matrix when this is called.
+  virtual void on_d_sparse_configured() {}
+
+  /// @brief Hook called by both set_O_sparse overloads after base-class buffer
+  /// setup is complete. Override to react to a new O_sparse without having to
+  /// call the base-class implementation explicitly. The protected O_sparse
+  /// member holds the newly set matrix when this is called.
+  virtual void on_o_sparse_configured() {}
+
   /// @brief For a classical `[n,k]` code, this is `n`.
   std::size_t block_size = 0;
 

--- a/libs/qec/lib/decoder.cpp
+++ b/libs/qec/lib/decoder.cpp
@@ -290,6 +290,7 @@ void decoder::set_O_sparse(const std::vector<std::vector<uint32_t>> &O_sparse) {
   validate_sparse_column_indices(this->O_sparse, block_size, "O_sparse");
   this->pimpl->corrections.clear();
   this->pimpl->corrections.resize(O_sparse.size());
+  on_o_sparse_configured();
 }
 
 void decoder::set_O_sparse(const std::vector<int64_t> &O_sparse_vec_in) {
@@ -297,6 +298,7 @@ void decoder::set_O_sparse(const std::vector<int64_t> &O_sparse_vec_in) {
   validate_sparse_column_indices(this->O_sparse, block_size, "O_sparse");
   this->pimpl->corrections.clear();
   this->pimpl->corrections.resize(O_sparse.size());
+  on_o_sparse_configured();
 }
 
 uint32_t decoder::get_num_msyn_per_decode() const {
@@ -352,11 +354,13 @@ void set_D_sparse_common(decoder *decoder,
 void decoder::set_D_sparse(const std::vector<std::vector<uint32_t>> &D_sparse) {
   this->D_sparse = D_sparse;
   set_D_sparse_common(this, D_sparse, pimpl.get());
+  on_d_sparse_configured();
 }
 
 void decoder::set_D_sparse(const std::vector<int64_t> &D_sparse_vec_in) {
   set_sparse_from_vec(D_sparse_vec_in, this->D_sparse);
   set_D_sparse_common(this, this->D_sparse, pimpl.get());
+  on_d_sparse_configured();
 }
 
 bool decoder::enqueue_syndrome(const uint8_t *syndrome,


### PR DESCRIPTION
## Description

Add two protected virtual hooks to the base cudaq::qec::decoder — on_d_sparse_configured() and on_o_sparse_configured() — called at the end of both set_D_sparse(...) and set_O_sparse(...) overloads. Both default to no-ops, so existing decoders are unaffected.  This gives subclasses a safe extension point to react to geometry (re)configuration without overriding the setters and manually re-invoking the base implementation.

## Runtime / performance impact
N/A

## Self-review checklist

Please confirm each item before requesting review. Check `[x]` or strike
through and explain.

### Before requesting review
- [x] I reviewed my own full diff in GitHub or my editor.
- [x] PR is in Draft if it is not yet ready for review.
- [x] Temporary / debugging changes have been removed.
- [x] Local test logs reviewed; no unexplained warnings or errors.
- [x] CI logs reviewed; no unexplained warnings or errors.
- [x] Full CI has been run.

### Scope and size
- [x] PR is under ~1000 lines, or an exception is justified in the description.
- [x] Refactoring-only changes are isolated in their own PR(s).
- [x] No existing tests were disabled or modified just to make this PR pass
      (if so, an issue has been raised).

### Tests
- [x] New functionality has new tests.
- [x] Tests fail if the new functionality is broken (including crashes), not
      just when it is missing.
- [x] Negative tests added where exceptions are expected.
- [x] Truth data added where simple `EXPECT_*` / `assert` checks are
      insufficient for algorithmic correctness.
- [x] CI runtime impact considered; team notified if significant.

### Documentation
- [x] Public-facing APIs have Doxygen docs.
- [x] User-visible behavior changes have public docs, or a follow-up is
      tracked.

### Code style
- [x] Naming follows the existing convention (`snake_case` vs `camelCase`) for
      the area being modified.

### Dependencies
- [x] No new third-party dependencies, **or** the team has been notified and
      OSRB tickets filed.
