### PR TITLE
Deprecate Solvers

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,26 @@ To learn more about how to work with the CUDA-QX libraries, please take a look a
 [cudaqx_docs]: https://nvidia.github.io/cudaqx
 [official_install]: https://nvidia.github.io/cudaqx/quickstart/installation.html
 
+## CUDA-Q Solvers is deprecated
+
+CUDA-Q Solvers 0.6.0 is the final planned release of that library. Development
+continues in [CUDA-Q Algorithms][cudaq_algorithms_github], which supersedes
+CUDA-Q Solvers and expands on it:
+
+```bash
+pip install cudaq-algorithms
+```
+
+See the [CUDA-Q Algorithms documentation][cudaq_algorithms_docs] for tutorials
+and examples, [cudaq-algorithms on PyPI][cudaq_algorithms_pypi] for the package,
+and [NVIDIA/cudaq-algorithms on GitHub][cudaq_algorithms_github] for the source
+code. The CUDA-Q QEC library in this repository is unaffected and continues to
+be developed here.
+
+[cudaq_algorithms_docs]: https://nvidia.github.io/cudaq-algorithms/
+[cudaq_algorithms_pypi]: https://pypi.org/project/cudaq-algorithms/
+[cudaq_algorithms_github]: https://github.com/NVIDIA/cudaq-algorithms
+
 ## Contributing
 
 There are many ways in which you can get involved with CUDA-QX. If you are

--- a/docs/sphinx/_solvers_deprecation.rst
+++ b/docs/sphinx/_solvers_deprecation.rst
@@ -1,0 +1,16 @@
+.. attention::
+
+   **CUDA-Q Solvers is deprecated.** Version 0.6.0 is the final planned
+   release of the CUDA-Q Solvers library. Development continues in **CUDA-Q
+   Algorithms**, which supersedes CUDA-Q Solvers and expands on it.
+
+   * Documentation, tutorials, and examples:
+     `CUDA-Q Algorithms documentation <https://nvidia.github.io/cudaq-algorithms/>`__.
+   * Install it with :code:`pip install cudaq-algorithms`
+     (`cudaq-algorithms on PyPI <https://pypi.org/project/cudaq-algorithms/>`__).
+   * Source code: `NVIDIA/cudaq-algorithms on GitHub
+     <https://github.com/NVIDIA/cudaq-algorithms>`__.
+
+   Existing code continues to work with CUDA-Q Solvers 0.6.0, but all new
+   features and fixes land in CUDA-Q Algorithms. We encourage every CUDA-Q
+   Solvers user to migrate.

--- a/docs/sphinx/api/solvers/cpp_api.rst
+++ b/docs/sphinx/api/solvers/cpp_api.rst
@@ -1,6 +1,8 @@
 CUDA-Q Solvers C++ API
 ******************************
 
+.. include:: /_solvers_deprecation.rst
+
 .. doxygenclass:: cudaq::solvers::operator_pool 
     :members:
 

--- a/docs/sphinx/api/solvers/gqe_api.rst
+++ b/docs/sphinx/api/solvers/gqe_api.rst
@@ -1,5 +1,3 @@
-.. include:: /_solvers_deprecation.rst
-
 .. function:: gqe(cost, pool, config=None, **kwargs)
 
     Run the Generative Quantum Eigensolver algorithm.

--- a/docs/sphinx/api/solvers/gqe_api.rst
+++ b/docs/sphinx/api/solvers/gqe_api.rst
@@ -1,3 +1,5 @@
+.. include:: /_solvers_deprecation.rst
+
 .. function:: gqe(cost, pool, config=None, **kwargs)
 
     Run the Generative Quantum Eigensolver algorithm.

--- a/docs/sphinx/api/solvers/python_api.rst
+++ b/docs/sphinx/api/solvers/python_api.rst
@@ -1,6 +1,8 @@
 CUDA-Q Solvers Python API
 ******************************
 
+.. include:: /_solvers_deprecation.rst
+
 .. automodule:: cudaq_solvers
     :members:
 

--- a/docs/sphinx/components/solvers/introduction.rst
+++ b/docs/sphinx/components/solvers/introduction.rst
@@ -1,6 +1,8 @@
 CUDA-Q Solvers Library
 =======================
 
+.. include:: /_solvers_deprecation.rst
+
 Overview
 --------
 The CUDA-Q Solvers library provides high-level quantum-classical hybrid 

--- a/docs/sphinx/conf.py.in
+++ b/docs/sphinx/conf.py.in
@@ -112,6 +112,7 @@ exclude_patterns = [
     'api/qec/cpp_realtime_decoding_api.rst',
     'api/qec/realtime_pipeline_api.rst',
     'api/solvers/gqe_api.rst',
+    '_solvers_deprecation.rst',
 ]
 
 # The reST default role (used for this markup: `text`) to use for all documents.

--- a/docs/sphinx/examples_rst/solvers/adapt.rst
+++ b/docs/sphinx/examples_rst/solvers/adapt.rst
@@ -1,6 +1,8 @@
 ADAPT-VQE
 ---------
 
