### PR TITLE
[CI] Give each build_wheels.yaml instance distinct artifact names

### DIFF
--- a/.github/workflows/build_wheels.yaml
+++ b/.github/workflows/build_wheels.yaml
@@ -42,7 +42,7 @@ on:
         required: false
       artifact_name_suffix:
         type: string
-        description: Optional suffix to append to every artifact name. Required when more than one instance of this workflow runs within a single parent run, so the instances do not overwrite each other's artifacts. Must match the value used by the run referenced by artifacts_from_run.
+        description: Optional suffix to append to the CUDA-Q wheel, CUDA-QX wheel and metapackage artifact names. Required when more than one instance of this workflow runs within a single parent run, so the instances do not overwrite each other's artifacts. Must match the value used by the run referenced by artifacts_from_run.
         required: false
   workflow_call:
     inputs:
@@ -85,7 +85,7 @@ on:
         required: false
       artifact_name_suffix:
         type: string
-        description: Optional suffix to append to every artifact name. Required when more than one instance of this workflow runs within a single parent run, so the instances do not overwrite each other's artifacts.
+        description: Optional suffix to append to the CUDA-Q wheel, CUDA-QX wheel and metapackage artifact names. Required when more than one instance of this workflow runs within a single parent run, so the instances do not overwrite each other's artifacts.
         default: ''
         required: false
     secrets:
@@ -115,7 +115,7 @@ jobs:
       - name: Upload release assets
         uses: actions/upload-artifact@v4
         with:
-          name: release-assets${{ inputs.artifact_name_suffix }}
+          name: release-assets
           path: '*.tar.gz'
           if-no-files-found: error
           retention-days: 1
@@ -205,7 +205,7 @@ jobs:
         if: ${{ inputs.assets_repo != '' && inputs.assets_tag != '' }}
         uses: actions/download-artifact@v4
         with:
-          name: release-assets${{ inputs.artifact_name_suffix }}
+          name: release-assets
           path: .
 
       - name: Get required CUDAQ version

--- a/.github/workflows/build_wheels.yaml
+++ b/.github/workflows/build_wheels.yaml
@@ -138,9 +138,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: ['3.11', '3.12', '3.13']
-        platform: ['amd64', 'arm64']
-        cuda_version: ['12.6', '13.0']
+        # TEMP(PR767-test): trimmed to one combination. Restore
+        #   python: ['3.11', '3.12', '3.13']
+        #   platform: ['amd64', 'arm64']
+        #   cuda_version: ['12.6', '13.0']
+        # before merging.
+        python: ['3.11']
+        platform: ['amd64']
+        cuda_version: ['12.6']
         toolchain:
           - cc: gcc-12
             cxx: g++-12
@@ -297,8 +302,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platform: ['amd64', 'arm64']
-        cuda_version: ['12.6', '13.0']
+        # TEMP(PR767-test): trimmed to one combination. Restore
+        #   platform: ['amd64', 'arm64']
+        #   cuda_version: ['12.6', '13.0']
+        # before merging.
+        platform: ['amd64']
+        cuda_version: ['12.6']
     # Use 32 CPUs rather than 8 (above) because we are only spawning one job per
     # platform rather than one job per Python version per platform.
     runs-on: ${{ startsWith(github.repository, 'NVIDIA/cudaqx') && format('linux-{0}-cpu32', matrix.platform) || 'ubuntu-latest' }}
@@ -356,8 +365,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: ['3.11', '3.12', '3.13']
-        platform: ['amd64', 'arm64']
+        # TEMP(PR767-test): trimmed to one combination. Restore
+        #   python: ['3.11', '3.12', '3.13']
+        #   platform: ['amd64', 'arm64']
+        # before merging.
+        python: ['3.11']
+        platform: ['amd64']
         cuda_version: ['12.6'] # intentionally not 13.0 because this is CPU.
   
     steps:
@@ -444,7 +457,10 @@ jobs:
   test-wheels-gpu:
     name: Test CUDA-QX wheels (GPU)
     needs: [build-cudaqx-wheels, build-cudaq-wheels]
