### PR TITLE
QEC decoding server: cut HOST_CALL latency ~10x (direct dispatch + bounded spin-then-block)

### DIFF
--- a/libs/qec/lib/realtime/decoding-server-cqr/CqrTransceiver.h
+++ b/libs/qec/lib/realtime/decoding-server-cqr/CqrTransceiver.h
@@ -8,11 +8,14 @@
 
 #pragma once
 
+#include "HopStats.h"
 #include "ITransceiver.h"
+#include "SpinPolicy.h"
 #include "cudaq/qec/realtime/decoder_rpc_wire_format.h"
 #include "cudaq/realtime/daemon/dispatcher/cudaq_realtime.h"
 #include "cudaq/realtime/daemon/dispatcher/dispatch_kernel_launch.h"
 
+#include <atomic>
 #include <condition_variable>
 #include <cstring>
 #include <deque>
@@ -122,17 +125,29 @@ inline bool parse_cqr_enqueue_frame(const void *rx_slot, std::size_t slot_size,
 class CqrTransceiver final : public ITransceiver {
 public:
   /// Called from CUDAQ handler threads for each incoming RPC.
-  /// Translates the CUDAQ-format payload to our wire format, enqueues an
-  /// RxFrame, then blocks until DecodingServer sends the response.
+  /// Translates the CUDAQ-format payload to our wire format, hands the frame
+  /// to the dispatch sink (direct mode) or enqueues it for recv(), then for
+  /// response-bearing calls blocks until DecodingServer sends the response.
   void inject(const void *rx_slot, void *tx_slot, std::size_t slot_size,
               uint32_t function_id);
+
+  /// Direct-dispatch mode: inject() invokes \p sink inline on its calling
+  /// CUDAQ dispatcher thread instead of queueing frames for the recv() loop,
+  /// removing one cross-thread handoff per RPC.  Installed by DecodingServer
+  /// during construction, before the transceiver is published to handler
+  /// threads (write-once, unsynchronized).
+  bool install_dispatch_sink(DispatchSink sink) override {
+    sink_ = std::move(sink);
+    return true;
+  }
 
   RxFrame recv() override;
   void send(const PeerId &peer, const uint8_t *data, std::size_t len) override;
   void shutdown() override;
 
 private:
-  bool stopped_ = false;
+  DispatchSink sink_;
+  std::atomic<bool> stopped_{false};
 
   // Write an immediate RPCResponse (no result payload) into the CUDAQ
   // tx_slot: OK acks fire-and-forget calls; error statuses complete blocking
@@ -144,6 +159,12 @@ private:
   struct PendingTx {
     void *tx_slot;
     std::size_t slot_size;
+    /// Completion flag on the blocked inject() caller's stack; every
+    /// completer stores 1 (release) immediately before set_value so a
+    /// spinning waiter (SpinPolicy.h) skips the futex wake.  Never dangles:
+    /// each pending entry is completed exactly once, and the waiter's frame
+    /// cannot unwind before set_value releases fut.wait().
+    std::atomic<uint32_t> *done_flag = nullptr;
     std::promise<void> done;
   };
 
@@ -171,6 +192,10 @@ private:
 inline void CqrTransceiver::inject(const void *rx_slot, void *tx_slot,
                                    std::size_t slot_size,
                                    uint32_t function_id) {
+  // inject() runs ON the CUDAQ transport dispatcher thread, so entry/exit
+  // here bracket the HOST_CALL handler as the dispatcher sees it.
+  hopstats::on_dispatcher_thread();
+  const uint64_t hs_entry = hopstats::entry_stamp();
   if (!rx_slot || !tx_slot || slot_size < sizeof(RPCHeader))
     return;
 
@@ -197,52 +222,118 @@ inline void CqrTransceiver::inject(const void *rx_slot, void *tx_slot,
   const auto *hdr = reinterpret_cast<const RPCHeader *>(frame.buf.data());
   const uint32_t rid = hdr->request_id;
   const uint64_t ptp = hdr->ptp_timestamp; // save before frame is moved
+  hopstats::begin_request(rid, function_id, hs_entry);
 
   if (function_id == kEnqueueSyndromesFunctionId) {
-    // Fire-and-forget: hand the frame to the server and ACK immediately
-    // (status OK = ACCEPTED) -- the dispatcher thread must not park on
-    // decoder execution, and per the spec the dispatcher still emits an
-    // RPCResponse into the tx_slot (the transport needs it to complete the
-    // slot; the caller drops it). A deferred decoder error is reported at
-    // this decoder's next get_corrections.
+    // Fire-and-forget: ACK immediately (status OK = ACCEPTED) -- the
+    // dispatcher thread must not park on decoder execution, and per the spec
+    // the dispatcher still emits an RPCResponse into the tx_slot (the
+    // transport needs it to complete the slot; the caller drops it). A
+    // deferred decoder error is reported at this decoder's next
+    // get_corrections.
+    if (sink_) {
+      // Direct dispatch: run the routing handler (session lookup +
+      // try_enqueue) inline on this thread -- no inbox, no recv-thread
+      // handoff.  ACK first so the client-visible ACK never waits on the
+      // handler; after shutdown the frame is dropped, matching the
+      // recv-loop-exited behavior of the queued path.
+      write_ack(tx_slot, rid, ptp);
+      if (stopped_.load(std::memory_order_acquire))
+        return;
+      // Both hop-1 probe endpoints stamp here: the handoff no longer exists.
+      hopstats::stamp_inbox_push(rid);
+      hopstats::stamp_recv_wake(frame.buf.data(), frame.buf.size(),
+                                /*was_empty=*/false);
+      try {
+        sink_(std::move(frame));
+      } catch (...) {
+        // tx_slot is already complete and enqueue errors surface at the next
+        // get_corrections by contract; nothing more to do (the dispatcher
+        // contains handler exceptions -- this guards the sink glue itself).
+      }
+      return;
+    }
     {
       std::lock_guard<std::mutex> lk(mtx_);
       inbox_.push_back(std::move(frame));
+      // Stamped under mtx_ so the recv thread's read is ordered by the lock.
+      hopstats::stamp_inbox_push(rid);
     }
     cv_.notify_one();
+    hopstats::stamp_notify1_ret(rid);
     write_ack(tx_slot, rid, ptp);
     return;
   }
 
   std::future<void> fut;
+  std::atomic<uint32_t> done_flag{0};
   {
     std::lock_guard<std::mutex> lk(mtx_);
-    // Reject new blocking RPCs after shutdown: the recv loop is exiting and
-    // will never dispatch this frame, so parking on the promise would hang
-    // the CUDAQ dispatcher thread forever.  Complete the slot immediately.
-    if (stopped_) {
+    // Reject new blocking RPCs after shutdown: nothing will ever dispatch
+    // this frame, so parking on the promise would hang the CUDAQ dispatcher
+    // thread forever.  Complete the slot immediately.
+    if (stopped_.load(std::memory_order_relaxed)) {
       write_ack(tx_slot, rid, ptp, RpcStatus::BAD_REQUEST);
       return;
     }
+    // pending_[rid] must exist BEFORE the frame is dispatched (either path):
+    // a synchronous handler error resolves the tx_slot through send(), which
+    // looks the entry up by request_id.
     auto &p = pending_[rid];
     p.tx_slot = tx_slot;
     p.slot_size = slot_size;
+    p.done_flag = &done_flag;
     fut = p.done.get_future();
-    inbox_.push_back(std::move(frame));
+    if (!sink_)
+      inbox_.push_back(std::move(frame));
+    hopstats::stamp_inbox_push(rid);
   }
-  cv_.notify_one();
+  if (sink_) {
+    // Direct dispatch on this thread.  mtx_ is NOT held here: the handler's
+    // error path re-enters send(), which takes mtx_.
+    hopstats::stamp_recv_wake(frame.buf.data(), frame.buf.size(),
+                              /*was_empty=*/false);
+    try {
+      sink_(std::move(frame));
+    } catch (...) {
+      // Self-complete on the sink-glue exception path: a live pending entry
+      // left behind would be completed by a later shutdown() drain against a
+      // tx_slot the transport has long since abandoned.
+      std::lock_guard<std::mutex> lk(mtx_);
+      if (pending_.erase(rid))
+        write_ack(tx_slot, rid, ptp, RpcStatus::INTERNAL_ERROR);
+      hopstats::invalidate(rid);
+      return;
+    }
+  } else {
+    cv_.notify_one();
+    hopstats::stamp_notify1_ret(rid);
+  }
 
   // Block until the DecodingSession worker calls send() with the response.
+  // Bounded spin on the stack completion flag first (SpinPolicy.h); the
+  // promise is still armed by every completer, so fut.wait() is the blocking
+  // fallback and returns immediately on a spin hit.
+  hopstats::stamp_wait_begin(rid);
+  spin_until([&] { return done_flag.load(std::memory_order_acquire) != 0; });
   fut.wait();
+  hopstats::finish_blocking(rid);
 }
 
 inline RxFrame CqrTransceiver::recv() {
   std::unique_lock<std::mutex> lk(mtx_);
-  cv_.wait(lk, [this] { return !inbox_.empty() || stopped_; });
+  // cold = inbox empty on arrival: a successful pop below means this thread
+  // really waited (or spun) for the producer's wakeup.
+  const bool hs_was_empty =
+      inbox_.empty() && !stopped_.load(std::memory_order_relaxed);
+  cv_.wait(lk, [this] {
+    return !inbox_.empty() || stopped_.load(std::memory_order_relaxed);
+  });
   if (inbox_.empty())
     return {}; // shutdown sentinel (empty buf)
   RxFrame frame = std::move(inbox_.front());
   inbox_.pop_front();
+  hopstats::stamp_recv_wake(frame.buf.data(), frame.buf.size(), hs_was_empty);
   return frame;
 }
 
@@ -256,13 +347,16 @@ inline void CqrTransceiver::shutdown() {
   std::unordered_map<uint32_t, PendingTx> drained;
   {
     std::lock_guard<std::mutex> lk(mtx_);
-    stopped_ = true;
+    stopped_.store(true, std::memory_order_release);
     drained = std::move(pending_);
     pending_.clear();
   }
   cv_.notify_all();
   for (auto &[rid, p] : drained) {
     write_ack(p.tx_slot, rid, /*ptp_timestamp=*/0, RpcStatus::BAD_REQUEST);
+    hopstats::invalidate(rid); // shutdown completions are not latency samples
+    if (p.done_flag)
+      p.done_flag->store(1, std::memory_order_release);
     p.done.set_value();
   }
 }
@@ -301,6 +395,9 @@ inline void CqrTransceiver::send(const PeerId & /*peer*/, const uint8_t *data,
     // bits.  Fail the RPC explicitly instead (the pre-decoding-server code
     // returned result-buffer-too-small here).
     write_ack(p.tx_slot, rid, resp->ptp_timestamp, RpcStatus::INTERNAL_ERROR);
+    hopstats::stamp_send_done(rid);
+    if (p.done_flag)
+      p.done_flag->store(1, std::memory_order_release);
     p.done.set_value();
     pending_.erase(it);
     return;
@@ -313,6 +410,9 @@ inline void CqrTransceiver::send(const PeerId & /*peer*/, const uint8_t *data,
   __atomic_store_n(reinterpret_cast<uint32_t *>(p.tx_slot),
                    cudaq::realtime::RPC_MAGIC_RESPONSE, __ATOMIC_RELEASE);
 
+  hopstats::stamp_send_done(rid);
+  if (p.done_flag)
+    p.done_flag->store(1, std::memory_order_release);
   p.done.set_value();
   pending_.erase(it);
 }

--- a/libs/qec/lib/realtime/decoding-server-cqr/DecodingServer.cpp
+++ b/libs/qec/lib/realtime/decoding-server-cqr/DecodingServer.cpp
@@ -7,6 +7,7 @@
  ******************************************************************************/
 
 #include "DecodingServer.h"
+#include "HopStats.h"
 #include "../../hardware_guards.h"
 
 #include "cudaq/qec/logger.h"
@@ -141,6 +142,7 @@ DecodingServer::DecodingServer(const std::string &config_yaml) {
       throw std::runtime_error(
           "device_graph transceiver did not provide a device scheduler");
   }
+  install_direct_dispatch();
 }
 
 DecodingServer::DecodingServer(std::unique_ptr<ITransceiver> transport,
@@ -156,6 +158,7 @@ DecodingServer::DecodingServer(std::unique_ptr<ITransceiver> transport,
     registry_.stop_workers();
     throw;
   }
+  install_direct_dispatch();
 }
 
 DecodingServer::DecodingServer(
@@ -175,6 +178,7 @@ DecodingServer::DecodingServer(
     throw;
   }
   register_handlers();
+  install_direct_dispatch();
 }
 
 DecodingServer::DecodingServer(std::vector<std::unique_ptr<ITransceiver>> owned,
@@ -188,6 +192,7 @@ DecodingServer::DecodingServer(std::vector<std::unique_ptr<ITransceiver>> owned,
     registry_.stop_workers();
     throw;
   }
+  install_direct_dispatch();
 }
 
 void *DecodingServer::graph_resources_for(uint64_t decoder_id) const {
@@ -214,6 +219,19 @@ DecodingServer::~DecodingServer() {
 void DecodingServer::init(const std::string &config_yaml) {
   registry_.load_from_config(config_yaml);
   register_handlers();
+}
+
+void DecodingServer::install_direct_dispatch() {
+  for (auto &[fid, t] : function_transport_) {
+    if (std::find(direct_dispatch_transports_.begin(),
+                  direct_dispatch_transports_.end(),
+                  t) != direct_dispatch_transports_.end())
+      continue;
+    if (t->install_dispatch_sink([this, transport = t](RxFrame &&frame) {
+          dispatcher_.dispatch(std::move(frame), *transport);
+        }))
+      direct_dispatch_transports_.push_back(t);
+  }
 }
 
 void DecodingServer::register_handlers() {
@@ -313,9 +331,22 @@ void DecodingServer::register_handlers() {
 void DecodingServer::run() {
   std::vector<ITransceiver *> unique_transports;
   for (auto &[fid, t] : function_transport_) {
+    // Direct-dispatch transports deliver frames from their own producer
+    // threads via the installed sink; a receiver thread here would park in
+    // recv() forever.
+    if (std::find(direct_dispatch_transports_.begin(),
+                  direct_dispatch_transports_.end(),
+                  t) != direct_dispatch_transports_.end())
+      continue;
     if (std::find(unique_transports.begin(), unique_transports.end(), t) ==
         unique_transports.end())
       unique_transports.push_back(t);
+  }
+
+  if (unique_transports.empty()) {
+    CUDA_QEC_INFO(
+        "DecodingServer: all transports direct-dispatch; no receiver threads");
+    return;
   }
 
   CUDA_QEC_INFO("DecodingServer: starting {} receiver thread(s)",
@@ -326,6 +357,7 @@ void DecodingServer::run() {
   recv_threads.reserve(unique_transports.size());
   for (ITransceiver *t : unique_transports) {
     recv_threads.emplace_back([this, t] {
+      hopstats::on_recv_thread();
       while (!shutdown_.load(std::memory_order_acquire)) {
         RxFrame frame = t->recv();
         if (frame.buf.empty())

--- a/libs/qec/lib/realtime/decoding-server-cqr/DecodingServer.h
+++ b/libs/qec/lib/realtime/decoding-server-cqr/DecodingServer.h
@@ -88,6 +88,16 @@ private:
   void init(const std::string &config_yaml);
   void register_handlers();
 
+  /// Offer each transport in function_transport_ a sink that routes frames
+  /// inline into dispatcher_ on the transport's own producer thread
+  /// (RpcDispatcher::dispatch and the registered handlers are safe for
+  /// concurrent callers: the dispatch table and session registry are
+  /// read-only once construction completes).  Transports that accept are
+  /// recorded in direct_dispatch_transports_ and excluded from run()'s
+  /// receiver threads.  Called at the end of every constructor, after
+  /// register_handlers() and after function_transport_ is populated.
+  void install_direct_dispatch();
+
   /// Create a transceiver for \p transport_type.  Throws for RoCE transports
   /// until per-session transceiver adapters are
   /// available via CUDAQ_REALTIME.
@@ -108,6 +118,9 @@ private:
   /// Routing within the server is by function_id, not by decoder_id.
   TransportMap function_transport_;
   std::vector<std::unique_ptr<ITransceiver>> owned_transports_;
+  /// Transports that accepted a direct-dispatch sink (non-owning pointers
+  /// into owned_transports_); run() starts no receiver thread for these.
+  std::vector<ITransceiver *> direct_dispatch_transports_;
 };
 
 } // namespace cudaq::qec::decoding_server

--- a/libs/qec/lib/realtime/decoding-server-cqr/DecodingSession.cpp
+++ b/libs/qec/lib/realtime/decoding-server-cqr/DecodingSession.cpp
@@ -7,6 +7,8 @@
  ******************************************************************************/
 
 #include "DecodingSession.h"
+#include "HopStats.h"
+#include "SpinPolicy.h"
 #include "../../hardware_guards.h"
 #include "cudaq/qec/logger.h"
 #include "cudaq/qec/realtime/decoder_rpc_wire_format.h"
@@ -113,6 +115,7 @@ void DecodingSession::start_worker() {
       pinned.set_exception(std::current_exception());
       return; // never serve work from a mispinned thread
     }
+    hopstats::on_worker_thread();
     worker_loop();
   });
   try {
@@ -125,13 +128,24 @@ void DecodingSession::start_worker() {
 }
 
 bool DecodingSession::try_enqueue(WorkItem item) {
-  std::lock_guard<std::mutex> lk(queue_mutex);
-  if (work_queue.size() >= queue_depth) {
-    ++busy_count;
-    return false;
+  const uint32_t hs_rid = item.request_id;
+  {
+    std::lock_guard<std::mutex> lk(queue_mutex);
+    if (work_queue.size() >= queue_depth) {
+      ++busy_count;
+      return false;
+    }
+    work_queue.push(std::move(item));
+    // Bumped under the lock: no missed-update window for the worker's spin,
+    // regardless of producer count.
+    queue_seq.fetch_add(1, std::memory_order_release);
+    hopstats::stamp_queue_push(hs_rid);
   }
-  work_queue.push(std::move(item));
+  // Notify after the unlock: a waiter woken while the producer still holds
+  // queue_mutex would immediately re-block on the lock (an extra futex
+  // round trip on every wakeup).
   queue_cv.notify_one();
+  hopstats::stamp_notify2_ret(hs_rid);
   return true;
 }
 
@@ -364,6 +378,23 @@ void DecodingSession::worker_loop() {
     WorkItem item;
     {
       std::unique_lock<std::mutex> lk(queue_mutex);
+      // cold = queue empty on arrival: a successful pop below means this
+      // thread really waited (or spun) for try_enqueue's wakeup.
+      const bool hs_was_empty = work_queue.empty();
+      if (work_queue.empty() && !shutdown.load(std::memory_order_acquire)) {
+        // Bounded spin on the queue sequence before the condvar sleep
+        // (SpinPolicy.h): the snapshot is taken under the lock while the
+        // queue is empty, so it can only change when try_enqueue pushes;
+        // shutdown is observed directly.  Budget expiry falls through to
+        // the untimed wait below, whose predicate re-checks under the lock.
+        const uint64_t seen = queue_seq.load(std::memory_order_relaxed);
+        lk.unlock();
+        spin_until([&] {
+          return queue_seq.load(std::memory_order_acquire) != seen ||
+                 shutdown.load(std::memory_order_acquire);
+        });
+        lk.lock();
+      }
       // Untimed wait: stop_worker() stores the shutdown flag under
       // queue_mutex before notifying, so the wakeup cannot be lost and no
       // 100 ms poll is needed.
@@ -376,6 +407,7 @@ void DecodingSession::worker_loop() {
 
       item = std::move(work_queue.front());
       work_queue.pop();
+      hopstats::stamp_worker_wake(item.request_id, hs_was_empty);
     }
 
     const uint64_t busy =
@@ -407,6 +439,11 @@ void DecodingSession::worker_loop() {
       ++error_count;
       shot_state = ShotState::failed;
     }
+
+    // Fire-and-forget enqueues have no blocking waiter to close their
+    // sample; the worker closes it (blocking kinds close in inject()).
+    if (item.function_id == kEnqueueSyndromesFunctionId)
+      hopstats::finish_enqueue(item.request_id);
 
     g_busy_sessions.fetch_sub(1, std::memory_order_relaxed);
   }

--- a/libs/qec/lib/realtime/decoding-server-cqr/DecodingSession.h
+++ b/libs/qec/lib/realtime/decoding-server-cqr/DecodingSession.h
@@ -75,6 +75,10 @@ struct DecodingSession {
   std::condition_variable queue_cv;
   std::atomic<bool> shutdown{false};
   size_t queue_depth{kDefaultQueueDepth};
+  /// Bumped under queue_mutex after every push; the worker's bounded spin
+  /// watches it (a snapshot taken under the lock while the queue is empty
+  /// can only change when new work arrives).  See SpinPolicy.h.
+  std::atomic<uint64_t> queue_seq{0};
 
   // Latched when enqueue_syndromes is dropped (queue full). The shot remains
   // poisoned until reset_decoder clears all mutable state.

--- a/libs/qec/lib/realtime/decoding-server-cqr/HopStats.h
+++ b/libs/qec/lib/realtime/decoding-server-cqr/HopStats.h
@@ -1,0 +1,531 @@
+/****************************************************************-*- C++ -*-****
+ * Copyright (c) 2026 NVIDIA Corporation & Affiliates.                         *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+#pragma once
+
+/// Env-gated latency probes for the decoding-server HOST_CALL path.
+///
+/// A served RPC crosses three thread boundaries, each a condvar/promise
+/// futex wakeup; these probes measure every hop of every request:
+///
+///   hop1 (dispatcher->recv):    inject() inbox push -> recv() wake
+///   hop2 (recv->worker):        try_enqueue -> worker_loop wake
+///   hop3 (worker->dispatcher):  send() done -> inject() fut.wait wake
+///
+/// plus the stage durations between hops and the producer-side notify cost.
+/// handler_total (inject entry -> exit) brackets the whole HOST_CALL handler
+/// as the CUDAQ dispatcher sees it.
+///
+/// Off by default; when disabled every probe is a single predicted branch.
+/// Gates (each read once, on first use):
+///   QEC_DECODING_SERVER_HOP_STATS      unset/"" = off; "total" = only the
+///                                      handler-total stamps (probe-distortion
+///                                      A/B); any other value = full probes.
+///   QEC_DECODING_SERVER_HOP_STATS_CSV  per-sample CSV dump path, written at
+///                                      report time.
+///   QEC_PIN_DISPATCHER / QEC_PIN_RECV / QEC_PIN_WORKER
+///                                      pin that thread to a cpu id. Intended
+///                                      for single-decoder diagnosis runs:
+///                                      with multiple decoders every worker
+///                                      would share the one QEC_PIN_WORKER
+///                                      core.  QEC_PIN_RECV only applies to
+///                                      transports without a dispatch sink
+///                                      (direct-dispatch transports run no
+///                                      recv thread).
+///
+/// The spin-then-block wait policy (QEC_DECODING_SERVER_SPIN_US) is a
+/// production knob owned by SpinPolicy.h, not a diagnostic; the report's
+/// spin_us field echoes its effective budget.  Under direct dispatch
+/// (ITransceiver::install_dispatch_sink) hop1 no longer exists: both of its
+/// probe endpoints stamp back-to-back on the dispatcher thread, so hop1
+/// reports as warm ~0 with cold count 0 and notify1 is absent.
+///
+/// Correlation: a global slot array keyed by request_id & 0xFFFF (in-flight
+/// requests are bounded by the transport ring, so wraparound reuse is
+/// sequential). Timestamps are relaxed atomics -- the mutex/promise that
+/// already order each handoff also order the stamps; the atomics only keep
+/// the cross-thread reads well-defined. A slot is armed by inject() and
+/// consumed exactly once (worker_loop for fire-and-forget enqueues,
+/// inject()'s tail for blocking RPCs); the rid+armed check drops stale or
+/// foreign slots. Diagnostic-quality instrumentation: report/CSV formatting
+/// happens only at shutdown, never on the hot path.
+
+#include "SpinPolicy.h"
+#include "cudaq/qec/realtime/decoder_rpc_wire_format.h"
+#include "cudaq/realtime/daemon/dispatcher/dispatch_kernel_launch.h"
+
+#include <algorithm>
+#include <atomic>
+#include <chrono>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <pthread.h>
+#include <sched.h>
+#include <vector>
+
+namespace cudaq::qec::decoding_server::hopstats {
+
+// ---------------------------------------------------------------------------
+// Gates and small utilities
+// ---------------------------------------------------------------------------
+
+enum class Mode : int { off = 0, full = 1, total_only = 2 };
+
+inline Mode mode() {
+  static const Mode m = [] {
+    const char *e = std::getenv("QEC_DECODING_SERVER_HOP_STATS");
+    if (!e || !e[0])
+      return Mode::off;
+    if (std::strcmp(e, "total") == 0)
+      return Mode::total_only;
+    return Mode::full;
+  }();
+  return m;
+}
+
+inline bool enabled() { return mode() != Mode::off; }
+inline bool full() { return mode() == Mode::full; }
+
+inline uint64_t now_ns() {
+  return static_cast<uint64_t>(
+      std::chrono::duration_cast<std::chrono::nanoseconds>(
+          std::chrono::steady_clock::now().time_since_epoch())
+          .count());
+}
+
+// ---------------------------------------------------------------------------
+// Per-request slot (written by 3 threads at disjoint phases; the handoff
+// mutex/promise provides the ordering, relaxed atomics keep reads defined)
+// ---------------------------------------------------------------------------
+
+struct alignas(128) HopSlot {
+  std::atomic<uint64_t> t_entry{0};       // inject() entry (dispatcher)
+  std::atomic<uint64_t> t_inbox_push{0};  // hop1 start (dispatcher, under mtx_)
+  std::atomic<uint64_t> t_notify1_ret{0}; // after cv_.notify_one (dispatcher)
+  std::atomic<uint64_t> t_recv_wake{0};   // hop1 end (recv thread)
+  std::atomic<uint64_t> t_queue_push{0};  // hop2 start (recv thread)
+  std::atomic<uint64_t> t_notify2_ret{0}; // after queue_cv.notify_one (recv)
+  std::atomic<uint64_t> t_worker_wake{0}; // hop2 end (worker)
+  std::atomic<uint64_t> t_wait_begin{0};  // before fut.wait (dispatcher)
+  std::atomic<uint64_t> t_send_done{0};   // hop3 start (worker)
+  std::atomic<uint32_t> rid{0};
+  std::atomic<uint32_t> function_id{0};
+  std::atomic<uint8_t> armed{0};
+  std::atomic<uint8_t> cold1{0}; // recv() inbox was empty -> real wakeup
+  std::atomic<uint8_t> cold2{0}; // worker queue was empty -> real wakeup
+};
+static_assert(sizeof(HopSlot) == 128, "keep HopSlot one cache-line pair");
+
+constexpr std::size_t kSlotCount = 65536; // 8 MB BSS, paged in only if used
+inline HopSlot g_slots[kSlotCount];
+
+inline HopSlot &slot_for(uint32_t rid) {
+  return g_slots[rid & (kSlotCount - 1)];
+}
+
+inline bool armed_for(HopSlot &s, uint32_t rid) {
+  return s.armed.load(std::memory_order_relaxed) != 0 &&
+         s.rid.load(std::memory_order_relaxed) == rid;
+}
+
+// ---------------------------------------------------------------------------
+// Completed samples (one POD per request, appended lock-free)
+// ---------------------------------------------------------------------------
+
+constexpr int32_t kMissing = INT32_MIN; // stamp absent (mode/kind/race)
+
+struct Sample {
+  uint8_t kind;  // 0 enqueue, 1 get_corrections, 2 reset, 3 other
+  uint8_t cold1; // hop1 waiter actually slept/spun
+  uint8_t cold2; // hop2 waiter actually slept/spun
+  uint8_t cold3; // hop3: send() happened after fut.wait began
+  uint32_t rid;
+  int32_t hop1, hop2, hop3, total;
+  int32_t stage_build, stage_dispatch, stage_worker;
+  int32_t notify1, notify2;
+};
+
+constexpr std::size_t kMaxSamples = 262144; // ~12 MB; recording stops when full
+inline Sample g_samples[kMaxSamples];
+inline std::atomic<uint64_t> g_sample_count{0};
+
+inline uint8_t kind_of(uint32_t function_id) {
+  using namespace cudaq::qec::decoding::rpc;
+  if (function_id == kEnqueueSyndromesFunctionId)
+    return 0;
+  if (function_id == kGetCorrectionsFunctionId)
+    return 1;
+  if (function_id == kResetDecoderFunctionId)
+    return 2;
+  return 3;
+}
+
+// b - a in ns, kMissing when either stamp is absent, clamped to int32.
+inline int32_t delta_ns(uint64_t a, uint64_t b) {
+  if (!a || !b)
+    return kMissing;
+  const int64_t d = static_cast<int64_t>(b) - static_cast<int64_t>(a);
+  if (d > INT32_MAX)
+    return INT32_MAX;
+  if (d < INT32_MIN + 1)
+    return INT32_MIN + 1;
+  return static_cast<int32_t>(d);
+}
+
+inline void append_sample(const Sample &smp) {
+  const uint64_t idx = g_sample_count.fetch_add(1, std::memory_order_relaxed);
+  if (idx < kMaxSamples)
+    g_samples[idx] = smp;
+}
+
+// ---------------------------------------------------------------------------
+// Probes (call sites in CqrTransceiver.h / DecodingSession.cpp)
+// ---------------------------------------------------------------------------
+
+inline uint64_t entry_stamp() { return enabled() ? now_ns() : 0; }
+
+// Arm the slot for a new request; t_entry was taken at inject() entry,
+// before the rid was parsed.
+inline void begin_request(uint32_t rid, uint32_t function_id,
+                          uint64_t t_entry) {
+  if (!enabled())
+    return;
+  auto &s = slot_for(rid);
+  s.armed.store(0, std::memory_order_relaxed);
+  s.t_inbox_push.store(0, std::memory_order_relaxed);
+  s.t_notify1_ret.store(0, std::memory_order_relaxed);
+  s.t_recv_wake.store(0, std::memory_order_relaxed);
+  s.t_queue_push.store(0, std::memory_order_relaxed);
+  s.t_notify2_ret.store(0, std::memory_order_relaxed);
+  s.t_worker_wake.store(0, std::memory_order_relaxed);
+  s.t_wait_begin.store(0, std::memory_order_relaxed);
+  s.t_send_done.store(0, std::memory_order_relaxed);
+  s.cold1.store(0, std::memory_order_relaxed);
+  s.cold2.store(0, std::memory_order_relaxed);
+  s.rid.store(rid, std::memory_order_relaxed);
+  s.function_id.store(function_id, std::memory_order_relaxed);
+  s.t_entry.store(t_entry, std::memory_order_relaxed);
+  s.armed.store(1, std::memory_order_relaxed);
+}
+
+inline void stamp_inbox_push(uint32_t rid) {
+  if (!full())
+    return;
+  auto &s = slot_for(rid);
+  if (armed_for(s, rid))
+    s.t_inbox_push.store(now_ns(), std::memory_order_relaxed);
+}
+
+inline void stamp_notify1_ret(uint32_t rid) {
+  if (!full())
+    return;
+  auto &s = slot_for(rid);
+  if (armed_for(s, rid))
+    s.t_notify1_ret.store(now_ns(), std::memory_order_relaxed);
+}
+
+// After recv() pops a frame; reads the rid from the frame's RPCHeader.
+inline void stamp_recv_wake(const void *frame_data, std::size_t frame_len,
+                            bool was_empty) {
+  if (!full())
+    return;
+  if (!frame_data || frame_len < sizeof(cudaq::realtime::RPCHeader))
+    return;
+  const auto *hdr = static_cast<const cudaq::realtime::RPCHeader *>(frame_data);
+  auto &s = slot_for(hdr->request_id);
+  if (!armed_for(s, hdr->request_id))
+    return;
+  s.t_recv_wake.store(now_ns(), std::memory_order_relaxed);
+  s.cold1.store(was_empty ? 1 : 0, std::memory_order_relaxed);
+}
+
+inline void stamp_queue_push(uint32_t rid) {
+  if (!full())
+    return;
+  auto &s = slot_for(rid);
+  if (armed_for(s, rid))
+    s.t_queue_push.store(now_ns(), std::memory_order_relaxed);
+}
+
+inline void stamp_notify2_ret(uint32_t rid) {
+  if (!full())
+    return;
+  auto &s = slot_for(rid);
+  if (armed_for(s, rid))
+    s.t_notify2_ret.store(now_ns(), std::memory_order_relaxed);
+}
+
+inline void stamp_worker_wake(uint32_t rid, bool was_empty) {
+  if (!full())
+    return;
+  auto &s = slot_for(rid);
+  if (!armed_for(s, rid))
+    return;
+  s.t_worker_wake.store(now_ns(), std::memory_order_relaxed);
+  s.cold2.store(was_empty ? 1 : 0, std::memory_order_relaxed);
+}
+
+inline void stamp_wait_begin(uint32_t rid) {
+  if (!full())
+    return;
+  auto &s = slot_for(rid);
+  if (armed_for(s, rid))
+    s.t_wait_begin.store(now_ns(), std::memory_order_relaxed);
+}
+
+// Worker side, just before promise.set_value(): hop3 start.
+inline void stamp_send_done(uint32_t rid) {
+  if (!full())
+    return;
+  auto &s = slot_for(rid);
+  if (armed_for(s, rid))
+    s.t_send_done.store(now_ns(), std::memory_order_relaxed);
+}
+
+// Shutdown-drain completions are not latency samples.
+inline void invalidate(uint32_t rid) {
+  if (!enabled())
+    return;
+  auto &s = slot_for(rid);
+  if (s.rid.load(std::memory_order_relaxed) == rid)
+    s.armed.store(0, std::memory_order_relaxed);
+}
+
+// Blocking RPC completes: dispatcher thread, after fut.wait() returned.
+inline void finish_blocking(uint32_t rid) {
+  if (!enabled())
+    return;
+  auto &s = slot_for(rid);
+  if (!armed_for(s, rid))
+    return;
+  const uint64_t t_exit = now_ns();
+  s.armed.store(0, std::memory_order_relaxed);
+
+  Sample smp{};
+  smp.kind = kind_of(s.function_id.load(std::memory_order_relaxed));
+  smp.rid = rid;
+  const uint64_t e = s.t_entry.load(std::memory_order_relaxed);
+  smp.total = delta_ns(e, t_exit);
+  smp.hop1 = smp.hop2 = smp.hop3 = kMissing;
+  smp.stage_build = smp.stage_dispatch = smp.stage_worker = kMissing;
+  smp.notify1 = smp.notify2 = kMissing;
+  if (full()) {
+    const uint64_t ip = s.t_inbox_push.load(std::memory_order_relaxed);
+    const uint64_t n1 = s.t_notify1_ret.load(std::memory_order_relaxed);
+    const uint64_t rw = s.t_recv_wake.load(std::memory_order_relaxed);
+    const uint64_t qp = s.t_queue_push.load(std::memory_order_relaxed);
+    const uint64_t n2 = s.t_notify2_ret.load(std::memory_order_relaxed);
+    const uint64_t ww = s.t_worker_wake.load(std::memory_order_relaxed);
+    const uint64_t wb = s.t_wait_begin.load(std::memory_order_relaxed);
+    const uint64_t sd = s.t_send_done.load(std::memory_order_relaxed);
+    smp.stage_build = delta_ns(e, ip);
+    smp.hop1 = delta_ns(ip, rw);
+    smp.notify1 = delta_ns(ip, n1);
+    smp.stage_dispatch = delta_ns(rw, qp);
+    smp.hop2 = delta_ns(qp, ww);
+    smp.notify2 = delta_ns(qp, n2);
+    smp.stage_worker = delta_ns(ww, sd);
+    smp.hop3 = delta_ns(sd, t_exit);
+    smp.cold1 = s.cold1.load(std::memory_order_relaxed);
+    smp.cold2 = s.cold2.load(std::memory_order_relaxed);
+    smp.cold3 = (sd && wb && sd > wb) ? 1 : 0;
+  }
+  append_sample(smp);
+}
+
+// Fire-and-forget enqueue completes: worker thread, after the handler ran.
+// total here = inject entry -> handler done (the enqueue pipeline latency).
+inline void finish_enqueue(uint32_t rid) {
+  if (!full())
+    return;
+  auto &s = slot_for(rid);
+  if (!armed_for(s, rid))
+    return;
+  const uint64_t t_done = now_ns();
+  s.armed.store(0, std::memory_order_relaxed);
+
+  Sample smp{};
+  smp.kind = kind_of(s.function_id.load(std::memory_order_relaxed));
+  smp.rid = rid;
+  const uint64_t e = s.t_entry.load(std::memory_order_relaxed);
+  const uint64_t ip = s.t_inbox_push.load(std::memory_order_relaxed);
+  const uint64_t n1 = s.t_notify1_ret.load(std::memory_order_relaxed);
+  const uint64_t rw = s.t_recv_wake.load(std::memory_order_relaxed);
+  const uint64_t qp = s.t_queue_push.load(std::memory_order_relaxed);
+  const uint64_t n2 = s.t_notify2_ret.load(std::memory_order_relaxed);
+  const uint64_t ww = s.t_worker_wake.load(std::memory_order_relaxed);
+  smp.total = delta_ns(e, t_done);
+  smp.stage_build = delta_ns(e, ip);
+  smp.hop1 = delta_ns(ip, rw);
+  smp.notify1 = delta_ns(ip, n1);
+  smp.stage_dispatch = delta_ns(rw, qp);
+  smp.hop2 = delta_ns(qp, ww);
+  smp.notify2 = delta_ns(qp, n2);
+  smp.stage_worker = delta_ns(ww, t_done);
+  smp.hop3 = kMissing;
+  smp.cold1 = s.cold1.load(std::memory_order_relaxed);
+  smp.cold2 = s.cold2.load(std::memory_order_relaxed);
+  smp.cold3 = 0;
+  append_sample(smp);
+}
+
+// ---------------------------------------------------------------------------
+// Thread naming + optional pinning (named threads make ftrace readable)
+// ---------------------------------------------------------------------------
+
+inline void name_and_pin(const char *name, const char *pin_env) {
+  pthread_setname_np(pthread_self(), name);
+  const char *e = std::getenv(pin_env);
+  if (!e || !e[0])
+    return;
+  cpu_set_t set;
+  CPU_ZERO(&set);
+  CPU_SET(std::atoi(e), &set);
+  if (pthread_setaffinity_np(pthread_self(), sizeof(set), &set) != 0)
+    std::fprintf(stderr, "hopstats: %s=%s pin failed for %s\n", pin_env, e,
+                 name);
+}
+
+inline void on_dispatcher_thread() {
+  thread_local bool done = false;
+  if (!done) {
+    done = true;
+    name_and_pin("cqr-dispatch", "QEC_PIN_DISPATCHER");
+  }
+}
+
+inline void on_recv_thread() {
+  thread_local bool done = false;
+  if (!done) {
+    done = true;
+    name_and_pin("qec-recv", "QEC_PIN_RECV");
+  }
+}
+
+inline void on_worker_thread() {
+  thread_local bool done = false;
+  if (!done) {
+    done = true;
+    name_and_pin("qec-worker", "QEC_PIN_WORKER");
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Shutdown report (formatting cost paid only here)
+// ---------------------------------------------------------------------------
+
+inline double percentile_sorted(const std::vector<int32_t> &sorted, double p) {
+  if (sorted.empty())
+    return 0.0;
+  const double pos = p * static_cast<double>(sorted.size() - 1);
+  const std::size_t lo = static_cast<std::size_t>(pos);
+  const std::size_t hi = std::min(lo + 1, sorted.size() - 1);
+  const double frac = pos - static_cast<double>(lo);
+  return static_cast<double>(sorted[lo]) +
+         (static_cast<double>(sorted[hi]) - static_cast<double>(sorted[lo])) *
+             frac;
+}
+
+inline void report() {
+  if (!enabled())
+    return;
+  static std::atomic<bool> reported{false};
+  if (reported.exchange(true))
+    return;
+
+  const uint64_t total = g_sample_count.load(std::memory_order_relaxed);
+  const std::size_t n =
+      static_cast<std::size_t>(std::min<uint64_t>(total, kMaxSamples));
+  std::printf("QEC_HOP_STATS mode=%s recorded=%zu dropped=%llu spin_us=%lld\n",
+              full() ? "full" : "total", n,
+              static_cast<unsigned long long>(total - n),
+              static_cast<long long>(
+                  spin_budget_ns() < 0 ? -1 : spin_budget_ns() / 1000));
+
+  struct MetricDesc {
+    const char *name;
+    int32_t Sample::*field;
+    uint8_t Sample::*cold; // nullptr = no cold/warm split
+  };
+  const MetricDesc metrics[] = {
+      {"hop1", &Sample::hop1, &Sample::cold1},
+      {"hop2", &Sample::hop2, &Sample::cold2},
+      {"hop3", &Sample::hop3, &Sample::cold3},
+      {"total", &Sample::total, nullptr},
+      {"stage_build", &Sample::stage_build, nullptr},
+      {"stage_dispatch", &Sample::stage_dispatch, nullptr},
+      {"stage_worker", &Sample::stage_worker, nullptr},
+      {"notify1", &Sample::notify1, nullptr},
+      {"notify2", &Sample::notify2, nullptr},
+  };
+  const char *kind_names[] = {"enqueue_syndromes", "get_corrections",
+                              "reset_decoder", "other"};
+
+  std::vector<int32_t> vals;
+  for (int kind = 0; kind < 4; ++kind) {
+    for (const auto &m : metrics) {
+      const int subsets = m.cold ? 2 : 1; // cold, warm | all
+      for (int subset = 0; subset < subsets; ++subset) {
+        vals.clear();
+        for (std::size_t i = 0; i < n; ++i) {
+          const Sample &smp = g_samples[i];
+          if (smp.kind != kind)
+            continue;
+          const int32_t v = smp.*(m.field);
+          if (v == kMissing)
+            continue;
+          if (m.cold && ((smp.*(m.cold) != 0) != (subset == 0)))
+            continue;
+          vals.push_back(v);
+        }
+        if (vals.empty())
+          continue;
+        std::sort(vals.begin(), vals.end());
+        int64_t sum = 0;
+        for (int32_t v : vals)
+          sum += v;
+        const double avg = static_cast<double>(sum) /
+                           static_cast<double>(vals.size()) / 1000.0;
+        std::printf(
+            "QEC_HOP_STATS kind=%s metric=%s subset=%s count=%zu "
+            "min_us=%.2f avg_us=%.2f p50_us=%.2f p90_us=%.2f p99_us=%.2f "
+            "max_us=%.2f\n",
+            kind_names[kind], m.name,
+            m.cold ? (subset == 0 ? "cold" : "warm") : "all", vals.size(),
+            vals.front() / 1000.0, avg, percentile_sorted(vals, 0.50) / 1000.0,
+            percentile_sorted(vals, 0.90) / 1000.0,
+            percentile_sorted(vals, 0.99) / 1000.0, vals.back() / 1000.0);
+      }
+    }
+  }
+
+  if (const char *path = std::getenv("QEC_DECODING_SERVER_HOP_STATS_CSV");
+      path && path[0]) {
+    if (FILE *f = std::fopen(path, "w")) {
+      std::fprintf(f, "kind,rid,cold1,cold2,cold3,hop1_ns,hop2_ns,hop3_ns,"
+                      "total_ns,stage_build_ns,stage_dispatch_ns,"
+                      "stage_worker_ns,notify1_ns,notify2_ns\n");
+      for (std::size_t i = 0; i < n; ++i) {
+        const Sample &s = g_samples[i];
+        std::fprintf(f, "%s,%u,%u,%u,%u,%d,%d,%d,%d,%d,%d,%d,%d,%d\n",
+                     kind_names[s.kind], s.rid, s.cold1, s.cold2, s.cold3,
+                     s.hop1, s.hop2, s.hop3, s.total, s.stage_build,
+                     s.stage_dispatch, s.stage_worker, s.notify1, s.notify2);
+      }
+      std::fclose(f);
+      std::printf("QEC_HOP_STATS csv=%s rows=%zu\n", path, n);
+    } else {
+      std::fprintf(stderr, "hopstats: cannot open csv path %s\n", path);
+    }
+  }
+  std::fflush(stdout);
+}
+
+} // namespace cudaq::qec::decoding_server::hopstats

--- a/libs/qec/lib/realtime/decoding-server-cqr/ITransceiver.h
+++ b/libs/qec/lib/realtime/decoding-server-cqr/ITransceiver.h
@@ -73,6 +73,10 @@ struct RxFrame {
   ReleaseFn release_fn; ///< null except on GPU ring-buffer path
 };
 
+/// Sink a direct-dispatch transport invokes for each received frame, on the
+/// transport's own producer thread (see install_dispatch_sink).
+using DispatchSink = std::function<void(RxFrame &&)>;
+
 /// Transport abstraction used by DecodingServer and DecodingSession.
 struct ITransceiver {
   /// Block until a frame is available and return it (buf is owned by caller).
@@ -80,6 +84,15 @@ struct ITransceiver {
   /// sentinel that unblocks the receive loop so it can observe the shutdown
   /// flag and exit.
   virtual RxFrame recv() = 0;
+
+  /// Optional direct-dispatch hook: a transport whose frames originate on a
+  /// caller thread (CqrTransceiver::inject) may accept \p sink and invoke it
+  /// inline for each frame instead of queueing frames for recv() -- removing
+  /// one cross-thread handoff per RPC.  Returns true when accepted; the
+  /// server then must NOT run a recv() thread for this transport.  Installed
+  /// once, before the transport starts serving; the sink must be safe for
+  /// concurrent callers (one per producer thread).
+  virtual bool install_dispatch_sink(DispatchSink /*sink*/) { return false; }
 
   /// Unblock any thread waiting in recv() (which then returns an empty
   /// sentinel frame). Called by DecodingServer::stop().

--- a/libs/qec/lib/realtime/decoding-server-cqr/RpcDispatcher.cpp
+++ b/libs/qec/lib/realtime/decoding-server-cqr/RpcDispatcher.cpp
@@ -77,6 +77,12 @@ void RpcDispatcher::dispatch(RxFrame frame, ITransceiver &transport) {
   } catch (const std::exception &e) {
     cudaq::qec::error("RpcDispatcher: handler threw: {}", e.what());
     writer.write_error(RpcStatus::INTERNAL_ERROR);
+  } catch (...) {
+    // Non-std exceptions (decoder plugins): under direct dispatch an escape
+    // would unwind into the transport's inject() caller instead of a recv
+    // thread; contain it here on both paths.
+    cudaq::qec::error("RpcDispatcher: handler threw a non-std exception");
+    writer.write_error(RpcStatus::INTERNAL_ERROR);
   }
 }
 

--- a/libs/qec/lib/realtime/decoding-server-cqr/SpinPolicy.h
+++ b/libs/qec/lib/realtime/decoding-server-cqr/SpinPolicy.h
@@ -1,0 +1,83 @@
+/****************************************************************-*- C++ -*-****
+ * Copyright (c) 2026 NVIDIA Corporation & Affiliates.                         *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+#pragma once
+
+/// Bounded spin-then-block policy for the decoding server's cross-thread
+/// waits (session work queue, blocking-RPC response).
+///
+/// A sleeping waiter costs a futex wake on the producer plus a scheduler
+/// switch-in on the consumer (~3-4 us on Grace-class hosts, with deep-idle
+/// outliers near 100 us).  Spinning on an atomic for a bounded window before
+/// blocking removes that cost whenever the producer answers within the
+/// budget (~0.3-0.5 us per handoff), while an idle thread still parks after
+/// one budget window.  The blocking primitive stays armed on every path, so
+/// semantics are identical to pure blocking; the spin only skips the sleep.
+///
+/// Budget selection (read once, at first use):
+///   QEC_DECODING_SERVER_SPIN_US   unset/"" -> kDefaultSpinBudgetUs;
+///                                 0  -> always block (no spin);
+///                                 N  -> spin N us, then block;
+///                                 -1 -> spin forever, never block -- the
+///                                       dedicated-core realtime posture,
+///                                       best paired with QEC_PIN_* pinning.
+
+#include <chrono>
+#include <cstdint>
+#include <cstdlib>
+
+namespace cudaq::qec::decoding_server {
+
+/// Default spin budget (µs): long enough to cover any realistic decode
+/// cadence -- request gaps within a shot are well under this even on the
+/// software udp wire -- while an idle thread burns at most one such window
+/// per idle transition before sleeping.
+inline constexpr long kDefaultSpinBudgetUs = 200;
+
+/// Effective spin budget in nanoseconds: -1 = infinite, 0 = disabled.
+inline int64_t spin_budget_ns() {
+  static const int64_t v = [] {
+    const char *e = std::getenv("QEC_DECODING_SERVER_SPIN_US");
+    const long long us = (e && e[0]) ? std::atoll(e) : kDefaultSpinBudgetUs;
+    return us < 0 ? int64_t{-1} : static_cast<int64_t>(us) * 1000;
+  }();
+  return v;
+}
+
+inline void cpu_relax() {
+#if defined(__aarch64__)
+  asm volatile("yield" ::: "memory");
+#elif defined(__x86_64__)
+  asm volatile("pause" ::: "memory");
+#endif
+}
+
+/// Spin until \p pred holds or the budget expires; returns pred's last value
+/// so callers fall through to their blocking wait on false.  The caller's
+/// blocking primitive must still be armed by every completer -- the spin is
+/// an optimization of the wait, never a replacement for the wakeup.
+template <typename Pred>
+inline bool spin_until(Pred pred) {
+  const int64_t budget = spin_budget_ns();
+  if (budget == 0)
+    return pred();
+  const auto now_ns = [] {
+    return std::chrono::duration_cast<std::chrono::nanoseconds>(
+               std::chrono::steady_clock::now().time_since_epoch())
+        .count();
+  };
+  const int64_t deadline = budget < 0 ? 0 : now_ns() + budget;
+  while (!pred()) {
+    if (budget > 0 && now_ns() >= deadline)
+      return false;
+    cpu_relax();
+  }
+  return true;
+}
+
+} // namespace cudaq::qec::decoding_server

--- a/libs/qec/lib/realtime/decoding-server-cqr/decoding_server_cqr.cpp
+++ b/libs/qec/lib/realtime/decoding-server-cqr/decoding_server_cqr.cpp
@@ -23,6 +23,7 @@
 
 #include "CqrTransceiver.h"
 #include "DecodingServer.h"
+#include "HopStats.h"
 #include "cudaq/qec/logger.h"
 #include "cudaq/qec/realtime/decoder_rpc_wire_format.h"
 #include "cudaq/qec/realtime/decoding_config.h"
@@ -387,6 +388,7 @@ extern "C" __attribute__((visibility("default"))) void
 cudaqx_qec_decoding_server_print_stats() {
   if (g_server)
     g_server->print_session_stats();
+  cudaq::qec::decoding_server::hopstats::report();
 }
 
 /// Stop the DecodingServer receive loop and join its thread. The server calls
@@ -401,4 +403,7 @@ cudaqx_qec_decoding_server_shutdown() {
     g_server.reset();
     g_transceiver = nullptr;
   }
+  // Latency-probe report (QEC_DECODING_SERVER_HOP_STATS); prints once, after
+  // all producers (dispatcher handlers, session workers) have quiesced.
+  cudaq::qec::decoding_server::hopstats::report();
 }

--- a/libs/qec/tools/decoding-server/decoding_server.cpp
+++ b/libs/qec/tools/decoding-server/decoding_server.cpp
@@ -86,11 +86,13 @@
 #include <cstdint>
 #include <cstdlib>
 #include <cstring>
+#include <fcntl.h>
 #include <fstream>
 #include <iostream>
 #include <sstream>
 #include <string>
 #include <thread>
+#include <unistd.h>
 #include <vector>
 
 extern "C" void cudaqx_qec_realtime_device_call_service_force_link();
@@ -184,6 +186,47 @@ bool parse_args(int argc, char **argv, ServerConfig &cfg) {
 std::atomic<int> g_shutdown{0};
 void on_signal(int) { g_shutdown.store(1, std::memory_order_release); }
 
+/// Env-gated /dev/cpu_dma_latency hold: while the fd stays open, the kernel
+/// keeps every CPU out of idle states whose exit latency exceeds the written
+/// target, removing the deep-idle wakeup tail (~90 us outliers at p99) from
+/// served RPCs.  QEC_DECODING_SERVER_CPU_DMA_LATENCY_US = target in
+/// microseconds (0 = shallowest idle only); requires write access to
+/// /dev/cpu_dma_latency (root).  Failure warns and continues -- it is a
+/// latency QoS, not a correctness requirement.  In-process applications hold
+/// the fd themselves; this belongs to the process owner, hence the tool.
+class CpuDmaLatencyHold {
+public:
+  CpuDmaLatencyHold() {
+    const char *env = std::getenv("QEC_DECODING_SERVER_CPU_DMA_LATENCY_US");
+    if (!env || !env[0])
+      return;
+    const int32_t target_us = std::atoi(env);
+    fd_ = ::open("/dev/cpu_dma_latency", O_WRONLY);
+    if (fd_ < 0 || ::write(fd_, &target_us, sizeof(target_us)) !=
+                       static_cast<ssize_t>(sizeof(target_us))) {
+      std::cerr << "WARNING: cannot hold /dev/cpu_dma_latency at " << target_us
+                << " us (need root); deep-idle wakeup outliers remain"
+                << std::endl;
+      if (fd_ >= 0) {
+        ::close(fd_);
+        fd_ = -1;
+      }
+      return;
+    }
+    std::cout << "QEC_DECODING_SERVER_CPU_DMA_LATENCY held at " << target_us
+              << " us" << std::endl;
+  }
+  ~CpuDmaLatencyHold() {
+    if (fd_ >= 0)
+      ::close(fd_);
+  }
+  CpuDmaLatencyHold(const CpuDmaLatencyHold &) = delete;
+  CpuDmaLatencyHold &operator=(const CpuDmaLatencyHold &) = delete;
+
+private:
+  int fd_ = -1;
+};
+
 // Resolve a --transport value to the provider shared library to load:
 // anything with a '/' is a caller-supplied library path (the partner
 // drop-in); a bare name maps to libcudaq-realtime-bridge-<name>.so next to
@@ -229,6 +272,9 @@ int main(int argc, char **argv) {
   ServerConfig cfg;
   if (!parse_args(argc, argv, cfg))
     return 1;
+
+  // Held for the whole run (env-gated no-op when unset); see the class doc.
+  CpuDmaLatencyHold dma_latency_hold;
 
   std::signal(SIGINT, on_signal);
   std::signal(SIGTERM, on_signal);

--- a/libs/qec/unittests/test_decoding_server_core.cpp
+++ b/libs/qec/unittests/test_decoding_server_core.cpp
@@ -20,6 +20,7 @@
 #include <gtest/gtest.h>
 
 #include <array>
+#include <atomic>
 #include <chrono>
 #include <cstdint>
 #include <cstring>
@@ -479,6 +480,61 @@ TEST(CqrDirectDispatch, ShutdownReleasesBlockedInjectWaiter) {
   EXPECT_EQ(response->magic, cudaq::realtime::RPC_MAGIC_RESPONSE);
   EXPECT_EQ(response->status, static_cast<int32_t>(RpcStatus::BAD_REQUEST));
   EXPECT_EQ(response->request_id, 7u);
+}
+
+TEST(CqrDirectDispatch, ConcurrentCollidingClientRidsCompleteTheirOwnSlots) {
+  // Per-decoder rings mean one dispatcher thread per ring calls inject()
+  // concurrently, and each ring's caller session numbers its requests
+  // independently -- so distinct in-flight blocking calls legitimately carry
+  // the SAME client request_id.  Every caller must still receive ITS OWN
+  // response in ITS tx_slot (correlation is by the transceiver's unique
+  // token), discriminated here by the echoed ptp_timestamp.  Under
+  // client-rid keying this deadlocks or cross-completes slots.
+  constexpr int kThreads = 4;
+  CqrTransceiver transceiver;
+  RpcDispatcher dispatcher;
+  std::atomic<int> arrived{0};
+  dispatcher.register_handler(
+      kGetCorrectionsFunctionId, [&](RxFrame, ResponseWriter &writer) {
+        // Hold every handler until all callers hold a live pending entry, so
+        // the colliding-rid window genuinely overlaps.
+        arrived.fetch_add(1, std::memory_order_acq_rel);
+        while (arrived.load(std::memory_order_acquire) < kThreads)
+          std::this_thread::yield();
+        writer.write_error(RpcStatus::NOT_READY);
+      });
+  ASSERT_TRUE(transceiver.install_dispatch_sink([&](RxFrame &&frame) {
+    dispatcher.dispatch(std::move(frame), transceiver);
+  }));
+
+  constexpr uint32_t kSharedClientRid = 42; // collides across all "rings"
+  std::vector<std::vector<uint8_t>> rx(kThreads);
+  std::vector<std::vector<uint8_t>> tx(kThreads);
+  for (int t = 0; t < kThreads; ++t) {
+    rx[t] = make_cqr_slot(kGetCorrectionsFunctionId, kSharedClientRid);
+    reinterpret_cast<RPCHeader *>(rx[t].data())->ptp_timestamp = 1000 + t;
+    tx[t].assign(sizeof(RPCResponse), 0);
+  }
+
+  std::vector<std::thread> callers;
+  for (int t = 0; t < kThreads; ++t)
+    callers.emplace_back([&, t] {
+      transceiver.inject(rx[t].data(), tx[t].data(), rx[t].size(),
+                         kGetCorrectionsFunctionId);
+    });
+  for (auto &caller : callers)
+    caller.join();
+
+  for (int t = 0; t < kThreads; ++t) {
+    const auto *response = reinterpret_cast<const RPCResponse *>(tx[t].data());
+    EXPECT_EQ(response->magic, cudaq::realtime::RPC_MAGIC_RESPONSE) << t;
+    EXPECT_EQ(response->status, static_cast<int32_t>(RpcStatus::NOT_READY))
+        << t;
+    EXPECT_EQ(response->request_id, kSharedClientRid)
+        << "client rid not restored for caller " << t;
+    EXPECT_EQ(response->ptp_timestamp, 1000u + t)
+        << "response landed in the wrong caller's tx_slot";
+  }
 }
 
 // ---------------------------------------------------------------------------

--- a/libs/qec/unittests/test_decoding_server_core.cpp
+++ b/libs/qec/unittests/test_decoding_server_core.cpp
@@ -6,6 +6,7 @@
  * the terms of the Apache License 2.0 which accompanies this distribution.    *
  *******************************************************************************/
 
+#include "CqrTransceiver.h"
 #include "DecodingServer.h"
 #include "DecodingSession.h"
 #include "RoundAccumulator.h"
@@ -18,8 +19,10 @@
 
 #include <gtest/gtest.h>
 
+#include <array>
 #include <chrono>
 #include <cstdint>
+#include <cstring>
 #include <cuda_runtime_api.h>
 #include <memory>
 #include <stdexcept>
@@ -349,6 +352,175 @@ TEST(DecodingSessionPinHandshake, PinnedWorkerStartsAndServes) {
     std::this_thread::sleep_for(std::chrono::milliseconds(5));
   EXPECT_EQ(session->reset_count.load(), 1u)
       << "pinned worker did not serve the queued item";
+}
+
+// ---------------------------------------------------------------------------
+// CqrTransceiver direct dispatch (install_dispatch_sink): the handler runs
+// inline on the inject() caller thread, with no recv-thread handoff.
+// ---------------------------------------------------------------------------
+
+// CQR request slot: RPCHeader (+ optional payload) as the CUDAQ dispatcher
+// hands it to inject().
+std::vector<uint8_t> make_cqr_slot(uint32_t function_id, uint32_t request_id,
+                                   const std::vector<uint8_t> &payload = {}) {
+  std::vector<uint8_t> slot(sizeof(RPCHeader) + payload.size());
+  RPCHeader header{};
+  header.magic = cudaq::realtime::RPC_MAGIC_REQUEST;
+  header.function_id = function_id;
+  header.arg_len = static_cast<uint32_t>(payload.size());
+  header.request_id = request_id;
+  std::memcpy(slot.data(), &header, sizeof(header));
+  if (!payload.empty())
+    std::memcpy(slot.data() + sizeof(header), payload.data(), payload.size());
+  return slot;
+}
+
+TEST(CqrDirectDispatch, RunsBlockingHandlerInlineAndCompletesTxSlot) {
+  CqrTransceiver transceiver;
+  RpcDispatcher dispatcher;
+  std::thread::id handler_tid{};
+  dispatcher.register_handler(kGetCorrectionsFunctionId,
+                              [&](RxFrame, ResponseWriter &writer) {
+                                handler_tid = std::this_thread::get_id();
+                                writer.write_error(RpcStatus::NOT_READY);
+                              });
+  ASSERT_TRUE(transceiver.install_dispatch_sink([&](RxFrame &&frame) {
+    dispatcher.dispatch(std::move(frame), transceiver);
+  }));
+
+  const auto rx = make_cqr_slot(kGetCorrectionsFunctionId, /*request_id=*/42);
+  std::vector<uint8_t> tx(sizeof(RPCResponse));
+  // Completing this call single-threaded also locks in the invariant that
+  // inject() does not hold its mutex across the sink: the handler's
+  // write_error re-enters send(), which takes the same mutex -- a violation
+  // deadlocks right here.
+  transceiver.inject(rx.data(), tx.data(), rx.size(),
+                     kGetCorrectionsFunctionId);
+
+  EXPECT_EQ(handler_tid, std::this_thread::get_id())
+      << "handler did not run inline on the inject() caller thread";
+  const auto *response = reinterpret_cast<const RPCResponse *>(tx.data());
+  EXPECT_EQ(response->magic, cudaq::realtime::RPC_MAGIC_RESPONSE);
+  EXPECT_EQ(response->status, static_cast<int32_t>(RpcStatus::NOT_READY));
+  EXPECT_EQ(response->request_id, 42u);
+}
+
+TEST(CqrDirectDispatch, EnqueueAcksImmediatelyAndDispatchesInline) {
+  CqrTransceiver transceiver;
+  RpcDispatcher dispatcher;
+  std::thread::id handler_tid{};
+  int32_t status_at_handler_time = -1;
+  std::vector<uint8_t> handler_frame;
+  std::vector<uint8_t> tx(sizeof(RPCResponse));
+  dispatcher.register_handler(
+      kEnqueueSyndromesFunctionId, [&](RxFrame frame, ResponseWriter &) {
+        handler_tid = std::this_thread::get_id();
+        // The fire-and-forget ACK must be complete BEFORE the handler runs:
+        // an exception after a deferred ACK would stall the CUDAQ transport
+        // on an unwritten tx slot.
+        status_at_handler_time =
+            reinterpret_cast<const RPCResponse *>(tx.data())->status;
+        handler_frame = frame.buf;
+      });
+  ASSERT_TRUE(transceiver.install_dispatch_sink([&](RxFrame &&frame) {
+    dispatcher.dispatch(std::move(frame), transceiver);
+  }));
+
+  // 4-arg CUDAQ enqueue wire format: [u64 decoder_id][u64 counter]
+  // [u64 mapping_id][u64 num_syndromes][bit-packed bytes].
+  std::vector<uint8_t> payload(4 * sizeof(uint64_t) + 1);
+  const std::array<uint64_t, 4> fields = {/*decoder_id=*/3, /*counter=*/7,
+                                          /*mapping_id=*/0,
+                                          /*num_syndromes=*/1};
+  std::memcpy(payload.data(), fields.data(), sizeof(fields));
+  payload.back() = 1;
+  const auto rx =
+      make_cqr_slot(kEnqueueSyndromesFunctionId, /*request_id=*/23, payload);
+
+  transceiver.inject(rx.data(), tx.data(), rx.size(),
+                     kEnqueueSyndromesFunctionId);
+
+  EXPECT_EQ(handler_tid, std::this_thread::get_id());
+  EXPECT_EQ(status_at_handler_time, 0) << "enqueue ACK not written before "
+                                          "the handler ran";
+  ASSERT_EQ(handler_frame.size(),
+            sizeof(RPCHeader) + sizeof(EnqueueRequestPayload) + 1);
+  const auto *request = reinterpret_cast<const EnqueueRequestPayload *>(
+      handler_frame.data() + sizeof(RPCHeader));
+  EXPECT_EQ(request->decoder_id, 3);
+  EXPECT_EQ(request->counter, 7);
+  EXPECT_EQ(request->num_syndromes, 1);
+  EXPECT_EQ(handler_frame.back(), 1);
+}
+
+TEST(CqrDirectDispatch, ShutdownReleasesBlockedInjectWaiter) {
+  CqrTransceiver transceiver;
+  RpcDispatcher dispatcher;
+  // Handler intentionally produces no response: inject() parks on its
+  // pending promise exactly as it does while a session worker decodes.
+  dispatcher.register_handler(kGetCorrectionsFunctionId,
+                              [](RxFrame, ResponseWriter &) {});
+  ASSERT_TRUE(transceiver.install_dispatch_sink([&](RxFrame &&frame) {
+    dispatcher.dispatch(std::move(frame), transceiver);
+  }));
+
+  const auto rx = make_cqr_slot(kGetCorrectionsFunctionId, /*request_id=*/7);
+  std::vector<uint8_t> tx(sizeof(RPCResponse));
+  std::thread waiter([&] {
+    transceiver.inject(rx.data(), tx.data(), rx.size(),
+                       kGetCorrectionsFunctionId);
+  });
+
+  std::this_thread::sleep_for(std::chrono::milliseconds(20));
+  transceiver.shutdown(); // drain must complete the slot and release waiter
+  waiter.join();          // hangs here (test timeout) if the drain is broken
+
+  const auto *response = reinterpret_cast<const RPCResponse *>(tx.data());
+  EXPECT_EQ(response->magic, cudaq::realtime::RPC_MAGIC_RESPONSE);
+  EXPECT_EQ(response->status, static_cast<int32_t>(RpcStatus::BAD_REQUEST));
+  EXPECT_EQ(response->request_id, 7u);
+}
+
+// ---------------------------------------------------------------------------
+// Spin-then-block worker wait (SpinPolicy.h): both arrival modes must be
+// served regardless of the configured budget (the env knob is parsed once
+// per process, so this test is deliberately budget-agnostic).
+// ---------------------------------------------------------------------------
+
+TEST(DecodingSessionSpin, ProcessesBurstAndIdleArrivals) {
+  auto [session, decoder] = make_session();
+  (void)decoder;
+  // ControlledDecoder is unpinned, so start_worker's CUDA pin is a no-op and
+  // this test runs on driverless boxes too.
+  ASSERT_NO_THROW(session->start_worker());
+
+  CaptureTransceiver transport;
+  // Burst: back-to-back arrivals land inside the worker's spin window when
+  // spinning is enabled.
+  constexpr uint64_t kBurst = 8;
+  for (uint64_t i = 0; i < kBurst; ++i)
+    ASSERT_TRUE(session->try_enqueue(make_reset(transport)));
+  for (int i = 0; i < 400 && session->reset_count.load() < kBurst; ++i)
+    std::this_thread::sleep_for(std::chrono::milliseconds(5));
+  EXPECT_EQ(session->reset_count.load(), kBurst);
+
+  // Idle arrival: the worker is far past any finite spin budget and parked
+  // in its condvar wait; the push must still wake it (the blocking fallback
+  // stays armed).
+  std::this_thread::sleep_for(std::chrono::milliseconds(300));
+  ASSERT_TRUE(session->try_enqueue(make_reset(transport)));
+  for (int i = 0; i < 400 && session->reset_count.load() < kBurst + 1; ++i)
+    std::this_thread::sleep_for(std::chrono::milliseconds(5));
+  EXPECT_EQ(session->reset_count.load(), kBurst + 1);
+
+  // stop_worker() must return promptly from an idle worker whether it is
+  // mid-spin or parked (the spin predicate observes the shutdown flag).
+  const auto t0 = std::chrono::steady_clock::now();
+  session->stop_worker();
+  const auto stop_ms = std::chrono::duration_cast<std::chrono::milliseconds>(
+                           std::chrono::steady_clock::now() - t0)
+                           .count();
+  EXPECT_LT(stop_ms, 1000) << "stop_worker did not interrupt the wait";
 }
 
 } // namespace


### PR DESCRIPTION
## Description

A HOST_CALL RPC served by the decoding server crossed three thread
boundaries — CUDAQ dispatcher → receiver-thread inbox, receiver → session
worker queue, worker → dispatcher response promise. Each handoff is a
condvar/promise futex sleep/wake costing ~3–4 µs on Grace-class hosts, plus
a ~90–115 µs p99 tail when the sleeping core sits in a deep idle state.
Those handoffs, not the decoders, dominated the handler latency observed during testing.

This PR removes or short-circuits all three, on top of the #682
architecture:

1. **Direct dispatch** — `CqrTransceiver::inject()` hands each translated
   frame straight to `RpcDispatcher::dispatch()` on the calling CUDAQ
   dispatcher thread via a sink installed by `DecodingServer` at
   construction (`ITransceiver::install_dispatch_sink`). No receiver thread
   is started for CQR transports; the inbox/recv path remains for
   transports that decline the sink (and stays unit-tested).
   `RpcDispatcher::dispatch` gains a catch-all so no handler exception can
   unwind into the transport.
2. **Bounded spin-then-block** (`SpinPolicy.h`) — the per-decoder session
   worker spins on an atomic queue sequence, and the blocking-RPC waiter on
   a stack-owned completion flag, before falling back to their untouched
   condvar/promise waits. Default budget 200 µs;
   `QEC_DECODING_SERVER_SPIN_US` overrides (`0` = always block, `-1` =
   never block). Idle threads park after one budget window.
3. **Small levers** — `notify_one()` hoisted out of `queue_mutex` in
   `try_enqueue`, and an opt-in `/dev/cpu_dma_latency` hold in the
   standalone tool (`QEC_DECODING_SERVER_CPU_DMA_LATENCY_US`) that removes
   the deep-idle p99 tail.

`HopStats.h` adds env-gated per-request latency probes across the hops
(`QEC_DECODING_SERVER_HOP_STATS[=1|total|_CSV]`), off by default (one
predicted branch per probe; p50 unchanged within 0.1 µs), plus
`QEC_PIN_DISPATCHER/WORKER` thread pinning for controlled measurements.

## Runtime / performance impact

Stock configuration (no env vars), HOST_CALL round trip, median (p99), udp
two-process rig, d3/r12 surface code, 2000 shots:

| RPC | before | after |
|---|---|---|
| enqueue_syndromes | 11.0 µs (108) | 0.8 µs (5.3) |
| get_corrections | 18.1 µs (124) | 1.6 µs (7.2) |
| reset_decoder | 18.0 µs (120) | 4.8 µs (8.5) |