+.. include:: /_solvers_deprecation.rst
+
 ADAPT-VQE is an advanced quantum algorithm designed to improve upon the
 standard Variational Quantum Eigensolver (VQE) approach for solving quantum
 chemistry problems. It addresses key challenges faced by traditional VQE

--- a/docs/sphinx/examples_rst/solvers/examples.rst
+++ b/docs/sphinx/examples_rst/solvers/examples.rst
@@ -2,6 +2,8 @@
 CUDA-Q Solvers by Example
 *************************
 
+.. include:: /_solvers_deprecation.rst
+
 Examples that illustrate how to use CUDA-QX for application development are available in C++ and Python.
 
 .. toctree::

--- a/docs/sphinx/examples_rst/solvers/gqe.rst
+++ b/docs/sphinx/examples_rst/solvers/gqe.rst
@@ -1,6 +1,8 @@
 Generative Quantum Eigensolver (GQE)
 -------------------------------------
 
+.. include:: /_solvers_deprecation.rst
+
 The GQE algorithm has presented a novel approach to variational optimization that leverages generative AI. It is an active research topic. 
 A core aspect of this research is with regards to the core cost / loss function the algorithm leverages. The current implementation provides 
 a cost function suitable to small scale simulation. The GQE implementation in CUDA-Q Solvers is based on this paper: `The generative quantum eigensolver 

--- a/docs/sphinx/examples_rst/solvers/molecular_hamiltonians.rst
+++ b/docs/sphinx/examples_rst/solvers/molecular_hamiltonians.rst
@@ -1,6 +1,8 @@
 Generating Molecular Hamiltonians
 ----------------------------------
 
+.. include:: /_solvers_deprecation.rst
+
 The CUDA-Q Solvers library accelerates a wide range of applications in the domain of quantum chemistry.
 To facilitate these calculations, CUDA-Q Solvers provides the `solver.create_molecule` function to allow users to generate the electronic Hamiltonians for many systems of interest.
 The molecule class contains informations about the Hamiltonian (`molecule.hamiltonian`) for the target systems.

--- a/docs/sphinx/examples_rst/solvers/qaoa.rst
+++ b/docs/sphinx/examples_rst/solvers/qaoa.rst
@@ -1,6 +1,8 @@
 Quantum Approximate Optimization Algorithm (QAOA)
 -------------------------------------------------
 
+.. include:: /_solvers_deprecation.rst
+
 The Quantum Approximate Optimization Algorithm (QAOA) is a hybrid quantum-classical algorithm that solves combinatorial optimization problems.
 
 Key features of QAOA:

--- a/docs/sphinx/examples_rst/solvers/vqe.rst
+++ b/docs/sphinx/examples_rst/solvers/vqe.rst
@@ -1,6 +1,8 @@
 Variational Quantum Eigensolver (VQE)
 -------------------------------------
 
+.. include:: /_solvers_deprecation.rst
+
 The Variational Quantum Eigensolver (VQE) is a hybrid quantum-classical algorithm designed to find the ground state energy of a quantum system. It combines quantum computation with classical optimization to iteratively improve an approximation of the ground state.
 
 Key features of VQE:

--- a/docs/sphinx/index.rst
+++ b/docs/sphinx/index.rst
@@ -8,6 +8,19 @@ libraries and Python packages that enable research, development, and application
 creation for use cases in quantum error correction and hybrid quantum-classical
 solvers.
 
+.. attention::
+
+   **CUDA-Q Solvers is deprecated.** Version 0.6.0 is the final planned
+   release of the CUDA-Q Solvers library. Development continues in **CUDA-Q
+   Algorithms**, which supersedes CUDA-Q Solvers and expands on it. Install it
+   with :code:`pip install cudaq-algorithms`
+   (`cudaq-algorithms on PyPI <https://pypi.org/project/cudaq-algorithms/>`__),
+   read the `CUDA-Q Algorithms documentation
+   <https://nvidia.github.io/cudaq-algorithms/>`__, and find the source code at
+   `NVIDIA/cudaq-algorithms on GitHub <https://github.com/NVIDIA/cudaq-algorithms>`__.
+   The CUDA-Q Solvers documentation below is retained for existing 0.6.0 users;
+   all new features and fixes land in CUDA-Q Algorithms.
+
 .. toctree::
    :maxdepth: 2
    :caption: Getting Started
@@ -59,11 +72,13 @@ APIs for common quantum-classical solver workflows.
     * Real-time decoding for active error correction on quantum hardware
     * Pre-built numerical experiment APIs
 
-* **cudaq-solvers**: Performant Quantum-Classical Simulation Workflows
+* **cudaq-solvers** (deprecated, superseded by `CUDA-Q Algorithms <https://nvidia.github.io/cudaq-algorithms/>`__): Performant Quantum-Classical Simulation Workflows
     * Variational Quantum Eigensolver (VQE)
     * ADAPT-VQE implementation that scales via CUDA-Q MQPU.
     * Quantum Approximate Optimization Algorithm (QAOA)
-    * More to come...
+    * Version 0.6.0 is the final planned release; continue with
+      `cudaq-algorithms <https://pypi.org/project/cudaq-algorithms/>`__ and its
+      `documentation <https://nvidia.github.io/cudaq-algorithms/>`__.
 
 Indices
 -------

