### PR TITLE
[QEC] Relax surface_code-1 emulate test tolerances for noise-model runs

### DIFF
--- a/libs/qec/unittests/realtime/app_examples/CMakeLists.txt
+++ b/libs/qec/unittests/realtime/app_examples/CMakeLists.txt
@@ -412,9 +412,14 @@ add_test(
     bash "${CMAKE_CURRENT_SOURCE_DIR}/surface_code-1-test.sh"
       ${CMAKE_CURRENT_BINARY_DIR}/surface_code-1-local
       ${CMAKE_CURRENT_BINARY_DIR}/surface_code-1-quantinuum-emulate
-      # QIR emulation applies no noise, so the live generate-and-decode run
-      # finds 0 errors / 0 corrections: this is a lowering + run smoke test.
-      3 0 0 NULL 12
+      # surface_code-1 attaches its noise via a host-side cudaq::noise_model
+      # (not in-kernel cudaq::apply_noise, which the erase-noise pass strips).
+      # Whether that model reaches the simulator under --emulate depends on the
+      # CUDA-Q version, so the run finds either 0 errors / 0 corrections or a
+      # realistic handful of both. Bound the residual logical errors the same
+      # way the local tests do and leave the corrections bound at 0, so this
+      # passes either way. This remains primarily a lowering + run smoke test.
+      3 60 0 NULL 12
       ${CMAKE_BINARY_DIR}/lib
   WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
 )
@@ -425,7 +430,8 @@ add_test(
     bash "${CMAKE_CURRENT_SOURCE_DIR}/surface_code-1-test.sh"
       ${CMAKE_CURRENT_BINARY_DIR}/surface_code-1-local
       ${CMAKE_CURRENT_BINARY_DIR}/surface_code-1-quantinuum-emulate
-      5 0 0 NULL 5
+      # See the distance-3 test above for why the non-zero bound is not 0.
+      5 60 0 NULL 5
       ${CMAKE_BINARY_DIR}/lib
   WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
 )


### PR DESCRIPTION
The two surface_code-1 --target quantinuum --emulate tests assert that the live generate-and-decode run finds exactly 0 residual logical errors, on the premise recorded in the CMake comment that "QIR emulation applies no noise".

That premise no longer holds on recent CUDA-Q (since NVIDIA/cuda-quantum#5051. surface_code-1 attaches its circuit-level depolarizing noise through a host-side cudaq::noise_model handed to cudaq::run, and the noise model travels on the ExecutionContext