### PR TITLE
[QEC] Add common decoder stats functions for ease of logging and replay

### DIFF
--- a/libs/qec/include/cudaq/qec/realtime/nvtx_helpers.h
+++ b/libs/qec/include/cudaq/qec/realtime/nvtx_helpers.h
@@ -25,6 +25,7 @@ struct NvtxRange {
   cudaq::qec::realtime::experimental::NvtxRange _nvtx_range_##__LINE__(name)
 #define NVTX_PUSH(name) nvtxRangePushA(name)
 #define NVTX_POP() nvtxRangePop()
+#define NVTX_MARK(name) nvtxMarkA(name)
 
 } // namespace cudaq::qec::realtime::experimental
 #else
@@ -32,5 +33,6 @@ struct NvtxRange {
 #define NVTX_RANGE(name) (void)0
 #define NVTX_PUSH(name) (void)0
 #define NVTX_POP() (void)0
+#define NVTX_MARK(name) (void)0
 
 #endif

--- a/libs/qec/lib/CMakeLists.txt
+++ b/libs/qec/lib/CMakeLists.txt
@@ -56,6 +56,7 @@ set(DECODERS_SOURCES
   decoder.cpp
   decoder_config_payload.cpp
   decoder_config_schema.cpp
+  decoder_stats.cpp
   logger.cpp
   logger_forwarder.cpp
   plugin_loader.cpp

--- a/libs/qec/lib/decoder_stats.cpp
+++ b/libs/qec/lib/decoder_stats.cpp
@@ -1,0 +1,238 @@
+/*******************************************************************************
+ * Copyright (c) 2022 - 2026 NVIDIA Corporation & Affiliates.                  *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+// Out-of-line half of decoder_stats.h: the shared machinery behind the
+// realtime `[DecoderStats]` log stream. Everything a reporting decoder does
+// per call -- resolving the level, stamping the line prefix, routing the line
+// to the logger or to a raw printf, recording a latency sample and emitting
+// the lifetime summary -- is defined here rather than in the header, so a
+// decoder that opts in pays for a declaration and a call rather than for
+// fmt and chrono instantiations in every translation unit that sees it.
+//
+// This lives in the same library as decoder.cpp so that a decoder plugin,
+// which already links that library to reach decoder itself, resolves these
+// symbols without linking anything further.
+
+#include "decoder_stats.h"
+#include "cudaq/qec/logger.h"
+#include <algorithm>
+#include <chrono>
+#include <cmath>
+#include <cstdio>
+#include <cstdlib>
+#include <fmt/ranges.h>
+
+namespace cudaq::qec {
+
+void collect_set_bits(const uint8_t *bits, std::size_t count,
+                      std::vector<uint32_t> &out) {
+  out.clear();
+  for (std::size_t i = 0; i < count; ++i)
+    if (bits[i])
+      out.push_back(static_cast<uint32_t>(i));
+}
+
+// The inverse of latency_series::bucket_of(): rebuild the value range a bucket
+// covers and return its midpoint, which is the best estimate available for a
+// sample whose exact value was not retained.
+double latency_series::bucket_midpoint_us(std::size_t bucket) {
+  const int octave =
+      static_cast<int>(bucket >> sub_bucket_bits) + first_octave_ns;
+  const auto sub = static_cast<uint64_t>(bucket & (sub_buckets_per_octave - 1));
+  const uint64_t width = uint64_t{1} << (octave - sub_bucket_bits);
+  const uint64_t lower = (uint64_t{1} << octave) + sub * width;
+  return static_cast<double>(lower + width / 2) / 1000.0;
+}
+
+// Nearest-rank over the histogram: walk buckets in increasing value order
+// until the cumulative count reaches the requested rank.
+double latency_series::percentile_us(double fraction) const {
+  if (count == 0)
+    return 0.0;
+  if (fraction <= 0.0)
+    return min_us;
+  if (fraction >= 1.0)
+    return max_us;
+  const auto rank =
+      static_cast<uint64_t>(std::ceil(fraction * static_cast<double>(count)));
+  uint64_t cumulative = 0;
+  for (std::size_t bucket = 0; bucket < buckets_.size(); bucket++) {
+    cumulative += buckets_[bucket];
+    if (cumulative < rank)
+      continue;
+    // The bucket is coarser than the extremes we tracked exactly, so a
+    // single-sample or narrow series still reports a value it actually saw.
+    return std::clamp(bucket_midpoint_us(bucket), min_us, max_us);
+  }
+  return max_us;
+} // end - latency_series::percentile_us()
+
+decoder_stats::decoder_stats(const void *owner) : owner_(owner) {
+  if (const char *env = std::getenv("CUDAQ_QEC_DEBUG_DECODER"))
+    printf_mode_ = env[0] == '1' || env[0] == 'y' || env[0] == 'Y';
+}
+
+// Destructors are implicitly noexcept, and emit_summary() formats and logs, so
+// an allocation failure there would terminate instead of losing a stats line.
+decoder_stats::~decoder_stats() {
+  try {
+    emit_summary();
+  } catch (...) {
+  }
+} // end - decoder_stats::~decoder_stats
+
+void decoder_stats::note_submit(bool first_of_shot) {
+  const auto now = clock::now();
+  if (first_of_shot) {
+    shot_start_ = now;
+    shot_open_ = true;
+  }
+  last_submit_ = now;
+  have_submit_ = true;
+}
+
+double decoder_stats::since_last_submit_us() const {
+  if (!have_submit_)
+    return 0.0;
+  return std::chrono::duration<double, std::micro>(clock::now() - last_submit_)
+      .count();
+}
+
+void decoder_stats::note_decode_complete() {
+  if (!have_submit_)
+    return;
+  const auto now = clock::now();
+  tail_latency_.add(
+      std::chrono::duration<double, std::micro>(now - last_submit_).count());
+  if (shot_open_)
+    shot_latency_.add(
+        std::chrono::duration<double, std::micro>(now - shot_start_).count());
+  // The next submit belongs to the next shot, whose first_of_shot reopens the
+  // full-shot clock.
+  shot_open_ = false;
+  have_submit_ = false;
+}
+
+void decoder_stats::note_reset() {
+  shot_open_ = false;
+  have_submit_ = false;
+}
+
+void decoder_stats::emit_summary(const char *file_name, int line_no) {
+  if (tail_latency_.count == 0)
+    return;
+  const auto detail_level = detail();
+  if (detail_level == stats_detail::off)
+    return;
+  // One line for the decoder's whole lifetime, so unlike the per-call lines it
+  // reports at info.
+  emit(stats_detail::summary,
+       // Two decimals because these are microseconds and a realtime decode is
+       // often a fraction of one, where a single decimal would quantize away
+       // the difference between two decoders.
+       fmt::format(
+           "{} stats_summary Decodes:{} TailAvg:{:.2f}us "
+           "TailP50:{:.2f}us TailP90:{:.2f}us TailP99:{:.2f}us "
+           "TailMin:{:.2f}us TailMax:{:.2f}us Shots:{} "
+           "ShotAvg:{:.2f}us ShotP50:{:.2f}us ShotP90:{:.2f}us "
+           "ShotP99:{:.2f}us ShotMin:{:.2f}us ShotMax:{:.2f}us",
+           prefix(), tail_latency_.count, tail_latency_.average_us(),
+           tail_latency_.percentile_us(0.50), tail_latency_.percentile_us(0.90),
+           tail_latency_.percentile_us(0.99), tail_latency_.min_us,
+           tail_latency_.max_us, shot_latency_.count,
+           shot_latency_.average_us(), shot_latency_.percentile_us(0.50),
+           shot_latency_.percentile_us(0.90), shot_latency_.percentile_us(0.99),
+           shot_latency_.min_us, shot_latency_.max_us),
+       file_name, line_no);
+  // A caller may emit between warmup and measurement. Start a fresh aggregate
+  // after every successful emission, and leave disabled summaries intact so
+  // they can still be reported if the level is enabled before destruction.
+  tail_latency_ = {};
+  shot_latency_ = {};
+} // end - decoder_stats::emit_summary()
+
+stats_detail decoder_stats::detail() const {
+  if (printf_mode_)
+    return stats_detail::arrays;
+  if (!detail::should_log(detail::log_level::info))
+    return stats_detail::off;
+  return detail::should_log(detail::log_level::debug) ? stats_detail::arrays
+                                                      : stats_detail::summary;
+}
+
+std::string decoder_stats::prefix() {
+  return fmt::format("[DecoderStats][{}] Counter:{} DecoderId:{}", owner_,
+                     ++counter_, decoder_id_);
+}
+
+void decoder_stats::emit(stats_detail detail_level, const std::string &message,
+                         const char *file_name, int line_no) const {
+  if (printf_mode_) {
+    std::printf("%s\n", message.c_str());
+    return;
+  }
+  // The level macros hard-code their own level and call site, and CUDA_QEC_DBG
+  // compiles away unless CUDAQ_DEBUG is defined, so go to log_message directly;
+  // detail() has already checked the level.
+  detail::log_message(detail_level == stats_detail::arrays
+                          ? detail::log_level::debug
+                          : detail::log_level::info,
+                      "{}", file_name, line_no, message);
+}
+
+void decoder_stats::emit_frame_call(const char *call,
+                                    const std::vector<uint8_t> &corrections,
+                                    const char *file_name, int line_no) {
+  const auto detail_level = detail();
+  if (detail_level != stats_detail::arrays)
+    return;
+  emit(detail_level,
+       fmt::format("{} {} called ObservableCorrectionsTotal:{}", prefix(), call,
+                   fmt::join(corrections, ",")),
+       file_name, line_no);
+}
+
+void decoder_stats::append_replay_fields(std::string &line,
+                                         const replay_fields &fields) const {
+  line += fmt::format(
+      " InputMsyn:{} InputDetectors:{} Errors:{} "
+      "Observables:{} ObservableCorrectionsThisCall:{} "
+      "ObservableCorrectionsTotal:{}",
+      fmt::join(fields.msyn, ","), fmt::join(fields.detectors, ","),
+      fmt::join(fields.errors, ","), fmt::join(fields.observables, ","),
+      fmt::join(fields.corrections_this_call, ","),
+      fmt::join(fields.corrections_total, ","));
+}
+
+void decoder_stats::append_replay_fields(
+    std::string &line, const sparse_scratch &scratch,
+    const std::vector<uint8_t> &corrections_total) const {
+  append_replay_fields(line,
+                       replay_fields{.msyn = scratch.msyn,
+                                     .detectors = scratch.detectors,
+                                     .errors = scratch.errors,
+                                     .observables = frame_flip_ids(),
+                                     .corrections_this_call = frame_flips(),
+                                     .corrections_total = corrections_total});
+}
+
+void decoder_stats::diff_frame(const std::vector<uint8_t> &before,
+                               const std::vector<uint8_t> &now) {
+  frame_flips_.clear();
+  frame_flip_ids_.clear();
+  if (before.size() != now.size())
+    return;
+  frame_flips_.resize(now.size());
+  for (std::size_t i = 0; i < now.size(); ++i) {
+    frame_flips_[i] = now[i] ^ before[i];
+    if (frame_flips_[i])
+      frame_flip_ids_.push_back(static_cast<uint32_t>(i));
+  }
+}
+
+} // namespace cudaq::qec

--- a/libs/qec/lib/decoder_stats.h
+++ b/libs/qec/lib/decoder_stats.h
@@ -1,0 +1,348 @@
+/****************************************************************-*- C++ -*-****
+ * Copyright (c) 2022 - 2026 NVIDIA Corporation & Affiliates.                  *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+#pragma once
+
+#include <array>
+#include <chrono>
+#include <cstdint>
+#include <string>
+#include <vector>
+
+/// @file
+/// @brief Shared machinery for the realtime `[DecoderStats]` log stream.
+/// @details
+/// This is not a public header: it sits beside its implementation in
+/// libs/qec/lib rather than in the installed include tree, so it adds nothing
+/// to the decoder API. Nothing in decoder.h pulls it in and the base decoder
+/// does not own an instance. A decoder that wants latency instrumentation
+/// includes it, holds a decoder_stats member and reports through it, which
+/// keeps the cost off every decoder that does not. A target that consumes this
+/// must add libs/qec/lib to its private include directories.
+///
+/// It stays within C++17 so that a decoder compiled as CUDA C++17 can consume
+/// it: vector references rather than std::span, and the
+/// __builtin_FILE/__builtin_LINE default arguments that logger.h already uses
+/// in place of std::source_location.
+///
+/// Every decoder that reports through this header emits the same line format,
+/// which is the format `libs/qec/utils/replay_decoder_logs.py` consumes. The
+/// parts that are identical for every decoder live here -- level selection,
+/// output routing, the line prefix and counter, and the sparse/dense
+/// conversions the lines need -- so a decoder only has to decide which fields
+/// to report.
+///
+/// A decoder that reports its submits and decode completions also gets a
+/// `stats_summary` line when it is destroyed, aggregating two latencies over
+/// the decoder's lifetime: the tail latency from a shot's last measurements
+/// reaching enqueue_syndrome() to the end of its decode, and the full-shot
+/// latency from that shot's first measurements to the same point. Both include
+/// whatever delay the caller adds between the two, since that is what a
+/// realtime application experiences, and both are reported as a count, mean,
+/// min, max and percentiles -- see latency_series for how the percentiles are
+/// estimated. By default the aggregate spans the decoder's whole lifetime. A
+/// decoder with an explicit warmup phase may call emit_summary() afterward; a
+/// successful emission starts a fresh aggregate for later decodes.
+///
+/// Two levels are recognized. `info` reports that one summary and nothing else,
+/// so an instrumented realtime run costs a clock read per submit and per decode
+/// and emits a single line. `debug` adds a line per instrumented call, counts
+/// and sparse arrays together, which is the volume a replay capture needs and
+/// the volume a streaming path cannot afford. `CUDAQ_QEC_DEBUG_DECODER=1`
+/// selects the per-call form through a raw printf, bypassing the logger (and
+/// therefore a log forwarder, which truncates long messages and so breaks
+/// replay).
+
+namespace cudaq::qec {
+
+/// @brief How much detail an instrumented call should emit.
+enum class stats_detail {
+  off,     ///< Nothing is logged; skip all measurement and formatting.
+  summary, ///< Only the lifetime summary line; each call stays silent but still
+           ///< records the timestamps that summary aggregates.
+  arrays   ///< A line per call, with the counts, durations and sparse arrays.
+};
+
+/// @brief Append the positions of the set bytes in `[bits, bits + count)`.
+/// @details Callers own `out` so several arrays can be alive in one line; it is
+/// cleared first, and keeping it as a member avoids reallocating per call.
+void collect_set_bits(const uint8_t *bits, std::size_t count,
+                      std::vector<uint32_t> &out);
+
+/// @brief Reusable storage for the sparse arrays a decode line reports.
+/// @details A decoder holds one of these so an enabled log reuses its
+/// allocations instead of converting into fresh vectors per decode. Fill the
+/// members with collect_set_bits() or directly, then hand the whole struct to
+/// decoder_stats::append_replay_fields(). A decoder with no error-space result
+/// simply leaves `errors` empty.
+struct sparse_scratch {
+  /// @brief Sparse indices of the raw measurement bits consumed.
+  std::vector<uint32_t> msyn;
+  /// @brief Sparse indices of the detectors that fired.
+  std::vector<uint32_t> detectors;
+  /// @brief Sparse indices of the predicted error mechanisms.
+  std::vector<uint32_t> errors;
+
+  /// @brief Drop the previous line's contents, keeping the capacity.
+  void clear() {
+    msyn.clear();
+    detectors.clear();
+    errors.clear();
+  }
+};
+
+/// @brief The array fields `replay_decoder_logs.py` reads from a decode line.
+/// @details Every decoder fills the same set so the replay tool needs no
+/// per-decoder knowledge. An empty vector renders as an empty value, which the
+/// tool reads as "none".
+struct replay_fields {
+  /// @brief Sparse indices of the raw measurement bits consumed.
+  const std::vector<uint32_t> &msyn;
+  /// @brief Sparse indices of the detectors that fired.
+  const std::vector<uint32_t> &detectors;
+  /// @brief Sparse indices of the predicted error mechanisms, if any.
+  const std::vector<uint32_t> &errors;
+  /// @brief Sparse indices of the observables flipped by this decode.
+  const std::vector<uint32_t> &observables;
+  /// @brief Dense per-observable flips contributed by this decode.
+  const std::vector<uint8_t> &corrections_this_call;
+  /// @brief Dense per-observable accumulated Pauli frame.
+  const std::vector<uint8_t> &corrections_total;
+};
+
+/// @brief Running count, average, min, max and percentiles over a latency
+/// series, recorded without allocating or retaining the samples.
+///
+/// @details A realtime decoder cannot know how many shots it will see, so there
+/// is no sample buffer to size up front, and growing one mid-run would stall
+/// the path being measured. Instead each sample increments one counter in a
+/// log-spaced histogram sized at compile time: `sub_buckets_per_octave`
+/// subdivisions of every power of two from `first_octave_ns` up, which is what
+/// lets one table cover the sub-microsecond decodes and the millisecond
+/// outliers at the same relative resolution. Count, mean, min and max stay
+/// exact; the percentiles are estimates whose error is bounded by the bucket
+/// width, near 1.6% of the value at the default resolution.
+struct latency_series {
+  std::size_t count = 0;
+  double sum_us = 0.0;
+  double min_us = 0.0;
+  double max_us = 0.0;
+
+  void add(double us) {
+    if (count == 0 || us < min_us)
+      min_us = us;
+    if (count == 0 || us > max_us)
+      max_us = us;
+    sum_us += us;
+    ++count;
+    ++buckets_[bucket_of(us)];
+  }
+
+  double average_us() const { return count ? sum_us / count : 0.0; }
+
+  /// @brief Estimate the latency at `fraction` of the distribution, where 0.5
+  /// is the median.
+  /// @details Nearest-rank: the smallest sample at or above the requested rank,
+  /// reported as the midpoint of its bucket and clamped to the exact min and
+  /// max, so the result never falls outside the range actually seen. Returns 0
+  /// for an empty series.
+  double percentile_us(double fraction) const;
+
+private:
+  /// Powers of two are subdivided this finely, which fixes the resolution: a
+  /// bucket spans 1/32 of its value, so a midpoint estimate is within 1/64.
+  static constexpr int sub_bucket_bits = 5;
+  static constexpr std::size_t sub_buckets_per_octave = 1u << sub_bucket_bits;
+  /// Nothing below 64ns is resolved, which two clock reads already exceed, and
+  /// nothing above 2^27ns (~134ms); both ends clamp into the end buckets while
+  /// min_us and max_us keep the exact value.
+  static constexpr int first_octave_ns = 6;
+  static constexpr int octaves = 21;
+  static constexpr std::size_t bucket_count = octaves * sub_buckets_per_octave;
+
+  /// @brief Which counter a sample belongs to: its octave picks the range, the
+  /// next `sub_bucket_bits` mantissa bits pick the subdivision within it.
+  static std::size_t bucket_of(double us) {
+    const double ns = us * 1000.0;
+    // Also catches NaN and a clock that ran backwards; min_us keeps the value.
+    if (!(ns >= 1.0))
+      return 0;
+    const auto value = static_cast<uint64_t>(ns);
+    const int octave = 63 - __builtin_clzll(value);
+    if (octave < first_octave_ns)
+      return 0;
+    const auto index = static_cast<std::size_t>(octave - first_octave_ns);
+    if (index >= octaves)
+      return bucket_count - 1;
+    const auto sub = static_cast<std::size_t>(
+        (value >> (octave - sub_bucket_bits)) & (sub_buckets_per_octave - 1));
+    return (index << sub_bucket_bits) | sub;
+  }
+
+  static double bucket_midpoint_us(std::size_t bucket);
+
+  /// 21 octaves x 32 sub-buckets of uint64: ~5KB held with the object, so
+  /// recording a sample never touches the allocator.
+  std::array<uint64_t, bucket_count> buckets_ = {};
+};
+
+/// @brief Per-decoder instrumentation state for the `[DecoderStats]` stream.
+///
+/// One instance lives in the decoder that opts in, so that decoder and its own
+/// helpers share one counter and one resolved output mode. Hold it as a member
+/// rather than constructing one per call: it carries the latency histograms the
+/// summary aggregates, and constructing one reads the environment.
+class decoder_stats {
+public:
+  /// @brief Construct for `owner`, whose address identifies the decoder in the
+  /// log. Reads `CUDAQ_QEC_DEBUG_DECODER` once.
+  explicit decoder_stats(const void *owner = nullptr);
+
+  /// @brief Emits the latency summary for the decoder being destroyed.
+  ~decoder_stats();
+
+  /// @brief Point the log lines at their decoder. Needed when the owner cannot
+  /// be known at construction.
+  void set_owner(const void *owner) { owner_ = owner; }
+
+  /// @brief Record the decoder id reported by every line.
+  void set_decoder_id(uint32_t decoder_id) { decoder_id_ = decoder_id; }
+
+  /// @brief Resolve how much to log right now.
+  /// @details Probes `info` first, so a disabled call costs one relaxed atomic
+  /// load: a threshold low enough to admit `debug` admits `info` as well.
+  stats_detail detail() const;
+
+  /// @brief Start a line: "[DecoderStats][owner] Counter:N DecoderId:M".
+  /// @details Advances the counter, so call it once per emitted line.
+  std::string prefix();
+
+  /// @brief Emit a finished line at the level `detail` implies.
+  /// @details The defaulted file and line make the log report the decoder that
+  /// emitted the line rather than this file.
+  void emit(stats_detail detail, const std::string &message,
+            const char *file_name = __builtin_FILE(),
+            int line_no = __builtin_LINE()) const;
+
+  /// @brief Emit a line for a realtime call that only reads or clears the
+  /// correction frame, such as `get_obs_corrections` or `reset_decoder`.
+  /// @details A per-call line, so it appears at `arrays` and nowhere else; the
+  /// level check is done here because these call sites have nothing else to
+  /// gate.
+  void emit_frame_call(const char *call,
+                       const std::vector<uint8_t> &corrections,
+                       const char *file_name = __builtin_FILE(),
+                       int line_no = __builtin_LINE());
+
+  /// @brief Append the replay field set to `line`.
+  /// @details Only meaningful at `stats_detail::arrays`; the field names are
+  /// fixed because the replay tool matches on them.
+  void append_replay_fields(std::string &line,
+                            const replay_fields &fields) const;
+
+  /// @brief Append the replay field set from a decoder's `scratch`.
+  /// @details Fills the observable fields from the last diff_frame(), so call
+  /// that first. `corrections_total` is the accumulated Pauli frame.
+  void
+  append_replay_fields(std::string &line, const sparse_scratch &scratch,
+                       const std::vector<uint8_t> &corrections_total) const;
+
+  /// @brief Record that measurements were accepted at this instant.
+  /// @param first_of_shot Whether these are the shot's first measurements,
+  /// which is what starts the full-shot clock. Passing it explicitly means a
+  /// level raised part-way through a shot reports no shot latency for that shot
+  /// instead of a short one measured from the middle.
+  /// @details Only the enabled path should call this: it reads the clock.
+  void note_submit(bool first_of_shot);
+
+  /// @brief Microseconds since the last note_submit(), or 0 if there was none.
+  double since_last_submit_us() const;
+
+  /// @brief Record that a decode finished, closing this shot's latencies.
+  /// @details Accumulates the interval since the last submit and, when the
+  /// shot's first submit was seen, the interval since that first submit.
+  void note_decode_complete();
+
+  /// @brief Abandon an unfinished shot, as a reset discards its measurements.
+  void note_reset();
+
+  /// @brief Emit the aggregate latency line, if any decode was measured.
+  /// @details Called on destruction; a decoder may also call it earlier, for
+  /// instance to separate a warmup phase from a measured one. A successful
+  /// emission clears the aggregate so the next line covers only later decodes;
+  /// when logging is disabled, the samples remain available for a later call.
+  void emit_summary(const char *file_name = __builtin_FILE(),
+                    int line_no = __builtin_LINE());
+
+  /// @brief Diff two Pauli frames into reusable scratch.
+  /// @details A size mismatch yields no flips rather than a diff against a
+  /// stale frame, which happens when O is replaced mid-stream.
+  void diff_frame(const std::vector<uint8_t> &before,
+                  const std::vector<uint8_t> &now);
+
+  /// @brief Dense flips from the last diff_frame().
+  const std::vector<uint8_t> &frame_flips() const { return frame_flips_; }
+
+  /// @brief Sparse flipped indices from the last diff_frame().
+  const std::vector<uint32_t> &frame_flip_ids() const {
+    return frame_flip_ids_;
+  }
+
+private:
+  using clock = std::chrono::steady_clock;
+
+  const void *owner_ = nullptr;
+  uint32_t decoder_id_ = 0;
+  uint32_t counter_ = 0;
+  /// Whether CUDAQ_QEC_DEBUG_DECODER selected the forwarder-proof printf path.
+  bool printf_mode_ = false;
+  std::vector<uint8_t> frame_flips_;
+  std::vector<uint32_t> frame_flip_ids_;
+  /// Latency bookkeeping: when the current shot's first and latest
+  /// measurements arrived, and the two series closed out by each decode.
+  clock::time_point shot_start_;
+  clock::time_point last_submit_;
+  bool shot_open_ = false;
+  bool have_submit_ = false;
+  latency_series tail_latency_;
+  latency_series shot_latency_;
+};
+
+/// @brief Elapsed-time stopwatch for the stage durations a per-call line
+/// reports, which measures nothing at the levels that emit no such line.
+///
+/// Reading a clock costs more than the branch that skips it, and an
+/// instrumented path usually wants several stage timings, so this keeps the
+/// `detail == arrays ? now() : time_point{}` dance out of decoder code. The
+/// lifetime summary's latencies do not come from here; they come from
+/// decoder_stats::note_submit() and note_decode_complete().
+class stats_timer {
+public:
+  explicit stats_timer(stats_detail detail)
+      : enabled_(detail == stats_detail::arrays) {
+    if (enabled_)
+      last_ = clock::now();
+  }
+
+  /// @brief Microseconds since construction or the previous lap.
+  double lap_us() {
+    if (!enabled_)
+      return 0.0;
+    const auto now = clock::now();
+    const std::chrono::duration<double, std::micro> elapsed = now - last_;
+    last_ = now;
+    return elapsed.count();
+  }
+
+private:
+  using clock = std::chrono::steady_clock;
+  bool enabled_;
+  clock::time_point last_;
+};
+
+} // namespace cudaq::qec

--- a/libs/qec/unittests/CMakeLists.txt
+++ b/libs/qec/unittests/CMakeLists.txt
@@ -35,6 +35,7 @@ find_package(CUDAToolkit REQUIRED)
 add_compile_options(-Wno-attributes) 
 
 add_executable(test_decoders test_decoders.cpp decoders/sample_decoder.cpp)
+target_include_directories(test_decoders PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../lib)
 target_link_libraries(test_decoders PRIVATE GTest::gtest_main cudaq-qec-decoders libstim CUDA::cudart)
 add_dependencies(CUDAQXQECUnitTests test_decoders)
 gtest_discover_tests(test_decoders)

--- a/libs/qec/unittests/test_decoders.cpp
+++ b/libs/qec/unittests/test_decoders.cpp
@@ -9,7 +9,10 @@
 #include "stim.h"
 #include "cudaq/qec/decoder.h"
 #include "cudaq/qec/detector_error_model.h"
+#include "cudaq/qec/logger.h"
 #include "cudaq/qec/pcm_utils.h"
+// Private header from libs/qec/lib; see this target's include directories.
+#include "decoder_stats.h"
 #include <atomic>
 #include <cmath>
 #include <cstdlib>
@@ -39,6 +42,20 @@ public:
 private:
   std::string name;
   std::optional<std::string> oldValue;
+};
+
+// Restore the log level on scope exit so a failed expectation cannot leave the
+// rest of the suite logging.
+class ScopedLogLevel {
+public:
+  explicit ScopedLogLevel(cudaq::qec::detail::log_level level)
+      : previous(cudaq::qec::detail::get_log_level()) {
+    cudaq::qec::detail::set_log_level(level);
+  }
+  ~ScopedLogLevel() { cudaq::qec::detail::set_log_level(previous); }
+
+private:
+  cudaq::qec::detail::log_level previous;
 };
 } // namespace
 
@@ -227,6 +244,85 @@ TEST(SampleDecoder, RealtimeApiAndDefaultGraphHooks) {
 
   // Longer input than the configured measurement buffer is rejected.
   EXPECT_FALSE(decoder->enqueue_syndrome(msyn.data(), msyn.size() + 1));
+}
+
+// An explicit summary is a phase boundary: later summaries must not repeat the
+// warmup samples, and destruction must not emit the last phase a second time.
+TEST(DecoderStats, ExplicitSummaryStartsFreshAggregate) {
+  ScopedLogLevel scoped(cudaq::qec::detail::log_level::info);
+  testing::internal::CaptureStdout();
+  {
+    cudaq::qec::decoder_stats stats;
+    for (int phase = 0; phase < 2; ++phase) {
+      stats.note_submit(/*first_of_shot=*/true);
+      stats.note_decode_complete();
+      stats.emit_summary();
+    }
+  }
+  const auto log = testing::internal::GetCapturedStdout();
+
+  const std::string expected = "stats_summary Decodes:1 ";
+  std::size_t summaries = 0;
+  for (std::size_t at = 0; (at = log.find(expected, at)) != std::string::npos;
+       at += expected.size())
+    ++summaries;
+  EXPECT_EQ(summaries, 2u);
+  EXPECT_EQ(log.find("stats_summary Decodes:2 "), std::string::npos);
+}
+
+// The summary's percentiles come from a fixed-size log-spaced histogram, so
+// they are estimates while the count, mean, min and max stay exact. Feed a
+// known ramp so the estimates can be held to a tolerance.
+TEST(DecoderStats, LatencySeriesPercentilesTrackKnownDistribution) {
+  cudaq::qec::latency_series series;
+  EXPECT_EQ(series.count, 0u);
+  // An empty series has nothing to report rather than a stale or garbage value.
+  EXPECT_EQ(series.percentile_us(0.5), 0.0);
+
+  // A single sample is reported exactly: the bucket it lands in is wider than
+  // the value's own precision, so the estimate is clamped to the range seen.
+  series.add(7.25);
+  EXPECT_DOUBLE_EQ(series.percentile_us(0.5), 7.25);
+  EXPECT_DOUBLE_EQ(series.percentile_us(0.99), 7.25);
+
+  cudaq::qec::latency_series ramp;
+  for (int us = 1; us <= 1000; us++)
+    ramp.add(static_cast<double>(us));
+
+  EXPECT_EQ(ramp.count, 1000u);
+  EXPECT_DOUBLE_EQ(ramp.min_us, 1.0);
+  EXPECT_DOUBLE_EQ(ramp.max_us, 1000.0);
+  EXPECT_NEAR(ramp.average_us(), 500.5, 1e-9);
+
+  // Bucket quantization is proportional to the value, so hold each estimate to
+  // 5% of the exact percentile of the ramp.
+  EXPECT_NEAR(ramp.percentile_us(0.50), 500.0, 25.0);
+  EXPECT_NEAR(ramp.percentile_us(0.90), 900.0, 45.0);
+  EXPECT_NEAR(ramp.percentile_us(0.99), 990.0, 49.5);
+
+  // Percentiles are monotonic in the requested fraction and bounded by the
+  // exact extremes, whatever the distribution.
+  EXPECT_LE(ramp.min_us, ramp.percentile_us(0.50));
+  EXPECT_LE(ramp.percentile_us(0.50), ramp.percentile_us(0.90));
+  EXPECT_LE(ramp.percentile_us(0.90), ramp.percentile_us(0.99));
+  EXPECT_LE(ramp.percentile_us(0.99), ramp.max_us);
+}
+
+// A heavy tail is what the percentiles exist to expose: a handful of slow
+// samples must move p99 without dragging p50 along with them.
+TEST(DecoderStats, LatencySeriesPercentilesSeparateTailFromBody) {
+  // 2% slow, so the slow samples start below the 99th percentile rather than
+  // straddling it.
+  cudaq::qec::latency_series series;
+  for (int i = 0; i < 980; i++)
+    series.add(2.0);
+  for (int i = 0; i < 20; i++)
+    series.add(500.0);
+
+  EXPECT_NEAR(series.percentile_us(0.50), 2.0, 0.1);
+  EXPECT_NEAR(series.percentile_us(0.90), 2.0, 0.1);
+  EXPECT_NEAR(series.percentile_us(0.99), 500.0, 25.0);
+  EXPECT_DOUBLE_EQ(series.max_us, 500.0);
 }
 
 TEST(DecoderPlugins, SingleErrorLutExample_DecodesSingletonColumnSyndromes) {


### PR DESCRIPTION
## Description

Adds `decoder_stats`, the shared machinery behind the realtime `[DecoderStats]` log stream, so any decoder can report latency and replay fields in the line format `libs/qec/utils/replay_decoder_logs.py` already consumes.

`libs/qec/lib/decoder_stats.h` is deliberately **not** a public header: it sits beside its implementation rather than in the installed include tree, so it adds nothing to the decoder API and costs nothing for decoders that do not opt in. A decoder that wants instrumentation includes it, holds a `decoder_stats` member and adds `libs/qec/lib` to its private include directories.

At `info` it emits one lifetime summary line covering two latencies per shot -- tail (last measurements to end of decode) and full-shot (first measurements to the same point) -- as count, mean, min, max and p50/p90/p99. At `debug` it adds a per-call line with counts, durations and sparse arrays for replay capture. Percentiles come from a fixed-size log-spaced histogram rather than a sample buffer, since a realtime decoder cannot size a buffer up front and growing one mid-run would stall the path being measured; count, mean, min and max stay exact.

## Runtime / performance impact
N/A

## Self-review checklist

Please confirm each item before requesting review. Check `[x]` or strike through and explain.

### Before requesting review
- [x] I reviewed my own full diff in GitHub or my editor.
- [x] PR is in Draft if it is not yet ready for review.
- [x] Temporary / debugging changes have been removed.
- [x] Local test logs reviewed; no unexplained warnings or errors.
- [ ] CI logs reviewed; no unexplained warnings or errors.
- [ ] Full CI has been run.

### Scope and size
- [x] PR is under ~1000 lines, or an exception is justified in the description.
- [x] Refactoring-only changes are isolated in their own PR(s).
- [x] No existing tests were disabled or modified just to make this PR pass
      (if so, an issue has been raised).

### Tests
- [x] New functionality has new tests.
- [x] Tests fail if the new functionality is broken (including crashes), not
      just when it is missing.
- [x] Negative tests added where exceptions are expected.
- [x] Truth data added where simple `EXPECT_*` / `assert` checks are
      insufficient for algorithmic correctness.
- [x] CI runtime impact considered; team notified if significant.

### Documentation
- [x] Public-facing APIs have Doxygen docs.
- [x] User-visible behavior changes have public docs, or a follow-up is
      tracked.

### Code style
- [x] Naming follows the existing convention (`snake_case` vs `camelCase`) for
      the area being modified.

### Dependencies
- [x] No new third-party dependencies, **or** the team has been notified and
      OSRB tickets filed.
