### PR TITLE
Consolidate realtime dependency building.

### DIFF
--- a/.github/actions/build-lib/build_qec.sh
+++ b/.github/actions/build-lib/build_qec.sh
@@ -25,77 +25,9 @@ if [ -z "$CUDAQ_REALTIME_ROOT" ]; then
   git checkout "$CUDAQ_REF"
 
   # Install build tools and DOCA/Holoscan SDK for HSB.
-  # The cudaqx CI container has Mellanox OFED pre-installed, so we cannot use
-  # install_dev_prerequisites.sh (it installs doca-all which conflicts with
-  # the container's OFED packages). Instead, install only the DOCA dev headers
-  # and Holoscan SDK that we actually need.
-  CUDA_MAJOR_VERSION=$(nvcc --version | sed -n 's/^.*release \([0-9]\+\).*$/\1/p')
-  apt-get update && apt-get install -y --no-install-recommends \
-    ninja-build curl pkg-config
-
-  # Add DOCA repo and install only the GPUNetIO dev package (not doca-all)
-  DOCA_ARCH=$(uname -m)
-  case "$DOCA_ARCH" in aarch64|arm64) DOCA_ARCH="arm64-sbsa" ;; esac
-  DOCA_REPO="https://linux.mellanox.com/public/repo/doca/3.3.0/ubuntu24.04/$DOCA_ARCH"
-  curl -fsSL "$DOCA_REPO/GPG-KEY-Mellanox.pub" -o /usr/share/keyrings/GPG-KEY-Mellanox.pub
-  echo "deb [signed-by=/usr/share/keyrings/GPG-KEY-Mellanox.pub] $DOCA_REPO /" \
-    > /etc/apt/sources.list.d/doca.list
-  apt-get update
-  apt-get -y install --no-install-recommends libdoca-sdk-gpunetio-dev
-
-  # hololink_core links CUDA::nvrtc -- must match the exact toolkit version
-  CUDA_FULL_VERSION=$(nvcc --version | sed -n 's/^.*release \([0-9]\+\.[0-9]\+\).*$/\1/p')
-  CUDA_VER_DASH=$(echo $CUDA_FULL_VERSION | sed 's/\./-/')
-  apt-get install -y cuda-nvrtc-dev-$CUDA_VER_DASH 2>/dev/null || true
-
-  # Holoscan SDK (force-install if normal install fails due to missing deps)
-  apt-get install -y --no-install-recommends holoscan-cuda-$CUDA_MAJOR_VERSION || {
-    _hsdk_tmp=$(mktemp -d)
-    (cd "$_hsdk_tmp" && apt-get download holoscan holoscan-cuda-$CUDA_MAJOR_VERSION \
-      && dpkg --force-depends -i holoscan*.deb)
-    rm -rf "$_hsdk_tmp"
-  }
-
-  # Build holoscan-sensor-bridge (HSB) FIRST, so cuda-quantum realtime
-  # can build the bridge-gpu-roce wrapper library that links against it.
-  HSB_REPO=https://github.com/nvidia-holoscan/holoscan-sensor-bridge.git
-  HSB_REF=2.6.0-EA2
-  HSB_ROOT=/tmp/holoscan-sensor-bridge
+  export HSB_ROOT=/tmp/holoscan-sensor-bridge
   HSB_BUILD=${HSB_ROOT}/build
-
-  if [ ! -d /opt/mellanox/doca/include ]; then
-    echo "ERROR: DOCA SDK installation failed" >&2
-    exit 1
-  fi
-  if [ ! -d /opt/nvidia/holoscan ]; then
-    echo "ERROR: Holoscan SDK installation failed" >&2
-    exit 1
-  fi
-
-  cd /tmp
-  rm -rf holoscan-sensor-bridge
-  git clone --depth 1 --branch $HSB_REF $HSB_REPO holoscan-sensor-bridge
-  cd holoscan-sensor-bridge
-  # Strip operators we don't need to avoid configure failures from missing deps
-  sed -i '/add_subdirectory(audio_packetizer)/d; /add_subdirectory(compute_crc)/d;
-          /add_subdirectory(csi_to_bayer)/d; /add_subdirectory(image_processor)/d;
-          /add_subdirectory(iq_dec)/d; /add_subdirectory(iq_enc)/d;
-          /add_subdirectory(linux_coe_receiver)/d; /add_subdirectory(linux_receiver)/d;
-          /add_subdirectory(packed_format_converter)/d; /add_subdirectory(sub_frame_combiner)/d;
-          /add_subdirectory(udp_transmitter)/d; /add_subdirectory(emulator)/d;
-          /add_subdirectory(sig_gen)/d; /add_subdirectory(sig_viewer)/d' \
-    src/hololink/operators/CMakeLists.txt
-  export CUDA_NATIVE_ARCH=80
-  cmake -G Ninja -S . -B build \
-    -DCMAKE_BUILD_TYPE=Release \
-    -DHOLOLINK_BUILD_ONLY_NATIVE=OFF \
-    -DHOLOLINK_BUILD_PYTHON=OFF \
-    -DHOLOLINK_BUILD_TESTS=OFF \
-    -DHOLOLINK_BUILD_TOOLS=OFF \
-    -DHOLOLINK_BUILD_EXAMPLES=OFF \
-    -DHOLOLINK_BUILD_EMULATOR=OFF
-  cmake --build build --target gpu_roce_transceiver hololink_core
-  echo "holoscan-sensor-bridge built at $HSB_BUILD"
+  bash /tmp/cudaq-realtime-src/realtime/scripts/install_devdeps.sh
 
   # Build cuda-quantum realtime with HSB tools enabled,
   # which produces libcudaq-realtime-bridge-gpu-roce.so needed by the bridge.


### PR DESCRIPTION

## Description

This PR will follow https://github.com/NVIDIA/cuda-quantum/pull/5227, whereby the scripts responsible for building the realtime dependencies are consolidated.

With this change `buid_qec.sh` will be using a script provided by the realtime, to build the realtime dependencies.

## Runtime / performance impact
"N/A"

## Self-review checklist

Please confirm each item before requesting review. Check `[x]` or strike
through and explain.

### Before requesting review
- [x] I reviewed my own full diff in GitHub or my editor.
- [ ] PR is in Draft if it is not yet ready for review.
- [x] Temporary / debugging changes have been removed.
- [ ] Local test logs reviewed; no unexplained warnings or errors.
- [x] CI logs reviewed; no unexplained warnings or errors.
- [x] Full CI has been run.

### Scope and size
- [x] PR is under ~1000 lines, or an exception is justified in the description.
- [x] Refactoring-only changes are isolated in their own PR(s).
- [x] No existing tests were disabled or modified just to make this PR pass
      (if so, an issue has been raised).

### Tests
- [ ] New functionality has new tests.
- [ ] Tests fail if the new functionality is broken (including crashes), not
      just when it is missing.
- [ ] Negative tests added where exceptions are expected.
- [ ] Truth data added where simple `EXPECT_*` / `assert` checks are
      insufficient for algorithmic correctness.
- [ ] CI runtime impact considered; team notified if significant.

### Documentation
- [ ] Public-facing APIs have Doxygen docs.
- [ ] User-visible behavior changes have public docs, or a follow-up is
      tracked.

### Code style
- [x] Naming follows the existing convention (`snake_case` vs `camelCase`) for
      the area being modified.

### Dependencies
- [x] No new third-party dependencies, **or** the team has been notified and
      OSRB tickets filed.
