### PR TITLE
fix(qec): correct realtime decoding example commands

### DIFF
--- a/docs/sphinx/examples_rst/qec/realtime_decoding.rst
+++ b/docs/sphinx/examples_rst/qec/realtime_decoding.rst
@@ -427,11 +427,13 @@ Use the Quantinuum backend for hardware or emulation:
 
       # Compile for Quantinuum
       nvq++ --target quantinuum --quantinuum-machine Helios-1 \
+            --quantinuum-extra-payload-provider decoder      \
             my_circuit.cpp -lcudaq-qec \
             -lcudaq-qec-decoders \
             -lcudaq-qec-realtime-decoding \
-            -lcudaq-qec-realtime-decoding-quantinuum
-      
+            -lcudaq-qec-realtime-decoding-quantinuum \
+            -Wl,--export-dynamic
+
       ./a.out
 
 Compilation and Execution Examples
@@ -547,31 +549,32 @@ Python Execution
 .. code-block:: bash
 
    # Generate a decoder configuration file
-   python3 surface_code-1.py --distance 3 --save_dem config.yaml
+   python3 surface_code_1.py --distance 3 --save_dem config.yaml
    # Run the circuit with the decoder configuration
-   python3 surface_code-1.py --distance 3 --load_dem config.yaml --num_shots 1000
+   python3 surface_code_1.py --distance 3 --load_dem config.yaml --num_shots 1000
 
 
 **Quantinuum Backend (Hardware)**
 
 .. code-block:: bash
 
-   python3 surface_code-1.py --distance 3 --load_dem config.yaml --num_shots 1000 --target quantinuum --machine-name Helios-1
+   python3 surface_code_1.py --distance 3 --load_dem config.yaml --num_shots 1000 --target quantinuum --machine_name Helios-1 --project_id <project-id>
 
 **Key Points:**
 
 - Use real machine names (check Quantinuum portal for available machines)
+- ``--project_id``: Specify the Quantinuum project ID used for the hardware submission.
 - Reduce shot count for hardware experiments (hardware time is expensive)
 
 **Emulated Quantinuum Compilation Workflow**
 
 .. code-block:: bash
 
-   python3 surface_code-1.py --distance 3 --load_dem config.yaml --num_shots 1000 --target quantinuum --emulate
+   python3 surface_code_1.py --distance 3 --load_dem config.yaml --num_shots 1000 --target quantinuum --emulate
 
 **Key Points:**
 
-- ``emulate=True``: Emulate Quantinuum compilation path
+- ``--emulate``: Emulate the Quantinuum execution path
 - Decoder config is automatically uploaded to Quantinuum's servers when
   ``cudaq_qec.configure_decoders_from_file`` (Python) or
   :cpp:func:`cudaq::qec::decoding::config::configure_decoders_from_file` (C++) is called
@@ -591,7 +594,7 @@ Given that the user follows the structure of the examples provided, where each e
                     --save_dem config_d3.yaml --num_rounds 12
 
    ## Python
-   python surface_code-1.py --distance 3 --num_shots 1000 --p_cnot 0.001 \
+   python3 surface_code_1.py --distance 3 --num_shots 1000 --p_cnot 0.001 \
                             --save_dem config_d3.yaml --num_rounds 12
 
    # Phase 2: Run with Real-Time Decoding
@@ -645,8 +648,8 @@ They are valid both for python and C++ applications, however, they must be set b
 
 1. **Missing libraries**: Ensure all ``-lcudaq-qec-*`` libraries are linked
 2. **Wrong backend library**: Use ``-simulation`` for Stim, ``-quantinuum`` for Quantinuum
-3. **Missing** ``--export-dynamic`` **flag**: Required for Quantinuum targets
-4. **Wrong target flags**: ``--emulate`` with ``Helios-Fake`` for emulation, remove for hardware
+3. **Missing** ``-Wl,--export-dynamic`` **flag**: Required for Quantinuum targets
+4. **Wrong target flags**: Use ``--emulate`` for emulation. Omit it and provide ``--project_id`` for hardware
 
 **Common Runtime Issues:**
 

