### PR TITLE
Fix sync workflow

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -22,5 +22,10 @@ jobs:
         git config --global user.email "action@github.com"
         git config --global user.name "GitHub Action"
         git remote add upstream https://github.com/NVIDIA/cudaqx
-        git pull --ff-only upstream ${{ github.ref_name }}
+        # LFS objects are stored per repository and are not mirrored by a git
+        # push, so pull without smudging (the objects referenced by new
+        # upstream commits may not exist in this repository's LFS storage
+        # yet), fetch them from upstream, and let the push upload them.
+        GIT_LFS_SKIP_SMUDGE=1 git pull --ff-only upstream ${{ github.ref_name }}
+        git lfs fetch upstream ${{ github.ref_name }}
         git push origin


### PR DESCRIPTION
<!--
Thanks for contributing to CUDA-Q Libraries!

Please read the full Pull Request Guidelines in Contributing.md:
https://github.com/NVIDIA/cudaqx/blob/main/Contributing.md#pull-request-guidelines
-->

## Description

LFS objects are stored per-repository, so the sync workflow mirrors commits but not LFS content. When upstream adds a new LFS file, the pull fails at checkout with a 404 from the mirror's LFS storage.

Fix: pull with GIT_LFS_SKIP_SMUDGE=1, fetch the LFS objects from upstream, and let the existing push upload them to the mirror.

## Runtime / performance impact

<!--
If this change affects performance, paste benchmark numbers here.
Otherwise write "N/A".
-->
N/A

## Self-review checklist

Please confirm each item before requesting review. Check `[x]` or strike
through and explain.

### Before requesting review
- [x] I reviewed my own full diff in GitHub or my editor.
- [x] PR is in Draft if it is not yet ready for review.
- [x] Temporary / debugging changes have been removed.
- [x] Local test logs reviewed; no unexplained warnings or errors.
- [x] CI logs reviewed; no unexplained warnings or errors.
- [x] Full CI has been run.

### Scope and size
- [x] PR is under ~1000 lines, or an exception is justified in the description.
- [x] Refactoring-only changes are isolated in their own PR(s).
- [x] No existing tests were disabled or modified just to make this PR pass
      (if so, an issue has been raised).

### Tests
- [x] New functionality has new tests.
- [x] Tests fail if the new functionality is broken (including crashes), not
      just when it is missing.
- [x] Negative tests added where exceptions are expected.
- [x] Truth data added where simple `EXPECT_*` / `assert` checks are
      insufficient for algorithmic correctness.
- [x] CI runtime impact considered; team notified if significant.

### Documentation
- [x] Public-facing APIs have Doxygen docs.
- [x] User-visible behavior changes have public docs, or a follow-up is
      tracked.

### Code style
- [x] Naming follows the existing convention (`snake_case` vs `camelCase`) for
      the area being modified.

### Dependencies
- [x] No new third-party dependencies, **or** the team has been notified and
      OSRB tickets filed.