-    if: ${{ !failure() && !cancelled() }}
+    # TEMP(PR767-test): GPU wheel tests disabled to keep the manual run cheap;
+    # the artifact-name fix is exercised by the CPU test jobs. Restore
+    # `if: ${{ !failure() && !cancelled() }}` before merging.
+    if: false
     runs-on: linux-${{ matrix.runner.arch }}-gpu-${{ matrix.runner.gpu }}-latest-1
     container:
       image: nvidia/cuda:${{ matrix.cuda_version }}.0-base-ubuntu24.04

--- a/.github/workflows/build_wheels.yaml
+++ b/.github/workflows/build_wheels.yaml
@@ -40,6 +40,10 @@ on:
         type: string
         description: Optional suffix to append to CUDA-Q wheel cache keys.
         required: false
+      artifact_name_suffix:
+        type: string
+        description: Optional suffix to append to every artifact name. Required when more than one instance of this workflow runs within a single parent run, so the instances do not overwrite each other's artifacts. Must match the value used by the run referenced by artifacts_from_run.
+        required: false
   workflow_call:
     inputs:
       build_type:
@@ -79,6 +83,11 @@ on:
         type: string
         default: ''
         required: false
+      artifact_name_suffix:
+        type: string
+        description: Optional suffix to append to every artifact name. Required when more than one instance of this workflow runs within a single parent run, so the instances do not overwrite each other's artifacts.
+        default: ''
+        required: false
     secrets:
       CUDAQ_ACCESS_TOKEN:
         required: false
@@ -106,7 +115,7 @@ jobs:
       - name: Upload release assets
         uses: actions/upload-artifact@v4
         with:
-          name: release-assets
+          name: release-assets${{ inputs.artifact_name_suffix }}
           path: '*.tar.gz'
           if-no-files-found: error
           retention-days: 1
@@ -196,7 +205,7 @@ jobs:
         if: ${{ inputs.assets_repo != '' && inputs.assets_tag != '' }}
         uses: actions/download-artifact@v4
         with:
-          name: release-assets
+          name: release-assets${{ inputs.artifact_name_suffix }}
           path: .
 
       - name: Get required CUDAQ version