--- a/libs/qec/unittests/realtime/app_examples/surface_code-1-test.py
+++ b/libs/qec/unittests/realtime/app_examples/surface_code-1-test.py
@@ -56,6 +56,7 @@ CASES = [
             "num_shots": 100,
             "decoder_type": "multi_error_lut",
             "target": "quantinuum",
+            "emulate": True,
             "machine_name": "Helios-1Dummy",
             "number_of_non_zero_values_threshold": 0,
             "number_of_corrections_decoder_threshold": 0
@@ -69,6 +70,7 @@ CASES = [
             "num_shots": 100,
             "decoder_type": "multi_error_lut",
             "target": "quantinuum",
+            "emulate": True,
             "machine_name": "Helios-1Dummy",
             "number_of_non_zero_values_threshold": 0,
             "number_of_corrections_decoder_threshold": 0
@@ -126,6 +128,8 @@ def test_run_from_dem(case, dem_file):
     ]
     if "target" in case:
         argv += ["--target", case["target"]]
+    if case.get("emulate", False):
+        argv += ["--emulate"]
     if "machine_name" in case:
         argv += ["--machine_name", case["machine_name"]]
 
@@ -168,8 +172,6 @@ def test_quantinuum_requires_machine_name(case, dem_file):
             str(dem_file),
             "--target",
             "quantinuum",
-            "--emulate",
-            "false",
             # no --machine_name → should fail
         ])
 
@@ -187,8 +189,6 @@ def test_quantinuum_requires_project_id_remote(case, dem_file):
             str(dem_file),
             "--target",
             "quantinuum",
-            "--emulate",
-            "false",
             "--machine_name",
             "Helios-1SC",
             # no --project_id → should fail

--- a/libs/qec/unittests/realtime/app_examples/surface_code_1.py
+++ b/libs/qec/unittests/realtime/app_examples/surface_code_1.py
@@ -482,8 +482,7 @@ def run(argv: List[str]) -> Optional[dict]:
                         default="",
                         help="Machine name for Quantinuum target")
     parser.add_argument("--emulate",
-                        type=lambda s: s.lower() != "false",
-                        default=True,
+                        action="store_true",
                         help="Use emulation when running on Quantinuum target")
     parser.add_argument("--project_id",
                         type=str,


### PR DESCRIPTION
## Description

Corrects the mainline realtime decoding documentation and Python example commands.

- Uses the correct `surface_code_1.py` filename.
- Makes `--emulate` a standard opt-in flag instead of defaulting to emulation.
- Updates the Quantinuum hardware and emulation arguments.
- Adds the required Quantinuum payload provider and `-Wl,--export-dynamic` linker options.
- Updates the tests to distinguish hardware submission from emulation.


## Runtime / performance impact

N/A. 

## Self-review checklist

### Before requesting review

- [x] I reviewed my own full diff in GitHub or my editor.
- [ ] PR is in Draft until CI completes.
- [x] Temporary / debugging changes have been removed.
- [x] Local test logs reviewed; no unexplained warnings or errors.
- [x] CI logs reviewed; no unexplained warnings or errors.
- [x] Full CI has been run.

### Scope and size

- [x] PR is under ~1000 lines.
- [x] Refactoring-only changes are isolated in their own PR(s).
- [x] No existing tests were disabled or modified just to make this PR pass.

### Tests

- [x] The corrected CLI behavior is covered by tests.
- [x] Tests fail when the `--emulate` behavior is broken.
- [x] Negative tests cover missing Quantinuum machine and project IDs.
- [x] Algorithmic truth-data changes are not applicable.
- [x] No significant CI runtime impact is expected.

### Documentation

- [x] Doxygen changes are not applicable.
- [x] User-visible command-line behavior is documented.

### Code style

- [x] Naming follows the existing convention for this area.

### Dependencies

- [x] No new third-party dependencies.