--- a/docs/sphinx/quickstart/installation.rst
+++ b/docs/sphinx/quickstart/installation.rst
@@ -18,11 +18,29 @@ install individual components:
     # Install QEC library
     pip install cudaq-qec
 
-    # Install Solvers library
+    # Install Solvers library (deprecated - see the note below)
     pip install cudaq-solvers
 
     # Install both libraries
     pip install cudaq-qec cudaq-solvers
+
+.. attention::
+
+   **CUDA-Q Solvers is deprecated.** Version 0.6.0 is the final planned
+   release of the CUDA-Q Solvers library. New users should install **CUDA-Q
+   Algorithms** instead, which supersedes CUDA-Q Solvers and is where
+   development continues:
+
+   .. code-block:: bash
+
+       pip install cudaq-algorithms
+
+   See the `CUDA-Q Algorithms documentation
+   <https://nvidia.github.io/cudaq-algorithms/>`__ for installation
+   instructions, tutorials, and examples, `cudaq-algorithms on PyPI
+   <https://pypi.org/project/cudaq-algorithms/>`__ for the package, and
+   `NVIDIA/cudaq-algorithms on GitHub
+   <https://github.com/NVIDIA/cudaq-algorithms>`__ for the source code.
 
 CUDA-QX provides optional pip-installable components:
 
@@ -66,7 +84,8 @@ CUDA-QX is available as a Docker container with all dependencies pre-installed:
 
 The container includes:
     * CUDA-Q compiler and runtime
-    * CUDA-QX libraries (QEC and Solvers)
+    * CUDA-QX libraries (QEC and Solvers; note that Solvers is deprecated in
+      favor of `CUDA-Q Algorithms <https://nvidia.github.io/cudaq-algorithms/>`__)
     * All required dependencies
     * Example notebooks and tutorials
 

--- a/libs/solvers/README.md
+++ b/libs/solvers/README.md
@@ -1,5 +1,22 @@
 # CUDA-Q Solvers Library
 
+> [!IMPORTANT]
+> **CUDA-Q Solvers is deprecated.** Version 0.6.0 is the final planned
+> release of the CUDA-Q Solvers library. Development continues in **CUDA-Q
+> Algorithms**, which supersedes CUDA-Q Solvers and expands on it:
+>
+> ```bash
+> pip install cudaq-algorithms
+> ```
+>
+> * Documentation: https://nvidia.github.io/cudaq-algorithms/
+> * PyPI: https://pypi.org/project/cudaq-algorithms/
+> * GitHub: https://github.com/NVIDIA/cudaq-algorithms
+>
+> Existing code keeps working with CUDA-Q Solvers 0.6.0, but all new features
+> and fixes land in CUDA-Q Algorithms. We encourage every CUDA-Q Solvers user to
+> migrate.
+
 CUDA-Q Solvers provides GPU-accelerated implementations of common
 quantum-classical hybrid algorithms and numerical routines frequently
 used in quantum computing applications. The library is designed to
@@ -24,7 +41,11 @@ additional dependencies installed. You can install them with
 
 ## Getting Started
 
-For detailed documentation, tutorials, and API reference,
+New projects should start with the
+[CUDA-Q Algorithms documentation](https://nvidia.github.io/cudaq-algorithms/),
+which supersedes this library.
+
+For documentation, tutorials, and API reference for CUDA-Q Solvers 0.6.0,
 visit the [CUDA-Q Solvers Documentation](https://nvidia.github.io/cudaqx/components/solvers/introduction.html).
 
 ## License

--- a/libs/solvers/python/metapackages/README.md
+++ b/libs/solvers/python/metapackages/README.md
@@ -1,5 +1,22 @@
 # CUDA-Q Solvers Library
 
+> [!IMPORTANT]
+> **CUDA-Q Solvers is deprecated.** Version 0.6.0 is the final planned
+> release of the CUDA-Q Solvers library. Development continues in **CUDA-Q
+> Algorithms**, which supersedes CUDA-Q Solvers and expands on it:
+>
+> ```bash
+> pip install cudaq-algorithms
+> ```
+>
+> * Documentation: https://nvidia.github.io/cudaq-algorithms/
+> * PyPI: https://pypi.org/project/cudaq-algorithms/
+> * GitHub: https://github.com/NVIDIA/cudaq-algorithms
+>
+> Existing code keeps working with CUDA-Q Solvers 0.6.0, but all new features
+> and fixes land in CUDA-Q Algorithms. We encourage every CUDA-Q Solvers user to
+> migrate.
+
 CUDA-Q Solvers provides GPU-accelerated implementations of common
 quantum-classical hybrid algorithms and numerical routines frequently used in
 quantum computing applications. The library is designed to work seamlessly with


### PR DESCRIPTION
Deprecate Solvers in lieu of https://nvidia.github.io/cudaq-algorithms/. Future updates to this repo will be targeted at QEC only, and CUDA-Q Algorithms development will occur in https://github.com/NVIDIA/cudaq-algorithms.