@@ -241,7 +250,7 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
-          name: wheels-py${{ matrix.python }}-${{ matrix.platform }}-cu${{ steps.config.outputs.cuda_major }}
+          name: wheels-py${{ matrix.python }}-${{ matrix.platform }}-cu${{ steps.config.outputs.cuda_major }}${{ inputs.artifact_name_suffix }}
           path: /wheels/**
           retention-days: 14
 
@@ -276,7 +285,7 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
-          name: metapackages
+          name: metapackages${{ inputs.artifact_name_suffix }}
           path: /metapackages/**
           retention-days: 14
 
@@ -330,7 +339,7 @@ jobs:
       - name: Upload CUDAQ wheels
         uses: actions/upload-artifact@v4
         with:
-          name: cudaq-wheels-${{ matrix.platform }}-cu${{ steps.config.outputs.cuda_major }}
+          name: cudaq-wheels-${{ matrix.platform }}-cu${{ steps.config.outputs.cuda_major }}${{ inputs.artifact_name_suffix }}
           path: /cudaq-wheels
           retention-days: 14
           if-no-files-found: error
@@ -391,7 +400,7 @@ jobs:
         if: ${{ inputs.cudaq_wheels == 'Custom' }}
         uses: actions/download-artifact@v4
         with:
-          name: cudaq-wheels-${{ matrix.platform }}-cu${{ steps.config.outputs.cuda_major }}
+          name: cudaq-wheels-${{ matrix.platform }}-cu${{ steps.config.outputs.cuda_major }}${{ inputs.artifact_name_suffix }}
           path: /cudaq-wheels
           run-id: ${{ steps.config.outputs.run_id_to_use }}
           github-token: ${{ inputs.artifacts_from_run && secrets.WORKFLOW_TOKEN || github.token }}
@@ -399,7 +408,7 @@ jobs:
       - name: Download CUDA-QX Meta Packages
         uses: actions/download-artifact@v4
         with:
-          name: metapackages
+          name: metapackages${{ inputs.artifact_name_suffix }}
           path: /metapackages
           run-id: ${{ steps.config.outputs.run_id_to_use }}
           github-token: ${{ inputs.artifacts_from_run && secrets.WORKFLOW_TOKEN || github.token }}
@@ -407,7 +416,7 @@ jobs:
       - name: Download CUDA-QX wheels
         uses: actions/download-artifact@v4
         with:
-          name: wheels-py${{ matrix.python }}-${{ matrix.platform }}-cu${{ steps.config.outputs.cuda_major }}
+          name: wheels-py${{ matrix.python }}-${{ matrix.platform }}-cu${{ steps.config.outputs.cuda_major }}${{ inputs.artifact_name_suffix }}
           path: /wheels
           run-id: ${{ steps.config.outputs.run_id_to_use }}
           github-token: ${{ inputs.artifacts_from_run && secrets.WORKFLOW_TOKEN || github.token }}
@@ -508,7 +517,7 @@ jobs:
         if: ${{ inputs.cudaq_wheels == 'Custom' }}
         uses: actions/download-artifact@v4
         with:
-          name: cudaq-wheels-${{ matrix.runner.arch }}-cu${{ steps.config.outputs.cuda_major }}
+          name: cudaq-wheels-${{ matrix.runner.arch }}-cu${{ steps.config.outputs.cuda_major }}${{ inputs.artifact_name_suffix }}
           path: /cudaq-wheels
           run-id: ${{ steps.config.outputs.run_id_to_use }}
           github-token: ${{ inputs.artifacts_from_run && secrets.WORKFLOW_TOKEN || github.token }}
@@ -516,7 +525,7 @@ jobs:
       - name: Download CUDA-QX Meta Packages
         uses: actions/download-artifact@v4
         with:
-          name: metapackages
+          name: metapackages${{ inputs.artifact_name_suffix }}
           path: /metapackages
           run-id: ${{ steps.config.outputs.run_id_to_use }}
           github-token: ${{ inputs.artifacts_from_run && secrets.WORKFLOW_TOKEN || github.token }}
@@ -524,7 +533,7 @@ jobs:
       - name: Download CUDA-QX wheels
         uses: actions/download-artifact@v4
         with:
-          name: wheels-py${{ matrix.python }}-${{ matrix.runner.arch }}-cu${{ steps.config.outputs.cuda_major }}
+          name: wheels-py${{ matrix.python }}-${{ matrix.runner.arch }}-cu${{ steps.config.outputs.cuda_major }}${{ inputs.artifact_name_suffix }}
           path: /wheels
           run-id: ${{ steps.config.outputs.run_id_to_use }}
           github-token: ${{ inputs.artifacts_from_run && secrets.WORKFLOW_TOKEN || github.token }}

--- a/.github/workflows/build_wheels.yaml
+++ b/.github/workflows/build_wheels.yaml
@@ -138,14 +138,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # TEMP(PR767-test): trimmed to one combination. Restore
-        #   python: ['3.11', '3.12', '3.13']
-        #   platform: ['amd64', 'arm64']
-        #   cuda_version: ['12.6', '13.0']
-        # before merging.
-        python: ['3.11']
-        platform: ['amd64']
-        cuda_version: ['12.6']
+        python: ['3.11', '3.12', '3.13']
+        platform: ['amd64', 'arm64']
+        cuda_version: ['12.6', '13.0']
         toolchain:
           - cc: gcc-12
             cxx: g++-12
@@ -302,12 +297,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # TEMP(PR767-test): trimmed to one combination. Restore
-        #   platform: ['amd64', 'arm64']
-        #   cuda_version: ['12.6', '13.0']
-        # before merging.
-        platform: ['amd64']
-        cuda_version: ['12.6']
+        platform: ['amd64', 'arm64']
+        cuda_version: ['12.6', '13.0']
     # Use 32 CPUs rather than 8 (above) because we are only spawning one job per
     # platform rather than one job per Python version per platform.
     runs-on: ${{ startsWith(github.repository, 'NVIDIA/cudaqx') && format('linux-{0}-cpu32', matrix.platform) || 'ubuntu-latest' }}
@@ -365,12 +356,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # TEMP(PR767-test): trimmed to one combination. Restore
-        #   python: ['3.11', '3.12', '3.13']
-        #   platform: ['amd64', 'arm64']
-        # before merging.
-        python: ['3.11']
-        platform: ['amd64']
+        python: ['3.11', '3.12', '3.13']
+        platform: ['amd64', 'arm64']
         cuda_version: ['12.6'] # intentionally not 13.0 because this is CPU.
   
     steps:
@@ -457,10 +444,7 @@ jobs:
   test-wheels-gpu:
     name: Test CUDA-QX wheels (GPU)
     needs: [build-cudaqx-wheels, build-cudaq-wheels]
-    # TEMP(PR767-test): GPU wheel tests disabled to keep the manual run cheap;
-    # the artifact-name fix is exercised by the CPU test jobs. Restore
-    # `if: ${{ !failure() && !cancelled() }}` before merging.
-    if: false
+    if: ${{ !failure() && !cancelled() }}
     runs-on: linux-${{ matrix.runner.arch }}-gpu-${{ matrix.runner.gpu }}-latest-1
     container:
       image: nvidia/cuda:${{ matrix.cuda_version }}.0-base-ubuntu24.04

--- a/.github/workflows/nightly_tests.yaml
+++ b/.github/workflows/nightly_tests.yaml
@@ -124,6 +124,14 @@ jobs:
       cache_key_suffix: nightly
       cudaq_repo: ${{ needs.resolve-cudaq-main.outputs.repo }}
       cudaq_ref: ${{ needs.resolve-cudaq-main.outputs.ref }}
+      # This workflow runs build_wheels.yaml a second time within the same run
+      # (see the `wheels` job above, which builds against the pinned
+      # .cudaq_version). Without distinct artifact names the two instances
+      # upload artifacts under identical names, and the test jobs then download
+      # whichever instance happened to finish last. That mixes CUDA-QX wheels
+      # built against one CUDA-Q with the libcudaq of another, producing
+      # sporadic `undefined symbol` ImportErrors.
+      artifact_name_suffix: -cudaq-main
     secrets: inherit
 
   cleanup-nightly-cache:

--- a/.github/workflows/nightly_tests.yaml
+++ b/.github/workflows/nightly_tests.yaml
@@ -1,35 +1,5 @@
 name: Nightly tests
 
-# =============================================================================
-# TEMP(PR767-test): DO NOT MERGE. Revert this entire block and every
-# "TEMP(PR767-test)" marker in this file and in build_wheels.yaml before merging.
-#
-# Purpose: exercise the artifact-name collision fix with a pared-down manual
-# nightly (workflow_dispatch) instead of the full ~2h nightly.
-#
-# What is temporarily changed here:
-#   1. resolve-cudaq-main pins CUDA-Q to 7f0f524a09 instead of resolving main.
-#      That is the ref from nightly run 30883444365 (2026-08-04), which is
-#      post-#5005 and therefore ABI-incompatible with the pinned .cudaq_version
-#      (90b0f4d8, pre-#5005). This recreates the exact skew that produced
-#      "undefined symbol: _ZNK5cudaq16quantum_platform13validateQpuIdEm".
-#   2. build-cudaq-main is disabled. It only populates the /cudaq-install cache
-#      for the lib jobs; the wheel path builds its own CUDA-Q wheels. Disabling
-#      it also transitively skips cudaq-main-{all-libs,qec,solvers,docs}, whose
-#      `needs` include it.
-#   3. cudaq-main-wheels no longer needs build-cudaq-main.
-#   4. cleanup-nightly-cache is disabled so it does not delete the warm
-#      "-nightly" caches (including the pinned CUDA-Q wheels) that keep this
-#      test and its negative-control re-run cheap.
-#
-# build_wheels.yaml is trimmed to one matrix combination; see markers there.
-#
-# Expected result WITH the fix: both "Test CUDA-QX wheels (CPU)" jobs pass and
-# every artifact name is unique. Negative control: drop the
-# "artifact_name_suffix: -cudaq-main" line below and re-run; the pinned
-# instance's test job should then fail on the undefined symbol above.
-# =============================================================================
-
 on:
   schedule:
     - cron: '30 5 * * *' # Runs at 5:30am UTC
@@ -56,10 +26,7 @@ jobs:
         id: resolve
         run: |
           repo=NVIDIA/cuda-quantum
-          # TEMP(PR767-test): pinned instead of resolving main. Restore the
-          # git ls-remote line below before merging.
-          # ref=$(git ls-remote "https://github.com/${repo}.git" refs/heads/main | awk '{print $1}')
-          ref=7f0f524a095143d4ab8d27a8d1fabb2008b29975
+          ref=$(git ls-remote "https://github.com/${repo}.git" refs/heads/main | awk '{print $1}')
 
           if [[ -z "$ref" ]]; then
             echo "Failed to resolve ${repo}@main"
@@ -73,9 +40,6 @@ jobs:
 
   build-cudaq-main:
     name: Build CUDA-Q main
-    # TEMP(PR767-test): disabled; remove this `if` before merging. This also
-    # transitively skips cudaq-main-{all-libs,qec,solvers,docs}.
-    if: false
     needs: resolve-cudaq-main
     strategy:
       fail-fast: false
@@ -152,9 +116,7 @@ jobs:
 
   cudaq-main-wheels:
     name: Wheels against CUDA-Q main
-    # TEMP(PR767-test): build-cudaq-main dropped from needs; restore
-    # `[resolve-cudaq-main, build-cudaq-main]` before merging.
-    needs: [resolve-cudaq-main]
+    needs: [resolve-cudaq-main, build-cudaq-main]
     uses: ./.github/workflows/build_wheels.yaml
     with:
       build_type: Release
@@ -174,9 +136,7 @@ jobs:
 
   cleanup-nightly-cache:
     name: Clean up nightly cache
-    # TEMP(PR767-test): disabled so the warm "-nightly" caches survive for the
-    # negative-control re-run. Restore `if: ${{ always() }}` before merging.
-    if: false
+    if: ${{ always() }}
     needs:
       - wheels
       - resolve-cudaq-main

--- a/.github/workflows/nightly_tests.yaml
+++ b/.github/workflows/nightly_tests.yaml
@@ -1,5 +1,35 @@
 name: Nightly tests
 
+# =============================================================================
+# TEMP(PR767-test): DO NOT MERGE. Revert this entire block and every
+# "TEMP(PR767-test)" marker in this file and in build_wheels.yaml before merging.
+#
+# Purpose: exercise the artifact-name collision fix with a pared-down manual
+# nightly (workflow_dispatch) instead of the full ~2h nightly.
+#
+# What is temporarily changed here:
+#   1. resolve-cudaq-main pins CUDA-Q to 7f0f524a09 instead of resolving main.
+#      That is the ref from nightly run 30883444365 (2026-08-04), which is
+#      post-#5005 and therefore ABI-incompatible with the pinned .cudaq_version
+#      (90b0f4d8, pre-#5005). This recreates the exact skew that produced
+#      "undefined symbol: _ZNK5cudaq16quantum_platform13validateQpuIdEm".
+#   2. build-cudaq-main is disabled. It only populates the /cudaq-install cache
+#      for the lib jobs; the wheel path builds its own CUDA-Q wheels. Disabling
+#      it also transitively skips cudaq-main-{all-libs,qec,solvers,docs}, whose
+#      `needs` include it.
+#   3. cudaq-main-wheels no longer needs build-cudaq-main.
+#   4. cleanup-nightly-cache is disabled so it does not delete the warm
+#      "-nightly" caches (including the pinned CUDA-Q wheels) that keep this
+#      test and its negative-control re-run cheap.
+#
+# build_wheels.yaml is trimmed to one matrix combination; see markers there.
+#
+# Expected result WITH the fix: both "Test CUDA-QX wheels (CPU)" jobs pass and
+# every artifact name is unique. Negative control: drop the
+# "artifact_name_suffix: -cudaq-main" line below and re-run; the pinned
+# instance's test job should then fail on the undefined symbol above.
+# =============================================================================
+
 on:
   schedule:
     - cron: '30 5 * * *' # Runs at 5:30am UTC
@@ -26,7 +56,10 @@ jobs:
         id: resolve
         run: |
           repo=NVIDIA/cuda-quantum
-          ref=$(git ls-remote "https://github.com/${repo}.git" refs/heads/main | awk '{print $1}')
+          # TEMP(PR767-test): pinned instead of resolving main. Restore the
+          # git ls-remote line below before merging.
+          # ref=$(git ls-remote "https://github.com/${repo}.git" refs/heads/main | awk '{print $1}')
+          ref=7f0f524a095143d4ab8d27a8d1fabb2008b29975
 
           if [[ -z "$ref" ]]; then
             echo "Failed to resolve ${repo}@main"
@@ -40,6 +73,9 @@ jobs:
 
   build-cudaq-main:
     name: Build CUDA-Q main
+    # TEMP(PR767-test): disabled; remove this `if` before merging. This also
+    # transitively skips cudaq-main-{all-libs,qec,solvers,docs}.
+    if: false
     needs: resolve-cudaq-main
     strategy:
       fail-fast: false
@@ -116,7 +152,9 @@ jobs:
 
   cudaq-main-wheels:
     name: Wheels against CUDA-Q main
-    needs: [resolve-cudaq-main, build-cudaq-main]
+    # TEMP(PR767-test): build-cudaq-main dropped from needs; restore
+    # `[resolve-cudaq-main, build-cudaq-main]` before merging.
+    needs: [resolve-cudaq-main]
     uses: ./.github/workflows/build_wheels.yaml
     with:
       build_type: Release
@@ -136,7 +174,9 @@ jobs:
 
   cleanup-nightly-cache:
     name: Clean up nightly cache
-    if: ${{ always() }}
+    # TEMP(PR767-test): disabled so the warm "-nightly" caches survive for the
+    # negative-control re-run. Restore `if: ${{ always() }}` before merging.
+    if: false
     needs:
       - wheels
       - resolve-cudaq-main


### PR DESCRIPTION
## Problem

`nightly_tests.yaml` invokes `build_wheels.yaml` **twice** within a single run:

- `wheels` — builds against the pinned `.cudaq_version`
- `cudaq-main-wheels` — builds against CUDA-Q `main`

Both instances uploaded artifacts under **identical names**. Every wheel artifact
appears exactly twice per nightly run — all four `cudaq-wheels-{arch}-cu1{2,3}`,
all twelve `wheels-py3.*`, and `metapackages`. For example, in run
[30883444365](https://github.com/NVIDIA/cudaqx/actions/runs/30883444365):

| Artifact ID | Name | Uploaded | Built against |
|---|---|---|---|
| 8882160104 | `cudaq-wheels-amd64-cu12` | 06:17:34 | pinned, CUDA-Q `90b0f4d8` |
| 8882752498 | `cudaq-wheels-amd64-cu12` | 06:45:11 | main, CUDA-Q `7f0f524a` |

`actions/download-artifact` resolves by name, so the test jobs pick up whichever
instance finished last. The pinned CPU test job downloaded `8882752498` —
main's CUDA-Q wheels — while testing CUDA-QX wheels built against the pin.

The ABI mismatch then surfaces as an `ImportError` on whatever symbol happens to
differ between the two CUDA-Q revisions. In the run above, CUDA-Q
[#5005](https://github.com/NVIDIA/cuda-quantum/pull/5005) changed a
`quantum_platform` member that is called from inline header code, so it leaks
into every downstream `.so`:

libcudaq-qec.so: undefined symbol: _ZNK5cudaq16quantum_platform13validateQpuIdEm

Because this is a race between two upload jobs, it fails **sporadically** across
architectures and Python versions rather than consistently — and it is not new.
The Aug 1 nightly failed the same way on a different symbol
(`_ZN14cudaq_internal8compiler13compileModuleE...`), simply because that was the
symbol that differed at the time.

## Fix

Add an optional `artifact_name_suffix` input to `build_wheels.yaml` and append it
to every artifact name (4 uploads and their 8 matching downloads across the CPU
and GPU test jobs). `nightly_tests.yaml` passes `-cudaq-main` from the CUDA-Q
main instance, so the two instances produce disjoint sets:

cudaq-wheels-amd64-cu12              <- pinned (.cudaq_version)
cudaq-wheels-amd64-cu12-cudaq-main   <- CUDA-Q main

The pinned instance keeps the default empty suffix, so its artifact names are
**unchanged** — this matters because `pr_workflow.yaml` and the
`artifacts_from_run` path both reference these names.

## Notes for reviewers

- **`artifacts_from_run` requires a matching suffix.** It reuses a prior run's
  artifacts by name, so re-running against a nightly that used `-cudaq-main`
  means passing the same `artifact_name_suffix`. This is documented in the
  `workflow_dispatch` input description, and the input is exposed there so it is
  settable from the UI — but it is a manual step.
- **A related latent issue is not addressed here.** In
  `get-cudaq-wheels/action.yaml` (and `get-cudaq-build`), `restore-keys` is the
  full cache key minus the `-nightly` suffix, so suffixed and unsuffixed callers
  share a cache pool. It is harmless today because the CUDA-Q ref is part of the
  key, and it is unrelated to these failures.

## Testing

YAML validated for both files. Full verification requires a nightly run or a
manual `workflow_dispatch`; this has not yet been exercised end to end.