### PR TITLE
[QEC] Accept both cc.StdvecType and cc.SequenceType in py_code

### DIFF
--- a/libs/qec/python/bindings/py_code.cpp
+++ b/libs/qec/python/bindings/py_code.cpp
@@ -151,9 +151,14 @@ public:
         if (!retTyObj.is_none()) {
           nb::object cc =
               nb::module_::import_("cudaq.mlir.dialects").attr("cc");
-          nb::object stdvecTy = cc.attr("StdvecType");
-          if (nb::cast<bool>(stdvecTy.attr("isinstance")(retTyObj))) {
-            nb::object eleTy = stdvecTy.attr("getElementType")(retTyObj);
+          // CUDA-Q renamed cc.StdvecType to cc.SequenceType (cuda-quantum
+          // #5089). Accept either name so this keeps working across both the
+          // pinned CUDA-Q version and main.
+          nb::object seqTy = nb::hasattr(cc, "SequenceType")
+                                 ? cc.attr("SequenceType")
+                                 : cc.attr("StdvecType");
+          if (nb::cast<bool>(seqTy.attr("isinstance")(retTyObj))) {
+            nb::object eleTy = seqTy.attr("getElementType")(retTyObj);
             returnsHandleVector = nb::cast<bool>(
                 cc.attr("MeasureHandleType").attr("isinstance")(eleTy));
           }


### PR DESCRIPTION
CUDA-Q renamed the internal cc.StdvecType to cc.SequenceType in NVIDIA/cuda-quantum#5089, which broke the stabilizer_round return-type validation in the Python code bindings with:

  AttributeError: module 'cudaq.mlir.dialects.cc' has no attribute
  'StdvecType'

Look up either name so the bindings work against both the currently pinned CUDA-Q version and CUDA-Q main. The two types expose the same isinstance/getElementType classmethods, so the validation logic is unchanged.