### PR TITLE
Allow a decoder to be constructed from a raw Stim DEM

### DIFF
--- a/libs/qec/include/cudaq/qec/realtime/decoding_config.h
+++ b/libs/qec/include/cudaq/qec/realtime/decoding_config.h
@@ -71,7 +71,7 @@ struct decoder_config {
   /// GPU-accelerated decoder, hence at this level rather than inside the
   /// per-decoder custom args. Unset = unpinned.
   std::optional<int> cuda_device_id;
-  /// The five fields below describe the DEM two alternative ways, and exactly
+  /// The fields below describe the DEM three alternative ways, and exactly
   /// one of them applies:
   ///
   ///   - Flat form: H_sparse plus block_size, syndrome_size, O_sparse and
@@ -79,11 +79,21 @@ struct decoder_config {
   ///   - Chunk form: dem_chunks (which carries phases, connections, seam, and
   ///     num_rounds internally). The other five flat fields are derived by
   ///     expanding the phases, and must be omitted.
+  ///   - DEM form: stim_dem_path, the Stim model text itself. The decoder
+  ///     derives its own dimensions and observable mapping from it, so all of
+  ///     the flat fields except D_sparse must be omitted.
   ///
-  /// See expand_dem_chunks() for the derivation, which runs at decoder
-  /// construction so the rest of the pipeline only ever sees the flat form.
+  /// See expand_dem_chunks() for the chunk-form derivation, which runs at
+  /// decoder construction so the rest of the pipeline only ever sees the flat
+  /// form. DEM form stays as it is: the model text is what the decoder is
+  /// built from.
   uint64_t block_size = 0;
   uint64_t syndrome_size = 0;
+  /// Path to a Stim detector error model. When set, the decoder is
+  /// constructed from the DEM text rather than from `H_sparse`, which is what
+  /// a DEM-native decoder such as Chromobius requires. Interpreted like the
+  /// other model paths in a configuration, relative to the working directory.
+  std::string stim_dem_path;
   std::vector<std::int64_t> H_sparse;
   std::vector<std::int64_t> O_sparse;
   std::vector<std::int64_t> D_sparse;

--- a/libs/qec/lib/decoders/plugins/trt_decoder/trt_decoder.cpp
+++ b/libs/qec/lib/decoders/plugins/trt_decoder/trt_decoder.cpp
@@ -762,8 +762,15 @@ trt_decoder::trt_decoder(const cudaq::qec::sparse_binary_matrix &H,
       global_decoder_params_ =
           params.get<cudaqx::heterogeneous_map>("global_decoder_params");
       if (!global_decoder_name.empty()) {
+        // A DEM-native global decoder is constructed from the model text; the
+        // matrix arm is what every other global decoder takes.
         global_decoder_ =
-            decoder::get(global_decoder_name, H, global_decoder_params_);
+            global_decoder_params_.contains("stim_dem")
+                ? decoder::get(
+                      global_decoder_name,
+                      global_decoder_params_.get<std::string>("stim_dem"),
+                      global_decoder_params_)
+                : decoder::get(global_decoder_name, H, global_decoder_params_);
         CUDA_QEC_INFO("TensorRT decoder: global_decoder '{}' attached",
                       global_decoder_name);
       }

--- a/libs/qec/lib/realtime/config.cpp
+++ b/libs/qec/lib/realtime/config.cpp
@@ -464,19 +464,21 @@ struct MappingTraits<cudaq::qec::decoding::config::decoder_config> {
     io.mapOptional("dispatch", config.dispatch,
                    cudaq::qec::decoding::config::DecoderDispatch::host);
     io.mapOptional("cuda_device_id", config.cuda_device_id);
-    // The DEM arrives in one of two forms (see decoder_config). Everything
+    // The DEM arrives in one of three forms (see decoder_config). Everything
     // below the mapping calls enforces that exactly one of them is described,
-    // because the chunk form derives the flat fields and a config that spelled
-    // out both could disagree with itself.
+    // because the other two forms derive the flat fields and a config that
+    // spelled out more than one could disagree with itself.
     // A flat configuration names all five on the way out as well as the way
     // in. Emitting only the ones that differ from their defaults would drop a
     // legitimately empty O_sparse (a DEM with no observables) and leave behind
-    // a document that no longer parses. A chunk-form configuration takes the
-    // optional path so its derived fields stay absent, which is what makes the
-    // emitted document re-parse as chunk form.
+    // a document that no longer parses. A chunk-form or DEM-sourced
+    // configuration takes the optional path so its derived fields stay absent,
+    // which is what makes the emitted document re-parse in the form it was
+    // written in.
     const bool emitting_flat_form =
         io.outputting() &&
-        !(config.dem_chunks.has_value() && config.H_sparse.empty());
+        !((config.dem_chunks.has_value() || !config.stim_dem_path.empty()) &&
+          config.H_sparse.empty());
     if (emitting_flat_form) {
       io.mapRequired("block_size", config.block_size);
       io.mapRequired("syndrome_size", config.syndrome_size);
@@ -491,6 +493,7 @@ struct MappingTraits<cudaq::qec::decoding::config::decoder_config> {
       io.mapOptional("D_sparse", config.D_sparse, std::vector<std::int64_t>{});
     }
     io.mapOptional("dem_chunks", config.dem_chunks);
+    io.mapOptional("stim_dem_path", config.stim_dem_path, std::string{});
 
     // LLVM's YAML parser records a diagnostic and keeps going, so a malformed
     // document arrives here half-populated. Validate state only if error-free.
@@ -502,6 +505,12 @@ struct MappingTraits<cudaq::qec::decoding::config::decoder_config> {
     // expand_dem_chunks() leaves behind after it runs.
     const bool chunk_form =
         config.dem_chunks.has_value() && config.H_sparse.empty();
+
+    // DEM form when a Stim model file is named. The decoder is built from that
+    // text and derives its own dimensions and observable mapping, so the
+    // checks below that compare against syndrome_size do not apply to it; the
+    // D row count is checked against the constructed decoder instead.
+    const bool from_dem = !config.stim_dem_path.empty();
 
     // Both forms at once is legal but lopsided: H_sparse wins and the chunk
     // spec never runs. expand_dem_chunks() produces exactly this state, so it
@@ -517,6 +526,29 @@ struct MappingTraits<cudaq::qec::decoding::config::decoder_config> {
           "from dem_chunks.",
           config.id);
 
+    // dem_chunks and stim_dem_path each describe the whole DEM on their own,
+    // and unlike the flat form there is no precedence between them to fall
+    // back on, so a document naming both has to be rejected outright.
+    if (chunk_form && from_dem)
+      throw std::runtime_error(
+          "dem_chunks and stim_dem_path must not both be set for decoder " +
+          std::to_string(config.id) +
+          "; each describes the whole DEM on its own.");
+
+    // Whichever form is in play derives these from the model it names;
+    // accepting them here would let a config disagree with itself.
+    const auto reject_derived = [&config](const char *key, bool present,
+                                          const char *source) {
+      if (present)
+        throw std::runtime_error(
+            std::string(key) + " must not be set for decoder " +
+            std::to_string(config.id) + " because it is derived from " +
+            source +
+            ". Remove it, or describe the whole experiment with "
+            "H_sparse instead of " +
+            source + ".");
+    };
+
     if (chunk_form) {
       if (config.dem_chunks->num_rounds.has_value() &&
           *config.dem_chunks->num_rounds < 2)
@@ -524,24 +556,29 @@ struct MappingTraits<cudaq::qec::decoding::config::decoder_config> {
             "dem_chunks.num_rounds must be at least 2 for decoder " +
             std::to_string(config.id) + "; got " +
             std::to_string(*config.dem_chunks->num_rounds) + ".");
-      // These are all derived from the phases; accepting them here would let a
-      // config disagree with its own dem_chunks.
-      const auto reject_derived = [&](const char *key, bool present) {
-        if (present)
-          throw std::runtime_error(
-              std::string(key) + " must not be set for decoder " +
-              std::to_string(config.id) +
-              " because it is derived from dem_chunks. Remove it, or describe "
-              "the whole experiment with H_sparse instead of dem_chunks.");
-      };
-      reject_derived("block_size", config.block_size != 0);
-      reject_derived("syndrome_size", config.syndrome_size != 0);
-      reject_derived("O_sparse", !config.O_sparse.empty());
-      reject_derived("D_sparse", !config.D_sparse.empty());
+      reject_derived("block_size", config.block_size != 0, "dem_chunks");
+      reject_derived("syndrome_size", config.syndrome_size != 0, "dem_chunks");
+      reject_derived("O_sparse", !config.O_sparse.empty(), "dem_chunks");
+      reject_derived("D_sparse", !config.D_sparse.empty(), "dem_chunks");
+    } else if (from_dem) {
+      reject_derived("block_size", config.block_size != 0, "stim_dem_path");
+      reject_derived("syndrome_size", config.syndrome_size != 0,
+                     "stim_dem_path");
+      reject_derived("H_sparse", !config.H_sparse.empty(), "stim_dem_path");
+      reject_derived("O_sparse", !config.O_sparse.empty(), "stim_dem_path");
+      // D_sparse is the one model field the DEM text does not carry: it maps
+      // detectors onto the syndrome bits this decoder is sent. Its row count is
+      // checked against the constructed decoder's detector count, which is only
+      // known once the model has been read.
+      if (!io.outputting() && config.D_sparse.empty())
+        throw std::runtime_error(
+            "D_sparse is required for decoder " + std::to_string(config.id) +
+            " alongside stim_dem_path, which describes the DEM but not the "
+            "detectors this decoder is sent.");
     } else {
       // A flat document spells out its whole DEM, so every one of these fields
-      // has to be there. They are mapOptional only because the chunk form
-      // derives them; without this check a document that omits one parses into
+      // has to be there. They are mapOptional only because the other two forms
+      // derive them; without this check a document that omits one parses into
       // a zero-sized DEM and fails much later, at decoder construction.
       if (!io.outputting()) {
         std::string missing;
@@ -559,7 +596,8 @@ struct MappingTraits<cudaq::qec::decoding::config::decoder_config> {
               " is missing required field(s): " + missing +
               ". A flat DEM names block_size, syndrome_size, H_sparse, "
               "O_sparse and D_sparse together; use dem_chunks "
-              "to describe the same DEM one round at a time instead.");
+              "to describe the same DEM one round at a time, or stim_dem_path "
+              "to name the model text itself, instead.");
       } // end - if(!io.outputting())
 
       if (config.H_sparse.empty() && config.syndrome_size > 0)
@@ -605,7 +643,7 @@ struct MappingTraits<cudaq::qec::decoding::config::decoder_config> {
     if (!config.D_sparse.empty()) {
       auto num_D_rows =
           std::count(config.D_sparse.begin(), config.D_sparse.end(), -1);
-      if (num_D_rows != config.syndrome_size) {
+      if (!from_dem && num_D_rows != config.syndrome_size) {
         throw std::runtime_error("Number of rows in D_sparse vector is not "
                                  "equal to syndrome_size: " +
                                  std::to_string(num_D_rows) +
@@ -915,6 +953,7 @@ std::string decoder_config_json_schema() {
       {"block_size", llvm::json::Object{{"type", "integer"}, {"minimum", 0}}},
       {"syndrome_size",
        llvm::json::Object{{"type", "integer"}, {"minimum", 0}}},
+      {"stim_dem_path", llvm::json::Object{{"type", "string"}}},
       {"H_sparse", llvm::json::Object{{"$ref", "#/$defs/sparse_matrix"}}},
       {"O_sparse", llvm::json::Object{{"$ref", "#/$defs/sparse_matrix"}}},
       {"D_sparse", llvm::json::Object{{"$ref", "#/$defs/sparse_matrix"}}},
@@ -1028,9 +1067,9 @@ std::string decoder_config_json_schema() {
            {"type", "object"},
            {"properties", std::move(config_properties)},
            {"required", llvm::json::Array{"id", "type"}},
-           // The DEM is described either flat or as repeated phases. The
-           // parser additionally rejects a chunk-form document that also sets
-           // the derived fields, which is not expressible here.
+           // The DEM is described flat, as repeated phases, or as a Stim model
+           // file. The parser additionally rejects a document that also sets
+           // the fields the latter two derive, which is not expressible here.
            {"anyOf",
             llvm::json::Array{
                 llvm::json::Object{
@@ -1038,7 +1077,10 @@ std::string decoder_config_json_schema() {
                                                    "syndrome_size", "O_sparse",
                                                    "D_sparse"}}},
                 llvm::json::Object{
-                    {"required", llvm::json::Array{"dem_chunks"}}}}},
+                    {"required", llvm::json::Array{"dem_chunks"}}},
+                llvm::json::Object{
+                    {"required",
+                     llvm::json::Array{"stim_dem_path", "D_sparse"}}}}},
            {"additionalProperties", false},
            {"allOf", std::move(dispatch)}}},
       {"decoder_params", std::move(decoder_params)},

--- a/libs/qec/lib/realtime/realtime_decoding.cpp
+++ b/libs/qec/lib/realtime/realtime_decoding.cpp
@@ -9,6 +9,7 @@
 #include "realtime_decoding.h"
 #include "../hardware_guards.h"
 #include "cudaq/qec/decoder.h"
+#include "cudaq/qec/detector_error_model.h"
 #include "cudaq/qec/logger.h"
 #include "cudaq/qec/pcm_utils.h"
 #include "cudaq/qec/realtime/decoding_config.h"
@@ -17,6 +18,7 @@
 #include <cstdlib>
 #include <cstring>
 #include <dlfcn.h>
+#include <filesystem>
 #include <fmt/core.h>
 #include <fstream>
 #include <iterator>
@@ -161,6 +163,13 @@ namespace cudaq::qec::decoding::host {
 /// Read the DEM a decoder entry names.
 std::string read_stim_dem(
     const cudaq::qec::decoding::config::decoder_config &decoder_config) {
+  // A directory opens as a stream and fails only when read, past the check
+  // below.
+  std::error_code ec;
+  if (!std::filesystem::is_regular_file(decoder_config.stim_dem_path, ec))
+    throw std::runtime_error(
+        fmt::format("stim_dem_path is not a readable file: {}",
+                    decoder_config.stim_dem_path));
   std::ifstream file(decoder_config.stim_dem_path);
   if (!file)
     throw std::runtime_error(fmt::format(
@@ -247,6 +256,17 @@ std::unique_ptr<cudaq::qec::decoder> create_realtime_decoder(
     throw std::invalid_argument("Decoder ID is outside the uint32_t range: " +
                                 std::to_string(config_in.id));
 
+  // The parser rejects a config describing two forms, but a programmatically
+  // built one never passes through it. These two are what corrupt: chunk
+  // priors over an unrelated model, and an O_sparse that overwrites the
+  // mapping a DEM-native decoder installed for itself.
+  if (!config_in.stim_dem_path.empty() &&
+      (config_in.dem_chunks.has_value() || !config_in.O_sparse.empty()))
+    throw std::runtime_error(
+        "dem_chunks and O_sparse must not be set with stim_dem_path for "
+        "decoder " +
+        std::to_string(config_in.id));
+
   // A chunk-form configuration names its DEM one round at a time. Expand it
   // here so everything below is written against the flat form only.
   auto expanded_config = config_in;
@@ -273,6 +293,11 @@ std::unique_ptr<cudaq::qec::decoder> create_realtime_decoder(
   CUDA_QEC_INFO("Creating decoder {} of type {}", decoder_config.id,
                 decoder_config.type);
 
+  // Needed both to construct the decoder and to derive its observable mapping.
+  const std::string stim_dem_text = decoder_config.stim_dem_path.empty()
+                                        ? std::string{}
+                                        : read_stim_dem(decoder_config);
+
   auto params = prepare_decoder_params(decoder_config);
   // The phases carry a prior per fault, which the derived matrices do not. A
   // hand-written flat configuration would have had to pass these through
@@ -285,8 +310,8 @@ std::unique_ptr<cudaq::qec::decoder> create_realtime_decoder(
     // A DEM-native decoder is constructed from the model text itself. It
     // derives its own dimensions and, like chromobius, installs the observable
     // mapping its results are expressed in, so neither is supplied here.
-    decoder = cudaq::qec::get_decoder(decoder_config.type,
-                                      read_stim_dem(decoder_config), params);
+    decoder =
+        cudaq::qec::get_decoder(decoder_config.type, stim_dem_text, params);
     const auto num_D_rows = std::count(decoder_config.D_sparse.begin(),
                                        decoder_config.D_sparse.end(), -1);
     if (num_D_rows != static_cast<std::int64_t>(decoder->get_syndrome_size()))
@@ -309,12 +334,20 @@ std::unique_ptr<cudaq::qec::decoder> create_realtime_decoder(
     decoder = cudaq::qec::get_decoder(decoder_config.type, pcm, params);
   }
   decoder->set_decoder_id(decoder_config.id);
-  // Decoders that predict observables directly install the mapping their
+  // A decoder that predicts observables directly installs the mapping its
   // results are expressed in at construction (chromobius derives an identity
   // map from the DEM it read), so installing an empty one here would drop it
   // and leave get_corrections with nowhere to write.
-  if (!decoder_config.O_sparse.empty())
+  if (!decoder_config.O_sparse.empty()) {
     decoder->set_O_sparse(decoder_config.O_sparse);
+  } else if (!stim_dem_text.empty() && decoder->get_num_observables() == 0) {
+    // DEM form names no O_sparse and the LUT decoders install none, leaving the
+    // realtime path nothing to project onto. dem_from_stim_text() is what
+    // make_pcm_decoder() used, so the columns line up with the decoder's own.
+    const auto dem = cudaq::qec::dem_from_stim_text(stim_dem_text);
+    decoder->set_O_sparse(
+        cudaq::qec::pcm_to_sparse_vec(dem.observables_flips_matrix));
+  }
   decoder->set_D_sparse(decoder_config.D_sparse);
 
   // Force plugin initialization before the caller publishes the decoder for

--- a/libs/qec/lib/realtime/realtime_decoding.cpp
+++ b/libs/qec/lib/realtime/realtime_decoding.cpp
@@ -18,6 +18,8 @@
 #include <cstring>
 #include <dlfcn.h>
 #include <fmt/core.h>
+#include <fstream>
+#include <iterator>
 #include <limits>
 #include <set>
 #include <stdexcept>
@@ -156,6 +158,17 @@ static std::vector<uint8_t> pack_syndrome_bits(const uint8_t *syndromes,
 
 namespace cudaq::qec::decoding::host {
 
+/// Read the DEM a decoder entry names.
+std::string read_stim_dem(
+    const cudaq::qec::decoding::config::decoder_config &decoder_config) {
+  std::ifstream file(decoder_config.stim_dem_path);
+  if (!file)
+    throw std::runtime_error(fmt::format(
+        "stim_dem_path could not be opened: {}", decoder_config.stim_dem_path));
+  return std::string((std::istreambuf_iterator<char>(file)),
+                     std::istreambuf_iterator<char>());
+}
+
 cudaqx::heterogeneous_map prepare_decoder_params(
     const cudaq::qec::decoding::config::decoder_config &decoder_config) {
   auto params = decoder_config.decoder_custom_args_to_heterogeneous_map();
@@ -191,6 +204,16 @@ cudaqx::heterogeneous_map prepare_decoder_params(
       params.get<std::string>("global_decoder") == "pymatching";
   if (has_global_decoder && !params.contains("global_decoder_params"))
     params.insert("global_decoder_params", cudaqx::heterogeneous_map());
+
+  // A DEM-native global decoder (chromobius) cannot be built from the parent's
+  // H, so pass the model text down beside it. Decoders that do not ask for it
+  // ignore the key.
+  if (has_global_decoder && !decoder_config.stim_dem_path.empty()) {
+    auto global_decoder_params =
+        params.get<cudaqx::heterogeneous_map>("global_decoder_params");
+    global_decoder_params.insert("stim_dem", read_stim_dem(decoder_config));
+    params.insert("global_decoder_params", global_decoder_params);
+  }
 
   if (decoder_config.O_sparse.empty())
     return params;
@@ -236,12 +259,15 @@ std::unique_ptr<cudaq::qec::decoder> create_realtime_decoder(
         "D_sparse must be provided in decoder configuration");
   // pcm_from_sparse_vec() turns an empty H_sparse into an all-zero matrix
   // rather than failing, so without this check a config that described no DEM
-  // at all would build a decoder whose parity-check matrix decodes nothing.
-  if (decoder_config.H_sparse.empty())
+  // at all would build a decoder whose parity-check matrix decodes nothing. A
+  // DEM-sourced decoder is built from the model text instead, so it has no
+  // H_sparse to check.
+  if (decoder_config.H_sparse.empty() && decoder_config.stim_dem_path.empty())
     throw std::runtime_error(
         "H_sparse must be provided to build decoder " +
         std::to_string(decoder_config.id) +
-        ", either directly or by way of dem_chunks and num_rounds.");
+        ", either directly or by way of dem_chunks and num_rounds. A "
+        "DEM-native decoder can name a model with stim_dem_path instead.");
 
   auto t0 = std::chrono::high_resolution_clock::now();
   CUDA_QEC_INFO("Creating decoder {} of type {}", decoder_config.id,
@@ -254,25 +280,47 @@ std::unique_ptr<cudaq::qec::decoder> create_realtime_decoder(
   if (closed_dem && !params.contains("error_rate_vec"))
     params.insert("error_rate_vec", closed_dem->error_rates);
 
-  auto pcm = cudaq::qec::pcm_from_sparse_vec(decoder_config.H_sparse,
-                                             decoder_config.syndrome_size,
-                                             decoder_config.block_size);
-  const auto num_observables = std::count(decoder_config.O_sparse.begin(),
-                                          decoder_config.O_sparse.end(), -1);
-  // Materialize O before decoder construction to validate its sparse shape and
-  // column indices for every decoder type. TRT also receives this matrix in its
-  // constructor parameters through prepare_decoder_params() above.
-  (void)cudaq::qec::pcm_from_sparse_vec(
-      decoder_config.O_sparse, num_observables, decoder_config.block_size);
-  auto decoder = cudaq::qec::get_decoder(decoder_config.type, pcm, params);
+  std::unique_ptr<cudaq::qec::decoder> decoder;
+  if (!decoder_config.stim_dem_path.empty()) {
+    // A DEM-native decoder is constructed from the model text itself. It
+    // derives its own dimensions and, like chromobius, installs the observable
+    // mapping its results are expressed in, so neither is supplied here.
+    decoder = cudaq::qec::get_decoder(decoder_config.type,
+                                      read_stim_dem(decoder_config), params);
+    const auto num_D_rows = std::count(decoder_config.D_sparse.begin(),
+                                       decoder_config.D_sparse.end(), -1);
+    if (num_D_rows != static_cast<std::int64_t>(decoder->get_syndrome_size()))
+      throw std::runtime_error(fmt::format(
+          "Number of rows in D_sparse vector is not equal to the number of "
+          "detectors in {}: {} != {}",
+          decoder_config.stim_dem_path, num_D_rows,
+          decoder->get_syndrome_size()));
+  } else {
+    auto pcm = cudaq::qec::pcm_from_sparse_vec(decoder_config.H_sparse,
+                                               decoder_config.syndrome_size,
+                                               decoder_config.block_size);
+    const auto num_observables = std::count(decoder_config.O_sparse.begin(),
+                                            decoder_config.O_sparse.end(), -1);
+    // Materialize O before decoder construction to validate its sparse shape
+    // and column indices for every decoder type. TRT also receives this matrix
+    // in its constructor parameters through prepare_decoder_params() above.
+    (void)cudaq::qec::pcm_from_sparse_vec(
+        decoder_config.O_sparse, num_observables, decoder_config.block_size);
+    decoder = cudaq::qec::get_decoder(decoder_config.type, pcm, params);
+  }
   decoder->set_decoder_id(decoder_config.id);
-  decoder->set_O_sparse(decoder_config.O_sparse);
+  // Decoders that predict observables directly install the mapping their
+  // results are expressed in at construction (chromobius derives an identity
+  // map from the DEM it read), so installing an empty one here would drop it
+  // and leave get_corrections with nowhere to write.
+  if (!decoder_config.O_sparse.empty())
+    decoder->set_O_sparse(decoder_config.O_sparse);
   decoder->set_D_sparse(decoder_config.D_sparse);
 
   // Force plugin initialization before the caller publishes the decoder for
   // realtime work. This preserves configure_decoders()'s existing behavior.
   auto t1 = std::chrono::high_resolution_clock::now();
-  std::vector<cudaq::qec::float_t> syndrome(decoder_config.syndrome_size, 0.0);
+  std::vector<cudaq::qec::float_t> syndrome(decoder->get_syndrome_size(), 0.0);
   decoder->decode(syndrome);
   auto t2 = std::chrono::high_resolution_clock::now();
   std::chrono::duration<double> creation_duration = t1 - t0;

--- a/libs/qec/python/bindings/py_decoding_config.cpp
+++ b/libs/qec/python/bindings/py_decoding_config.cpp
@@ -187,6 +187,7 @@ void bindDecodingConfig(nb::module_ &mod) {
       .def_rw("type", &decoder_config::type)
       .def_rw("dispatch", &decoder_config::dispatch)
       .def_rw("cuda_device_id", &decoder_config::cuda_device_id)
+      .def_rw("stim_dem_path", &decoder_config::stim_dem_path)
       .def_rw("block_size", &decoder_config::block_size)
       .def_rw("syndrome_size", &decoder_config::syndrome_size)
       .def_rw("H_sparse", &decoder_config::H_sparse)

--- a/libs/qec/unittests/CMakeLists.txt
+++ b/libs/qec/unittests/CMakeLists.txt
@@ -53,6 +53,11 @@ if(TARGET cudaq-qec-decoding-server)
     cudaq-qec-realtime-decoding
     cudaq-qec-realtime-decoding-simulation
     cudaq::cudaq)
+  # The DEM-source test constructs chromobius through the plugin loader.
+  if(TARGET cudaq-qec-chromobius)
+    add_dependencies(test_decoders_yaml cudaq-qec-chromobius)
+    target_compile_definitions(test_decoders_yaml PRIVATE CUDAQX_QEC_HAS_CHROMOBIUS)
+  endif()
   add_dependencies(CUDAQXQECUnitTests test_decoders_yaml)
   gtest_discover_tests(test_decoders_yaml)
 

--- a/libs/qec/unittests/test_decoders_yaml.cpp
+++ b/libs/qec/unittests/test_decoders_yaml.cpp
@@ -13,6 +13,7 @@
 #include "cudaq/qec/logger.h"
 #include "cudaq/qec/pcm_utils.h"
 #include "cudaq/qec/realtime/decoding_config.h"
+#include <atomic>
 #include <cmath>
 #include <cstdint>
 #include <cstdlib>
@@ -1711,10 +1712,12 @@ TEST(DecoderChunkFormTest, StreamingConfigParsesWithoutNumRounds) {
 // stim_dem_path: the DEM text itself as the model a decoder is built from
 // ---------------------------------------------------------------------------
 
-#ifdef CUDAQX_QEC_HAS_CHROMOBIUS
-// Four detectors carrying the colour/basis annotation chromobius decodes from,
-// matching the model used by the chromobius unit tests.
-constexpr const char *kChromobiusDem = R"DEM(
+namespace {
+
+// Four detectors, six error mechanisms and one observable. The fourth detector
+// coordinate is the colour/basis annotation chromobius decodes from, matching
+// the model used by the chromobius unit tests; other decoders ignore it.
+constexpr const char *kStimDem = R"DEM(
 error(0.1) D0 D1
 error(0.1) D0 D1 D2
 error(0.1) D0 L0
@@ -1727,15 +1730,23 @@ detector(2, 0, 0, 0) D2
 detector(3, 0, 0, 1) D3
 )DEM";
 
+// One D row per detector in kStimDem, mapping detector i to measurement bit i.
+const std::vector<std::int64_t> kStimDemDSparse{0, -1, 1, -1, 2, -1, 3, -1};
+
 /// Writes the model to a file, since a config names a DEM by path.
 class ScopedDemFile {
 public:
   ScopedDemFile() {
-    static int counter = 0;
+    static std::atomic<int> counter{0};
     path_ = std::filesystem::temp_directory_path() /
-            ("unblock-" + std::to_string(getpid()) + "-" +
+            ("cudaqx-qec-test-" + std::to_string(getpid()) + "-" +
              std::to_string(counter++) + ".dem");
-    std::ofstream(path_) << kChromobiusDem;
+    std::ofstream out(path_);
+    out << kStimDem;
+    out.close();
+    // Everything below reads this back through the config, so a failed write
+    // has to fail here rather than as a confusing DEM parse error later.
+    EXPECT_TRUE(out) << "could not write " << path_;
   }
   ~ScopedDemFile() {
     std::error_code ec;
@@ -1747,6 +1758,223 @@ private:
   std::filesystem::path path_;
 };
 
+std::string dem_form_yaml(const std::string &dem_path,
+                          const std::string &extra_keys = {}) {
+  return R"(
+decoders:
+  - id: 0
+    type: multi_error_lut
+    stim_dem_path: )" +
+         dem_path + R"(
+    D_sparse: [0, -1, 1, -1, 2, -1, 3, -1]
+)" + extra_keys;
+}
+
+} // namespace
+
+TEST(DecoderDemFormTest, ParsesADemFormDocument) {
+  ScopedDemFile dem;
+  const auto config = parse_one(dem_form_yaml(dem.path()));
+  EXPECT_EQ(config.stim_dem_path, dem.path());
+  EXPECT_TRUE(config.H_sparse.empty());
+  EXPECT_TRUE(config.O_sparse.empty());
+  EXPECT_EQ(config.block_size, 0u);
+  EXPECT_EQ(config.syndrome_size, 0u);
+  EXPECT_EQ(config.D_sparse, kStimDemDSparse);
+}
+
+TEST(DecoderDemFormTest, EmittedDocumentReParsesAsDemForm) {
+  ScopedDemFile dem;
+  cudaq::qec::decoding::config::multi_decoder_config multi_config;
+  multi_config.decoders.push_back(parse_one(dem_form_yaml(dem.path())));
+
+  // The fields DEM form derives have to stay absent, or the emitted document
+  // would come back as an incomplete flat configuration.
+  const auto emitted = multi_config.to_yaml_str(200);
+  EXPECT_NE(emitted.find("stim_dem_path"), std::string::npos) << emitted;
+  EXPECT_EQ(emitted.find("H_sparse"), std::string::npos) << emitted;
+  EXPECT_EQ(emitted.find("O_sparse"), std::string::npos) << emitted;
+  EXPECT_EQ(emitted.find("block_size"), std::string::npos) << emitted;
+  EXPECT_EQ(emitted.find("syndrome_size"), std::string::npos) << emitted;
+
+  auto round_tripped =
+      cudaq::qec::decoding::config::multi_decoder_config::from_yaml_str(
+          emitted);
+  EXPECT_EQ(round_tripped, multi_config);
+  EXPECT_EQ(round_tripped.to_yaml_str(200), emitted);
+}
+
+TEST(DecoderDemFormTest, RejectsStimDemPathTogetherWithDemChunks) {
+  ScopedDemFile dem;
+  // Each names the whole DEM on its own, and there is no precedence between
+  // them the way a flat H_sparse wins over dem_chunks.
+  const auto yaml =
+      dem_chunks_yaml(3) + R"(    stim_dem_path: )" + dem.path() + "\n";
+  try {
+    cudaq::qec::decoding::config::multi_decoder_config::from_yaml_str(yaml);
+    ADD_FAILURE() << "expected dem_chunks + stim_dem_path to be rejected";
+  } catch (const std::runtime_error &error) {
+    EXPECT_NE(std::string(error.what()).find("stim_dem_path"),
+              std::string::npos)
+        << error.what();
+  }
+}
+
+TEST(DecoderDemFormTest, RejectsStimDemPathTogetherWithFlatMatrices) {
+  ScopedDemFile dem;
+  for (const char *derived :
+       {"    block_size: 6\n", "    syndrome_size: 4\n",
+        "    H_sparse: [0, 1, 2, -1]\n", "    O_sparse: [2, -1]\n"}) {
+    const auto yaml = dem_form_yaml(dem.path(), derived);
+    try {
+      cudaq::qec::decoding::config::multi_decoder_config::from_yaml_str(yaml);
+      ADD_FAILURE() << "expected rejection of " << derived;
+    } catch (const std::runtime_error &error) {
+      EXPECT_NE(std::string(error.what()).find("stim_dem_path"),
+                std::string::npos)
+          << error.what();
+    }
+  }
+}
+
+TEST(DecoderDemFormTest, RequiresDSparseAlongsideStimDemPath) {
+  ScopedDemFile dem;
+  // The DEM describes detectors but not which measurement bits form them, so
+  // this is the one model field DEM form cannot derive.
+  const auto yaml = R"(
+decoders:
+  - id: 0
+    type: multi_error_lut
+    stim_dem_path: )" +
+                    dem.path() + "\n";
+  try {
+    cudaq::qec::decoding::config::multi_decoder_config::from_yaml_str(yaml);
+    ADD_FAILURE() << "expected a missing D_sparse to be rejected";
+  } catch (const std::runtime_error &error) {
+    EXPECT_NE(std::string(error.what()).find("D_sparse"), std::string::npos)
+        << error.what();
+  }
+}
+
+TEST(DecoderDemFormTest, JsonSchemaAcceptsDemFormAlongsideTheOtherTwo) {
+  const auto schema =
+      cudaq::qec::decoding::config::decoder_config_json_schema();
+  EXPECT_NE(schema.find("\"stim_dem_path\""), std::string::npos);
+
+  // The three forms are alternatives, so none of them may appear in the
+  // envelope's own required list -- that would invalidate the other two.
+  // Keys are emitted alphabetically at a two-space indent, so allOf and anyOf
+  // come first and carry required arrays of their own; the envelope's is the
+  // one indented six spaces, directly under the $defs entry.
+  const auto at = schema.find("\n    \"decoder_config\": {");
+  ASSERT_NE(at, std::string::npos) << schema;
+  const auto required = schema.find("\n      \"required\": [", at);
+  ASSERT_NE(required, std::string::npos) << schema;
+  const auto required_end = schema.find(']', required);
+  ASSERT_NE(required_end, std::string::npos);
+  const auto envelope = schema.substr(required, required_end - required);
+
+  // Without this the checks below pass on any string, including the wrong
+  // required array or none at all.
+  EXPECT_NE(envelope.find("\"id\""), std::string::npos) << envelope;
+  EXPECT_NE(envelope.find("\"type\""), std::string::npos) << envelope;
+
+  for (const char *key :
+       {"stim_dem_path", "dem_chunks", "H_sparse", "D_sparse"})
+    EXPECT_EQ(envelope.find(key), std::string::npos)
+        << key << " in " << envelope;
+}
+
+TEST(DecoderDemFormTest, DerivesObservablesForADecoderThatInstallsNone) {
+  ScopedDemFile dem;
+
+  // The LUT decoders return error frames and never install an observable
+  // mapping of their own, and DEM form names no O_sparse to install for them.
+  // Without deriving one from the model, this decoder would come back with
+  // nothing to project onto and every realtime correction would be empty.
+  cudaq::qec::decoding::config::decoder_config dc;
+  dc.id = 0;
+  dc.type = "multi_error_lut";
+  dc.stim_dem_path = dem.path();
+  dc.D_sparse = kStimDemDSparse;
+
+  auto decoder = cudaq::qec::decoding::host::create_realtime_decoder(dc);
+  EXPECT_EQ(decoder->get_syndrome_size(), 4u);
+  EXPECT_EQ(decoder->get_num_observables(), 1u);
+}
+
+TEST(DecoderDemFormTest, ReportsAStimDemPathThatIsNotAFile) {
+  cudaq::qec::decoding::config::decoder_config dc;
+  dc.id = 0;
+  dc.type = "multi_error_lut";
+  dc.stim_dem_path = std::filesystem::temp_directory_path().string();
+  dc.D_sparse = kStimDemDSparse;
+
+  // A directory opens as a stream and only fails on the first read, so the
+  // error has to name the key and the path rather than the stream buffer.
+  try {
+    cudaq::qec::decoding::host::create_realtime_decoder(dc);
+    ADD_FAILURE() << "expected a directory to be rejected";
+  } catch (const std::runtime_error &error) {
+    EXPECT_NE(std::string(error.what()).find("stim_dem_path"),
+              std::string::npos)
+        << error.what();
+    EXPECT_NE(std::string(error.what()).find(dc.stim_dem_path),
+              std::string::npos)
+        << error.what();
+  }
+}
+
+// The parser's exclusivity rules reached the other way: decoder_config has
+// writable fields, so a caller can build one that never was a document.
+TEST(DecoderDemFormTest, RejectsDemChunksWithStimDemPathAtConstruction) {
+  ScopedDemFile dem;
+
+  // Four rounds close to four detectors, as many as kStimDem declares, so the
+  // D row check downstream cannot catch this. What reaches the decoder is the
+  // chunk-derived O_sparse and error_rate_vec over an unrelated model.
+  auto dc = parse_one(dem_chunks_yaml(4));
+  dc.stim_dem_path = dem.path();
+
+  try {
+    cudaq::qec::decoding::host::create_realtime_decoder(dc);
+    ADD_FAILURE() << "expected dem_chunks + stim_dem_path to be rejected";
+  } catch (const std::runtime_error &error) {
+    EXPECT_NE(std::string(error.what()).find("stim_dem_path"),
+              std::string::npos)
+        << error.what();
+    EXPECT_NE(std::string(error.what()).find("dem_chunks"), std::string::npos)
+        << error.what();
+  }
+}
+
+// block_size, syndrome_size and H_sparse are inert beside a DEM -- the DEM
+// branch reads none of them -- so O_sparse is the only flat field worth
+// rejecting: it overwrites the mapping a DEM-native decoder installed for
+// itself.
+TEST(DecoderDemFormTest, RejectsOSparseWithStimDemPathAtConstruction) {
+  ScopedDemFile dem;
+
+  cudaq::qec::decoding::config::decoder_config dc;
+  dc.id = 0;
+  dc.type = "multi_error_lut";
+  dc.stim_dem_path = dem.path();
+  dc.D_sparse = kStimDemDSparse;
+  dc.O_sparse = {2, -1};
+
+  try {
+    cudaq::qec::decoding::host::create_realtime_decoder(dc);
+    ADD_FAILURE() << "expected O_sparse + stim_dem_path to be rejected";
+  } catch (const std::runtime_error &error) {
+    EXPECT_NE(std::string(error.what()).find("O_sparse"), std::string::npos)
+        << error.what();
+    EXPECT_NE(std::string(error.what()).find("stim_dem_path"),
+              std::string::npos)
+        << error.what();
+  }
+}
+
+#ifdef CUDAQX_QEC_HAS_CHROMOBIUS
 TEST(ChromobiusOnDecodingServer, ConstructsFromARawDemSource) {
   ScopedDemFile dem;
 
@@ -1756,12 +1984,30 @@ TEST(ChromobiusOnDecodingServer, ConstructsFromARawDemSource) {
   dc.id = 0;
   dc.type = "chromobius";
   dc.stim_dem_path = dem.path();
-  dc.D_sparse = {0, -1, 1, -1, 2, -1, 3, -1};
+  dc.D_sparse = kStimDemDSparse;
 
   cudaq::qec::decoding::config::multi_decoder_config mc;
   mc.decoders.push_back(dc);
   ASSERT_EQ(cudaq::qec::decoding::config::configure_decoders(mc), 0);
   cudaq::qec::decoding::config::finalize_decoders();
+}
+
+TEST(ChromobiusOnDecodingServer, KeepsItsOwnObservableMapping) {
+  ScopedDemFile dem;
+
+  // Chromobius predicts observables directly and installs an identity mapping
+  // over them, which is expressed in a different space than the DEM-derived
+  // matrix other decoders get. Deriving one here would have to leave it alone.
+  cudaq::qec::decoding::config::decoder_config dc;
+  dc.id = 0;
+  dc.type = "chromobius";
+  dc.stim_dem_path = dem.path();
+  dc.D_sparse = kStimDemDSparse;
+
+  auto decoder = cudaq::qec::decoding::host::create_realtime_decoder(dc);
+  EXPECT_EQ(decoder->get_syndrome_size(), 4u);
+  EXPECT_EQ(decoder->get_num_observables(), 1u);
+  EXPECT_EQ(decoder->get_block_size(), 1u);
 }
 
 TEST(ChromobiusOnDecodingServer, MatrixOnlyConfigStillFails) {
@@ -1775,6 +2021,17 @@ TEST(ChromobiusOnDecodingServer, MatrixOnlyConfigStillFails) {
   mc.decoders.push_back(dc);
   EXPECT_NE(cudaq::qec::decoding::config::configure_decoders(mc), 0);
   cudaq::qec::decoding::config::finalize_decoders();
+
+  // configure_decoders() only reports a status code, so check that the refusal
+  // came from chromobius rejecting a matrix and not from something incidental.
+  try {
+    cudaq::qec::decoding::host::create_realtime_decoder(dc);
+    ADD_FAILURE() << "expected chromobius to reject a matrix-only config";
+  } catch (const std::runtime_error &error) {
+    EXPECT_NE(std::string(error.what()).find("detector error model"),
+              std::string::npos)
+        << error.what();
+  }
 }
 
 TEST(ChromobiusOnDecodingServer, DemReachesANestedGlobalDecoder) {
@@ -1786,7 +2043,7 @@ TEST(ChromobiusOnDecodingServer, DemReachesANestedGlobalDecoder) {
   dc.id = 0;
   dc.type = "trt_decoder";
   dc.stim_dem_path = dem.path();
-  dc.D_sparse = {0, -1, 1, -1, 2, -1, 3, -1};
+  dc.D_sparse = kStimDemDSparse;
   dc.decoder_custom_args.map().insert("global_decoder",
                                       std::string{"chromobius"});
   dc.decoder_custom_args.map().insert("global_decoder_params",

--- a/libs/qec/unittests/test_decoders_yaml.cpp
+++ b/libs/qec/unittests/test_decoders_yaml.cpp
@@ -22,6 +22,7 @@
 #include <limits>
 #include <optional>
 #include <stdexcept>
+#include <unistd.h>
 
 namespace {
 class ScopedEnv {
@@ -1705,3 +1706,102 @@ TEST(DecoderChunkFormTest, StreamingConfigParsesWithoutNumRounds) {
   EXPECT_THROW(cudaq::qec::decoding::config::expand_dem_chunks(expandable),
                std::runtime_error);
 }
+
+// ---------------------------------------------------------------------------
+// stim_dem_path: the DEM text itself as the model a decoder is built from
+// ---------------------------------------------------------------------------
+
+#ifdef CUDAQX_QEC_HAS_CHROMOBIUS
+// Four detectors carrying the colour/basis annotation chromobius decodes from,
+// matching the model used by the chromobius unit tests.
+constexpr const char *kChromobiusDem = R"DEM(
+error(0.1) D0 D1
+error(0.1) D0 D1 D2
+error(0.1) D0 L0
+error(0.1) D1 D2 D3
+error(0.1) D2 D3
+error(0.1) D3
+detector(0, 0, 0, 1) D0
+detector(1, 0, 0, 2) D1
+detector(2, 0, 0, 0) D2
+detector(3, 0, 0, 1) D3
+)DEM";
+
+/// Writes the model to a file, since a config names a DEM by path.
+class ScopedDemFile {
+public:
+  ScopedDemFile() {
+    static int counter = 0;
+    path_ = std::filesystem::temp_directory_path() /
+            ("unblock-" + std::to_string(getpid()) + "-" +
+             std::to_string(counter++) + ".dem");
+    std::ofstream(path_) << kChromobiusDem;
+  }
+  ~ScopedDemFile() {
+    std::error_code ec;
+    std::filesystem::remove(path_, ec);
+  }
+  std::string path() const { return path_.string(); }
+
+private:
+  std::filesystem::path path_;
+};
+
+TEST(ChromobiusOnDecodingServer, ConstructsFromARawDemSource) {
+  ScopedDemFile dem;
+
+  // No H_sparse and no O_sparse: the DEM is the model, and chromobius installs
+  // the observable mapping its results are expressed in.
+  cudaq::qec::decoding::config::decoder_config dc;
+  dc.id = 0;
+  dc.type = "chromobius";
+  dc.stim_dem_path = dem.path();
+  dc.D_sparse = {0, -1, 1, -1, 2, -1, 3, -1};
+
+  cudaq::qec::decoding::config::multi_decoder_config mc;
+  mc.decoders.push_back(dc);
+  ASSERT_EQ(cudaq::qec::decoding::config::configure_decoders(mc), 0);
+  cudaq::qec::decoding::config::finalize_decoders();
+}
+
+TEST(ChromobiusOnDecodingServer, MatrixOnlyConfigStillFails) {
+  // The converse: without a DEM source chromobius cannot be built, which is
+  // what naming a DEM lifts. If this ever passes, the test above proves
+  // nothing.
+  auto dc = create_test_sample_realtime_decoder_config(0);
+  dc.type = "chromobius";
+
+  cudaq::qec::decoding::config::multi_decoder_config mc;
+  mc.decoders.push_back(dc);
+  EXPECT_NE(cudaq::qec::decoding::config::configure_decoders(mc), 0);
+  cudaq::qec::decoding::config::finalize_decoders();
+}
+
+TEST(ChromobiusOnDecodingServer, DemReachesANestedGlobalDecoder) {
+  ScopedDemFile dem;
+
+  // The nesting half: a DEM-sourced entry hands the model text down through
+  // global_decoder_params, which is where trt_decoder builds chromobius from.
+  cudaq::qec::decoding::config::decoder_config dc;
+  dc.id = 0;
+  dc.type = "trt_decoder";
+  dc.stim_dem_path = dem.path();
+  dc.D_sparse = {0, -1, 1, -1, 2, -1, 3, -1};
+  dc.decoder_custom_args.map().insert("global_decoder",
+                                      std::string{"chromobius"});
+  dc.decoder_custom_args.map().insert("global_decoder_params",
+                                      cudaqx::heterogeneous_map{});
+
+  auto params = cudaq::qec::decoding::host::prepare_decoder_params(dc);
+  ASSERT_TRUE(params.contains("global_decoder_params"));
+  const auto global_params =
+      params.get<cudaqx::heterogeneous_map>("global_decoder_params");
+  ASSERT_TRUE(global_params.contains("stim_dem"));
+
+  // What trt_decoder passes to decoder::get() must build the decoder the
+  // config named.
+  auto global_decoder = cudaq::qec::decoder::get(
+      "chromobius", global_params.get<std::string>("stim_dem"), global_params);
+  EXPECT_EQ(global_decoder->get_syndrome_size(), 4);
+}
+#endif // CUDAQX_QEC_HAS_CHROMOBIUS


### PR DESCRIPTION
## Description
**Allow a realtime decoder to be constructed from a raw Stim DEM**

A realtime decoder config could only describe its error model as sparse matrices, so a DEM-native decoder such as Chromobius — which rejects a parity-check matrix outright — could not be configured on the realtime path. A decoder entry may now name a Stim detector error model with `stim_dem_path`, and the decoder is built from that text, deriving its own dimensions and observable mapping. This is a third way to describe the DEM alongside flat form and `dem_chunks`; exactly one applies.

```yaml
decoders:
  - id: 0
    type: chromobius
    stim_dem_path: color_code.dem
    D_sparse: [ 0, -1, 1, -1, 2, -1, 3, -1 ]
```

- The flat matrix keys become optional at the parser, and `stim_dem_path` rejects the fields it derives as well as `dem_chunks`. Checks against `syndrome_size` move to the constructed decoder. `D_sparse` stays required — the DEM describes detectors but not which measurement bits form them — and its row count is validated against the decoder's detector count.
- A decoder that installs its own observable mapping (Chromobius) keeps it; one that does not (the LUT decoders) gets a mapping derived from the same DEM, so corrections aren't silently empty.
- The model text reaches a nested global decoder through `global_decoder_params["stim_dem"]`, so `trt_decoder` can build Chromobius. Construction re-checks the combinations that corrupt, since a programmatically built config never passes through the parser.
- `stim_dem_path` is exposed on the Python `decoder_config` and added to the JSON schema as a third `anyOf` alternative.

**Test plan.** `test_decoders_yaml` covers DEM-form parsing, emission round-tripping, each validation rejection, the schema alternative, and the derived observable mapping; 67 pass / 3 skip. Chromobius cases compile only with the plugin built and cover `configure_decoders`, its own observable mapping, and the nested global decoder.

## Runtime / performance impact
N/A

## Self-review checklist

Please confirm each item before requesting review. Check `[x]` or strike
through and explain.

### Before requesting review
- [x] I reviewed my own full diff in GitHub or my editor.
- [x] PR is in Draft if it is not yet ready for review.
- [x] Temporary / debugging changes have been removed.
- [x] Local test logs reviewed; no unexplained warnings or errors.
- [x] CI logs reviewed; no unexplained warnings or errors.
- [x] Full CI has been run.

### Scope and size
- [x] PR is under ~1000 lines, or an exception is justified in the description.
- [x] Refactoring-only changes are isolated in their own PR(s).
- [x] No existing tests were disabled or modified just to make this PR pass
      (if so, an issue has been raised).

### Tests
- [x] New functionality has new tests.
- [x] Tests fail if the new functionality is broken (including crashes), not
      just when it is missing.
- [x] Negative tests added where exceptions are expected.
- [x] Truth data added where simple `EXPECT_*` / `assert` checks are
      insufficient for algorithmic correctness.
- [x] CI runtime impact considered; team notified if significant.

### Documentation
- [x] Public-facing APIs have Doxygen docs.
- [x] User-visible behavior changes have public docs, or a follow-up is
      tracked.

### Code style
- [x] Naming follows the existing convention (`snake_case` vs `camelCase`) for
      the area being modified.

### Dependencies
- [x] No new third-party dependencies, **or** the team has been notified and
      OSRB tickets filed.
