### PR TITLE
[Core] Add rvalue insert overload to heterogeneous_map

### DIFF
--- a/docs/sphinx/conf.py.in
+++ b/docs/sphinx/conf.py.in
@@ -250,6 +250,8 @@ nitpick_ignore = [
     ('cpp:identifier', 'details'),
     ('cpp:identifier', 'spin_op'),
     ('cpp:identifier', 'heterogeneous_map'),
+    ('cpp:identifier', 'is_bounded_char_array<std::remove_cv_t<T>>'),
+    ('cpp:identifier', 'is_bounded_char_array<std::remove_cv_t<T>>::value'),
     ('cpp:identifier', 'cudaq::qkernel<void(cudaq::qvector<>&)>'),
     ('cpp:identifier', 'cudaq::qkernel<void(patch)>'),
     ('cpp:identifier', 'cudaq::qkernel<void(patch, patch)>'),

--- a/libs/core/include/cuda-qx/core/heterogeneous_map.h
+++ b/libs/core/include/cuda-qx/core/heterogeneous_map.h
@@ -82,6 +82,20 @@ public:
     }
   }
 
+  /// @brief Insert a key-value pair into the map, moving the value in
+  /// @tparam T The type of the value
+  /// @param key The key
+  /// @param value The value, moved into the map
+  /// @note Only participates in overload resolution for rvalues; lvalues go to
+  /// the copying overload above. Useful for large payloads (e.g. LLR histories)
+  /// where the extra deep copy is expensive.
+  template <typename T, typename = std::enable_if_t<
+                            !std::is_lvalue_reference_v<T> &&
+                            !is_bounded_char_array<std::remove_cv_t<T>>::value>>
+  void insert(const std::string &key, T &&value) {
+    items.insert_or_assign(key, std::move(value));
+  }
+
   /// @brief Get a value from the map
   /// @tparam T The type of the value to retrieve
   /// @param key The key of the value to retrieve

--- a/libs/core/include/cuda-qx/core/heterogeneous_map.h
+++ b/libs/core/include/cuda-qx/core/heterogeneous_map.h
@@ -87,8 +87,8 @@ public:
   /// @param key The key
   /// @param value The value, moved into the map
   /// @note Only participates in overload resolution for rvalues; lvalues go to
-  /// the copying overload above. Useful for large payloads (e.g. LLR histories)
-  /// where the extra deep copy is expensive.
+  /// the copying overload above. Useful for large payloads where the extra
+  /// deep copy is expensive.
   template <typename T, typename = std::enable_if_t<
                             !std::is_lvalue_reference_v<T> &&
                             !is_bounded_char_array<std::remove_cv_t<T>>::value>>

--- a/libs/core/unittests/test_core.cpp
+++ b/libs/core/unittests/test_core.cpp
@@ -929,6 +929,51 @@ TEST(HeterogeneousMapTest, MoveAssignmentOperator) {
   EXPECT_EQ(source_map.size(), 0);
 }
 
+TEST(HeterogeneousMapTest, InsertMoveVector) {
+  cudaqx::heterogeneous_map map;
+  std::vector<double> data = {1.0, 2.0, 3.0, 4.0};
+  map.insert("vec", std::move(data));
+
+  EXPECT_TRUE(data.empty()); // source was moved from
+  auto retrieved = map.get<std::vector<double>>("vec");
+  EXPECT_EQ(retrieved.size(), 4u);
+  EXPECT_DOUBLE_EQ(retrieved[0], 1.0);
+  EXPECT_DOUBLE_EQ(retrieved[3], 4.0);
+}
+
+TEST(HeterogeneousMapTest, InsertMoveLargePayload) {
+  cudaqx::heterogeneous_map map;
+  std::vector<std::vector<float>> llr_history(100,
+                                               std::vector<float>(200, 0.5f));
+  map.insert("llr_history", std::move(llr_history));
+
+  EXPECT_TRUE(llr_history.empty()); // outer vector was moved from
+  auto stored = map.get<std::vector<std::vector<float>>>("llr_history");
+  EXPECT_EQ(stored.size(), 100u);
+  EXPECT_EQ(stored[0].size(), 200u);
+  EXPECT_FLOAT_EQ(stored[0][0], 0.5f);
+}
+
+TEST(HeterogeneousMapTest, InsertMoveOverwrites) {
+  cudaqx::heterogeneous_map map;
+  map.insert("key", std::vector<int>{1, 2, 3});
+  map.insert("key", std::vector<int>{10, 20});
+
+  auto v = map.get<std::vector<int>>("key");
+  EXPECT_EQ(v.size(), 2u);
+  EXPECT_EQ(v[0], 10);
+  EXPECT_EQ(v[1], 20);
+}
+
+TEST(HeterogeneousMapTest, InsertLvalueNotMoved) {
+  cudaqx::heterogeneous_map map;
+  std::vector<int> src = {7, 8, 9};
+  map.insert("vec", src); // lvalue — must go through copy overload
+
+  EXPECT_EQ(src.size(), 3u); // source intact
+  EXPECT_EQ(map.get<std::vector<int>>("vec"), src);
+}
+
 TEST(GraphTester, AddEdge) {
   cudaqx::graph g;
   g.add_edge(1, 2, 1.5);

--- a/libs/core/unittests/test_core.cpp
+++ b/libs/core/unittests/test_core.cpp
@@ -944,7 +944,7 @@ TEST(HeterogeneousMapTest, InsertMoveVector) {
 TEST(HeterogeneousMapTest, InsertMoveLargePayload) {
   cudaqx::heterogeneous_map map;
   std::vector<std::vector<float>> llr_history(100,
-                                               std::vector<float>(200, 0.5f));
+                                              std::vector<float>(200, 0.5f));
   map.insert("llr_history", std::move(llr_history));
 
   EXPECT_TRUE(llr_history.empty()); // outer vector was moved from

--- a/libs/qec/python/bindings/type_casters.h
+++ b/libs/qec/python/bindings/type_casters.h
@@ -126,7 +126,10 @@ struct type_caster<cudaqx::heterogeneous_map> {
     }
   }
 
-  static handle from_cpp(cudaqx::heterogeneous_map v, rv_policy,
+  // Take by const-reference: the map can hold large payloads (e.g. the
+  // bp_llr_history LLR matrix), and a by-value parameter deep-copied all of it
+  // on every conversion.
+  static handle from_cpp(const cudaqx::heterogeneous_map &v, rv_policy,
                          cleanup_list *) noexcept {
     try {
       nb::dict result;


### PR DESCRIPTION
- Adds a move-enabled insert(key, T&&) overload to heterogeneous_map that avoids an unnecessary deep copy when inserting rvalues (e.g. large vectors, nested containers)
- The overload uses SFINAE to restrict to rvalues only — lvalues continue to resolve to the existing copying overload, so the change is fully backward-compatible
- Adds four unit tests covering: move-from-vector, large payload move, overwrite-via-move, and lvalue-not-moved

Motivation

When inserting large payloads (e.g. syndrome history, LLR buffers) the existing copy-only insert forced an extra deep copy. The new overload lets callers pass std::move(large_object) to avoid that allocation.