### PR TITLE
Fix multi-logical decoding over per-decoder rings (surface_code-1) + CqrTransceiver request-id collisions

### DIFF
--- a/libs/qec/lib/realtime/decoding-server-cqr/CqrTransceiver.h
+++ b/libs/qec/lib/realtime/decoding-server-cqr/CqrTransceiver.h
@@ -231,8 +231,7 @@ inline void CqrTransceiver::inject(const void *rx_slot, void *tx_slot,
   // the DecodingSession worker echoes the token back in its response.  (The
   // client's rid is restored in send(); it cannot be the map key because
   // concurrent injects from different rings carry colliding rids.)
-  const uint32_t token =
-      next_token_.fetch_add(1, std::memory_order_relaxed);
+  const uint32_t token = next_token_.fetch_add(1, std::memory_order_relaxed);
   reinterpret_cast<RPCHeader *>(frame.buf.data())->request_id = token;
 
   std::future<void> fut;

--- a/libs/qec/lib/realtime/decoding-server-cqr/CqrTransceiver.h
+++ b/libs/qec/lib/realtime/decoding-server-cqr/CqrTransceiver.h
@@ -13,6 +13,7 @@
 #include "cudaq/realtime/daemon/dispatcher/cudaq_realtime.h"
 #include "cudaq/realtime/daemon/dispatcher/dispatch_kernel_launch.h"
 
+#include <atomic>
 #include <condition_variable>
 #include <cstring>
 #include <deque>
@@ -99,13 +100,19 @@ inline bool parse_cqr_enqueue_frame(const void *rx_slot, std::size_t slot_size,
 /// Bridges CUDAQ_REALTIME DeviceCallService handler callbacks to ITransceiver.
 ///
 /// CUDAQ calls handler functions synchronously with (rx_slot, tx_slot,
-/// slot_size), all on the SINGLE transport dispatcher thread.
+/// slot_size). With one ring (and one dispatcher thread) per decoder, these
+/// calls arrive CONCURRENTLY, one thread per ring — and each ring's caller
+/// session numbers its requests independently, so request_ids from different
+/// rings collide.
 ///
 /// Response-bearing calls (get_corrections, reset_decoder): inject() copies
-/// rx_slot bytes into an RxFrame, stores the tx_slot pointer keyed by
-/// request_id, and blocks until the DecodingSession worker calls send() with
-/// the response — at which point send() copies the bytes to tx_slot and
-/// unblocks the handler thread so CUDAQ can return.
+/// rx_slot bytes into an RxFrame, rewrites the frame's request_id to a
+/// process-unique token (the correlation key the DecodingSession worker
+/// echoes back — the client's original id is NOT unique across rings),
+/// stores the tx_slot pointer keyed by that token, and blocks until the
+/// worker calls send() with the response — at which point send() copies the
+/// bytes to tx_slot, restores the client's original request_id, and unblocks
+/// the handler thread so CUDAQ can return.
 ///
 /// Fire-and-forget calls (enqueue_syndromes): inject() enqueues the frame
 /// and writes an immediate ACCEPTED response into tx_slot WITHOUT blocking —
@@ -144,13 +151,19 @@ private:
   struct PendingTx {
     void *tx_slot;
     std::size_t slot_size;
+    uint32_t client_rid; // the caller's original request_id, restored in the
+                         // response written to tx_slot
     std::promise<void> done;
   };
 
   std::mutex mtx_;
   std::condition_variable cv_;
   std::deque<RxFrame> inbox_;
-  std::unordered_map<uint32_t, PendingTx> pending_; // keyed by request_id
+  // Keyed by a process-unique token (NOT the client's request_id: each
+  // ring's caller session numbers requests independently, so ids from
+  // different rings collide).
+  std::unordered_map<uint32_t, PendingTx> pending_;
+  std::atomic<uint32_t> next_token_{1};
 
   // Translate CUDAQ enqueue_syndromes payload (stdvec<i1> format) to our
   // RPCHeader + EnqueueRequestPayload + bit-packed bytes.
@@ -214,6 +227,14 @@ inline void CqrTransceiver::inject(const void *rx_slot, void *tx_slot,
     return;
   }
 
+  // Correlate by a process-unique token: rewrite the frame's request_id so
+  // the DecodingSession worker echoes the token back in its response.  (The
+  // client's rid is restored in send(); it cannot be the map key because
+  // concurrent injects from different rings carry colliding rids.)
+  const uint32_t token =
+      next_token_.fetch_add(1, std::memory_order_relaxed);
+  reinterpret_cast<RPCHeader *>(frame.buf.data())->request_id = token;
+
   std::future<void> fut;
   {
     std::lock_guard<std::mutex> lk(mtx_);
@@ -224,9 +245,10 @@ inline void CqrTransceiver::inject(const void *rx_slot, void *tx_slot,
       write_ack(tx_slot, rid, ptp, RpcStatus::BAD_REQUEST);
       return;
     }
-    auto &p = pending_[rid];
+    auto &p = pending_[token];
     p.tx_slot = tx_slot;
     p.slot_size = slot_size;
+    p.client_rid = rid;
     fut = p.done.get_future();
     inbox_.push_back(std::move(frame));
   }
@@ -261,8 +283,9 @@ inline void CqrTransceiver::shutdown() {
     pending_.clear();
   }
   cv_.notify_all();
-  for (auto &[rid, p] : drained) {
-    write_ack(p.tx_slot, rid, /*ptp_timestamp=*/0, RpcStatus::BAD_REQUEST);
+  for (auto &[token, p] : drained) {
+    write_ack(p.tx_slot, p.client_rid, /*ptp_timestamp=*/0,
+              RpcStatus::BAD_REQUEST);
     p.done.set_value();
   }
 }
@@ -287,10 +310,10 @@ inline void CqrTransceiver::send(const PeerId & /*peer*/, const uint8_t *data,
     return;
 
   const auto *resp = reinterpret_cast<const RPCResponse *>(data);
-  const uint32_t rid = resp->request_id;
+  const uint32_t token = resp->request_id; // inject()'s rewritten id
 
   std::lock_guard<std::mutex> lk(mtx_);
-  auto it = pending_.find(rid);
+  auto it = pending_.find(token);
   if (it == pending_.end())
     return;
 
@@ -300,14 +323,17 @@ inline void CqrTransceiver::send(const PeerId & /*peer*/, const uint8_t *data,
     // written, so the client would read stale slot memory as correction
     // bits.  Fail the RPC explicitly instead (the pre-decoding-server code
     // returned result-buffer-too-small here).
-    write_ack(p.tx_slot, rid, resp->ptp_timestamp, RpcStatus::INTERNAL_ERROR);
+    write_ack(p.tx_slot, p.client_rid, resp->ptp_timestamp,
+              RpcStatus::INTERNAL_ERROR);
     p.done.set_value();
     pending_.erase(it);
     return;
   }
 
-  // Write our RPCResponse into the CUDAQ tx_slot (layouts are compatible).
+  // Write our RPCResponse into the CUDAQ tx_slot (layouts are compatible),
+  // restoring the caller's original request_id in place of the token.
   std::memcpy(p.tx_slot, data, len);
+  static_cast<RPCResponse *>(p.tx_slot)->request_id = p.client_rid;
   // Publish the magic last (release store) so the CUDAQ runtime sees a
   // complete response before observing the magic word.
   __atomic_store_n(reinterpret_cast<uint32_t *>(p.tx_slot),

--- a/libs/qec/tools/decoding-server/decoding_server.cpp
+++ b/libs/qec/tools/decoding-server/decoding_server.cpp
@@ -516,6 +516,23 @@ int main(int argc, char **argv) {
                                          ring_argv.data()) != CUDAQ_OK) {
       std::cerr << "ERROR: failed to load/create transport provider '"
                 << ring_lib << "' for decoder " << ring.decoder_id << std::endl;
+      // A later ring failing where an earlier one succeeded is the signature
+      // of endpoint args that cannot be shared: every ring receives the same
+      // provider args, so an explicit --port=N binds ring 0 and collides on
+      // every ring after it.
+      const auto is_explicit_port = [](const std::string &a) {
+        return starts_with(a, "--port=") && a != "--port=0";
+      };
+      if (i > 0 && (std::any_of(cfg.provider_args.begin(),
+                                cfg.provider_args.end(), is_explicit_port) ||
+                    std::any_of(ring_extra_args.begin(), ring_extra_args.end(),
+                                is_explicit_port)))
+        std::cerr << "note: all " << rings.size()
+                  << " rings receive the same provider args; an explicit "
+                     "--port=N cannot be shared across rings -- use --port=0 "
+                     "and read each ring's port from the "
+                     "QEC_DECODING_SERVER_READY line"
+                  << std::endl;
       teardown_rings();
       return 1;
     }

--- a/libs/qec/unittests/realtime/app_examples/CMakeLists.txt
+++ b/libs/qec/unittests/realtime/app_examples/CMakeLists.txt
@@ -343,6 +343,28 @@ if(TARGET cudaq-qec-realtime-decoding-server-cqr)
           12
       WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
     )
+
+    # Two-process with two logical qubits: the server opens one ring per
+    # decoder and the client must wire each logical qubit's device_call
+    # session to its own ring (QEC_DECODING_SERVER_PORT_<id>, exported by the
+    # test script from the READY line's ring<id>= tokens). The script
+    # additionally asserts per-ring traffic (a client that funnels every
+    # decoder over ring 0 fails even if the totals look right) and exact
+    # per-decoder session stats (resets == shots, errors == 0 — the guard
+    # against concurrent rings losing RPCs to request-id collisions).
+    # Thresholds are the single-logical values scaled by 2.
+    add_test(
+      NAME app_examples.surface_code-1-cqr-two-process-test-distance-3-num-logical-2
+      COMMAND
+        bash "${CMAKE_CURRENT_SOURCE_DIR}/surface_code-1-cqr-two-process-test.sh"
+          ${CMAKE_CURRENT_BINARY_DIR}/surface_code-1-cqr
+          3 120 60
+          $<TARGET_FILE:decoding_server>
+          12
+          multi_error_lut
+          2
+      WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+    )
   endif()
 endif()
 

--- a/libs/qec/unittests/realtime/app_examples/surface_code-1-cqr-two-process-test.sh
+++ b/libs/qec/unittests/realtime/app_examples/surface_code-1-cqr-two-process-test.sh
@@ -29,6 +29,11 @@
 #   5: path to decoding_server executable
 #   6: num_rounds
 #   7: decoder_type (optional, defaults to multi_error_lut)
+#   8: num_logical (optional, defaults to 1). With N > 1 the server opens one
+#      ring per decoder; this script reads each ring<id>=<port> token off the
+#      READY line and exports it as QEC_DECODING_SERVER_PORT_<id>, which is
+#      how the app wires each logical qubit's device_call session to its own
+#      ring. This is the regression test for per-decoder-ring client wiring.
 
 set -e
 
@@ -46,6 +51,7 @@ number_of_corrections_decoder_threshold=$4
 SERVER_PATH=$5
 NUM_ROUNDS=$6
 DECODER_TYPE=${7:-multi_error_lut}
+NUM_LOGICAL=${8:-1}
 
 export CUDAQ_DEFAULT_SIMULATOR=stim
 
@@ -61,7 +67,7 @@ APP_LOG=load_dem-2proc-${FULL_SUFFIX}.log
 
 # [1] Generate the decoder config (no realtime channel needed for this pass).
 $EXE_PATH --distance $DISTANCE --num_rounds $NUM_ROUNDS --num_shots $NUM_SHOTS \
-  --save_dem $CONFIG_FILE \
+  --num_logical $NUM_LOGICAL --save_dem $CONFIG_FILE \
   --decoder_type $DECODER_TYPE | tee save_dem-2proc-$FULL_SUFFIX.log
 
 # [2] Start the decoding server on an ephemeral port with that config.
@@ -73,7 +79,11 @@ if [[ "$TRANSPORT" == "cpu_roce" ]]; then
   SERVER_ARGS+=(--device=${CUDAQ_CPU_ROCE_TEST_DAEMON_DEVICE:-mlx5_0})
   SERVER_ARGS+=(--local-ip=${CUDAQ_CPU_ROCE_TEST_DAEMON_IP:-10.0.0.2})
 fi
-$SERVER_PATH "${SERVER_ARGS[@]}" \
+# QEC_DECODING_SERVER_STATS makes the server print exact per-decoder session
+# counters at shutdown; the assertions below use them to catch RPCs that were
+# dispatched but never reached their session (e.g. correlation collisions
+# between concurrent per-decoder rings).
+QEC_DECODING_SERVER_STATS=1 $SERVER_PATH "${SERVER_ARGS[@]}" \
   > $SERVER_LOG 2>&1 &
 SERVER_PID=$!
 cleanup() {
@@ -97,13 +107,29 @@ if [[ -z "$SERVER_PORT" ]]; then
 fi
 echo "Decoding server ready on $TRANSPORT port $SERVER_PORT"
 
+# With multiple decoders the server serves each on its own ring and the READY
+# line carries one ring<id>=<port> token per decoder. Export ring 1..N-1 as
+# QEC_DECODING_SERVER_PORT_<id> so the app can wire each logical qubit's
+# device_call session to its decoder's ring.
+READY_LINE=$(grep -m1 "QEC_DECODING_SERVER_READY" $SERVER_LOG)
+for ((id = 1; id < NUM_LOGICAL; id++)); do
+  RING_PORT=$(echo "$READY_LINE" | sed -n "s/.*ring${id}=\([0-9]\+\).*/\1/p")
+  if [[ -z "$RING_PORT" ]]; then
+    echo "Error: READY line has no ring${id}= token for decoder ${id}"
+    echo "$READY_LINE"
+    exit 1
+  fi
+  export "QEC_DECODING_SERVER_PORT_${id}=${RING_PORT}"
+  echo "Decoder ${id} ring on port $RING_PORT"
+done
+
 # [3] Run the experiment; QEC_DECODING_SERVER_PORT routes every
 # cudaq::qec::decoding device_call over the selected channel to the server
 # (the app reads QEC_DECODING_SERVER_TRANSPORT for the channel type).
 QEC_DECODING_SERVER_PORT=$SERVER_PORT \
   $EXE_PATH --distance $DISTANCE --num_shots $NUM_SHOTS \
   --load_dem $CONFIG_FILE --num_rounds $NUM_ROUNDS \
-  --decoder_type $DECODER_TYPE \
+  --num_logical $NUM_LOGICAL --decoder_type $DECODER_TYPE \
   |& tee $APP_LOG
 
 # [4] Stop the server and collect its dispatch count.
@@ -136,12 +162,15 @@ fi
 # Two-process self-verification:
 #  - the app's in-process service count must be 0 (nothing decoded locally),
 #  - the server's dispatch count must cover every shot's device_calls
-#    (>= 3 per shot: reset_decoder + enqueues + get_corrections).
+#    (>= 3 per shot per decoder: reset_decoder + enqueues + get_corrections),
+#  - with multiple decoders, EVERY ring must have carried its decoder's share
+#    (the per-decoder-ring wiring regression check: a client that funnels all
+#    decoders over ring 0 fails the per-ring floor even if the total passes).
 if [[ "$inproc_dispatch_count" != "0" ]]; then
   echo "Error: expected in-process CQR dispatch count 0 (got '$inproc_dispatch_count'); decode did not stay in the server"
   return_code=1
 fi
-min_server_dispatches=$((NUM_SHOTS * 3))
+min_server_dispatches=$((NUM_SHOTS * 3 * NUM_LOGICAL))
 if ! [[ "$server_dispatch_count" =~ ^[0-9]+$ ]] || \
    [[ "$server_dispatch_count" -lt $min_server_dispatches ]]; then
   echo "Error: server dispatch count '$server_dispatch_count' is missing or below $min_server_dispatches; device_calls did not cross the $TRANSPORT wire"
@@ -150,6 +179,40 @@ if ! [[ "$server_dispatch_count" =~ ^[0-9]+$ ]] || \
 else
   echo "Server dispatch count check passed ($server_dispatch_count dispatches over $TRANSPORT)"
 fi
+min_ring_dispatches=$((NUM_SHOTS * 3))
+for ((id = 0; id < NUM_LOGICAL; id++)); do
+  ring_dispatched=$(grep "QEC_DECODING_SERVER_RING decoder=${id} " $SERVER_LOG \
+    | sed -n 's/.*dispatched=\([0-9]\+\).*/\1/p')
+  if ! [[ "$ring_dispatched" =~ ^[0-9]+$ ]] || \
+     [[ "$ring_dispatched" -lt $min_ring_dispatches ]]; then
+    echo "Error: decoder ${id}'s ring dispatched '$ring_dispatched' (< $min_ring_dispatches); its device_calls did not cross the $TRANSPORT wire"
+    cat $SERVER_LOG
+    return_code=1
+  else
+    echo "Ring ${id} dispatch count check passed ($ring_dispatched dispatches)"
+  fi
+done
+
+# Exact per-decoder session accounting (QEC_DECODING_SERVER_STATS): every
+# shot resets its decoder exactly once and reads corrections exactly once,
+# and no session may report errors. Ring-level dispatch counts alone cannot
+# catch RPCs that crossed the wire but were then lost before their session
+# (the request_id-collision regression), because a lost blocking RPC still
+# counts as dispatched.
+for ((id = 0; id < NUM_LOGICAL; id++)); do
+  stats_line=$(grep "QEC_DECODING_SERVER_DECODER_STATS id=${id} " $SERVER_LOG)
+  resets=$(echo "$stats_line" | sed -n 's/.*resets=\([0-9]\+\).*/\1/p')
+  corrections=$(echo "$stats_line" | sed -n 's/.*corrections=\([0-9]\+\).*/\1/p')
+  errors=$(echo "$stats_line" | sed -n 's/.*errors=\([0-9]\+\).*/\1/p')
+  if [[ "$resets" != "$NUM_SHOTS" || "$corrections" != "$NUM_SHOTS" || \
+        "$errors" != "0" ]]; then
+    echo "Error: decoder ${id} session stats resets=$resets corrections=$corrections errors=$errors (expected resets=$NUM_SHOTS corrections=$NUM_SHOTS errors=0); RPCs were lost or failed before reaching the session"
+    cat $SERVER_LOG
+    return_code=1
+  else
+    echo "Decoder ${id} session stats check passed (resets=$resets corrections=$corrections errors=$errors)"
+  fi
+done
 
 echo "Two-process test completed for distance $DISTANCE with return code $return_code"
 

--- a/libs/qec/unittests/realtime/app_examples/surface_code-1.cpp
+++ b/libs/qec/unittests/realtime/app_examples/surface_code-1.cpp
@@ -56,7 +56,9 @@
 // of resolving to the in-process trampolines. The decoding is served either by
 // the in-process decoding-server-cqr service
 // (CUDAQ_DEVICE_CALL_CHANNEL=host_dispatch) or by a standalone
-// decoding_server (QEC_DECODING_SERVER_PORT=<port>). The wire to the
+// decoding_server (QEC_DECODING_SERVER_PORT=<port>; with --num_logical N > 1
+// the server opens one ring per decoder, so ring i's port must additionally
+// be supplied as QEC_DECODING_SERVER_PORT_<i>). The wire to the
 // server defaults to udp loopback; set QEC_DECODING_SERVER_TRANSPORT=cpu_roce
 // to use the CPU RoCE RDMA channel instead (works over SoftRoCE/rdma_rxe; the
 // RDMA topology comes from the same CUDAQ_CPU_ROCE_TEST_* env vars as CUDA-Q's
@@ -73,13 +75,17 @@ std::string env_or(const char *name, const std::string &fallback) {
   return (value && *value) ? std::string(value) : fallback;
 }
 
-void initialize_realtime_channel(const char *prog) {
+void initialize_realtime_channel(const char *prog, int num_logical) {
   std::vector<std::string> args = {prog};
   if (const char *port = std::getenv("QEC_DECODING_SERVER_PORT");
       port && *port) {
     const std::string transport =
         env_or("QEC_DECODING_SERVER_TRANSPORT", "udp");
     if (transport == "cpu_roce") {
+      if (num_logical > 1)
+        throw std::runtime_error(
+            "--num_logical > 1 over cpu_roce is not supported by this "
+            "example (only the udp channel wires per-decoder rings here)");
       // The RDMA ring geometry (slots x slot-size) is part of the cpu_roce
       // wire contract: the channel writes requests directly into the server's
       // rings, so these must match decoding_server's --num-slots /
@@ -98,7 +104,31 @@ void initialize_realtime_channel(const char *prog) {
       args.push_back("--cudaq-device-call=udp");
       args.push_back("udp-host=127.0.0.1");
       args.push_back(std::string("udp-port=") + port);
+      // A one-ring-per-decoder server publishes one endpoint per decoder
+      // (READY line: `... ring0=<p0> ring1=<p1> ...`). Wire logical qubit
+      // i's device_call session to its own ring via device-scoped channel
+      // args (QEC_DECODING_SERVER_PORT_<i> -> udp-port.<i>=), the same
+      // convention as surface_code-4-yaml.
+      for (int device = 1; device < num_logical; ++device) {
+        const std::string name =
+            "QEC_DECODING_SERVER_PORT_" + std::to_string(device);
+        const char *scoped = std::getenv(name.c_str());
+        if (!scoped || !*scoped)
+          throw std::runtime_error(
+              name + " is required: with --num_logical " +
+              std::to_string(num_logical) +
+              " the decoding server serves each decoder on its own ring; "
+              "set " +
+              name + " to the ring" + std::to_string(device) +
+              "= port from the server's QEC_DECODING_SERVER_READY line");
+        args.push_back("udp-port." + std::to_string(device) + "=" + scoped);
+      }
     }
+  } else if (!std::getenv("CUDAQ_DEVICE_CALL_CHANNEL")) {
+    throw std::runtime_error(
+        "no realtime channel configured: set QEC_DECODING_SERVER_PORT=<port> "
+        "to decode via a standalone decoding_server (two-process), or "
+        "CUDAQ_DEVICE_CALL_CHANNEL=host_dispatch to decode in-process");
   }
   std::vector<char *> argv;
   for (auto &arg : args)
@@ -814,7 +844,12 @@ void show_help() {
   printf("  --num_shots <int>     Number of shots. Default: 10\n");
   printf("  --p_cnot <double>     Two-qubit depolarizing rate on CNOT gates. "
          "Range[0, 1]. Default: 0.001\n");
-  printf("  --num_logical <int>   Number of logical qubits. Default: 1\n");
+  printf("  --num_logical <int>   Number of logical qubits. Default: 1\n"
+         "      (Two-process runs against a decoding_server serve each\n"
+         "      logical qubit's decoder on its own ring: pass ring 0's port\n"
+         "      as QEC_DECODING_SERVER_PORT and ring i's port as\n"
+         "      QEC_DECODING_SERVER_PORT_<i>, from the server's READY "
+         "line.)\n");
   printf("  --num_rounds <int>    Number of measurement rounds. Default: "
          "distance\n");
   printf("  --seed <int>          Simulator seed for reproducible shots; "
@@ -999,15 +1034,14 @@ int main(int argc, char **argv) {
   auto code = cudaq::qec::get_code(
       "surface_code", cudaqx::heterogeneous_map{{"distance", opts.distance}});
 
-#ifdef QEC_APP_CQR
-  // Bring up the cudaq-realtime device-call channel for the shots' decoding
-  // device_calls. The --save_dem pass only characterizes the DEM (no shots, no
-  // device_calls), so it needs no channel.
-  if (!opts.save_dem)
-    initialize_realtime_channel(argv[0]);
-#endif
-
   try {
+#ifdef QEC_APP_CQR
+    // Bring up the cudaq-realtime device-call channel for the shots' decoding
+    // device_calls. The --save_dem pass only characterizes the DEM (no shots,
+    // no device_calls), so it needs no channel.
+    if (!opts.save_dem)
+      initialize_realtime_channel(argv[0], opts.num_logical);
+#endif
     demo_circuit_host(*code, opts);
   } catch (const std::exception &e) {
     printf("Error: %s\n", e.what());


### PR DESCRIPTION
Two-process `surface_code-1-cqr --num_logical N > 1` was broken: the example only wired decoder 0's ring, and the shared `CqrTransceiver` keyed in-flight blocking RPCs by client request_id - which collides across concurrent per-decoder rings, silently dropping ~30% of resets and corrupting decodes nondeterministically.

- `CqrTransceiver`: correlate responses by a process-unique token instead of the client request_id (restored in the response).
- `surface_code-1.cpp`: wire ring i via `QEC_DECODING_SERVER_PORT_<i>` (same convention as surface_code-4-yaml); clear fail-fast errors replace the opaque "null dispatch session" abort.
- Regression test: two-process num_logical=2 ctest asserting per-ring traffic and exact per-decoder session stats (resets == shots, errors == 0).
