### PR TITLE
Making the cudaq build stage optional. Default is unchanged.

### DIFF
--- a/docker/build_env/cudaqx.dev.Dockerfile
+++ b/docker/build_env/cudaqx.dev.Dockerfile
@@ -7,7 +7,9 @@
 # ============================================================================ #
 
 ARG base_image=ghcr.io/nvidia/cuda-quantum-devcontainer:amd64-cu12.6-gcc12-main
-FROM $base_image
+# Selects the final stage below; must be lowercase, since stage names are.
+ARG build_cudaq=on
+FROM $base_image AS deps
 
 ARG cuda_version=12.6
 
@@ -20,6 +22,12 @@ RUN apt-get update && CUDA_DASH=$(echo $cuda_version | tr '.' '-') \
   && apt-get install -y gfortran libblas-dev jq cuda-nvtx-${CUDA_DASH} \
   && apt-get install -y git-lfs \
   && apt-get autoremove -y --purge && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# build_cudaq=off: dev tools only, with no CUDA-Q source, build scripts, or
+# install prefix baked in, so CUDA-Q can be built anywhere later.
+FROM deps AS cudaq-off
+
+FROM deps AS cudaq-on
 
 COPY .cudaq_version /cudaq_version
 COPY scripts/build_cudaq_with_realtime.sh /usr/local/bin/build_cudaq_with_realtime.sh
@@ -40,3 +48,5 @@ RUN mkdir -p /workspaces/cudaq && cd /workspaces/cudaq \
 #RUN mkdir -p /workspaces/cudaqx && cd /workspaces/cudaqx \
 #  && cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -DCUDAQ_DIR=/usr/local/cudaq/lib/cmake/cudaq .. \
 #  && ninja install
+
+FROM cudaq-${build_cudaq}


### PR DESCRIPTION
## Description

I would like the ability to build an image for realtime development by composing the docker files for cudaqx and the [realtime](https://github.com/NVIDIA/cuda-quantum/blob/main/realtime/docker/assets.Dockerfile). In this process, I would need this docker file to skip the build part so development can use any cudaq build. 

The default behavior is unchanged and cudaq is still built in CI.

This is achieved by using a parametrized FROM.

## Runtime / performance impact

"N/A".


## Self-review checklist

Please confirm each item before requesting review. Check `[x]` or strike
through and explain.

### Before requesting review
- [x] I reviewed my own full diff in GitHub or my editor.
- [ ] PR is in Draft if it is not yet ready for review.
- [x] Temporary / debugging changes have been removed.
- [ ] Local test logs reviewed; no unexplained warnings or errors.
- [x] CI logs reviewed; no unexplained warnings or errors.
- [x] Full CI has been run. (These are ci file changes only but I ran "All libs" and "Build Dev image")

### Scope and size
- [x] PR is under ~1000 lines, or an exception is justified in the description.
- [x] Refactoring-only changes are isolated in their own PR(s).
- [x] No existing tests were disabled or modified just to make this PR pass
      (if so, an issue has been raised).

### Tests
- [ ] New functionality has new tests.
- [ ] Tests fail if the new functionality is broken (including crashes), not
      just when it is missing.
- [ ] Negative tests added where exceptions are expected.
- [ ] Truth data added where simple `EXPECT_*` / `assert` checks are
      insufficient for algorithmic correctness.
- [ ] CI runtime impact considered; team notified if significant.

### Documentation
- [ ] Public-facing APIs have Doxygen docs.
- [ ] User-visible behavior changes have public docs, or a follow-up is
      tracked.

### Code style
- [x] Naming follows the existing convention (`snake_case` vs `camelCase`) for
      the area being modified.

### Dependencies
- [x] No new third-party dependencies, **or** the team has been notified and
      OSRB tickets filed.
