### PR TITLE
Add CUDAQ_QEC_DECODERS_ONLY: build and test decoders without CUDA-Q

### DIFF
--- a/.github/workflows/lib_qec.yaml
+++ b/.github/workflows/lib_qec.yaml
@@ -17,6 +17,57 @@ on:
         required: false
 
 jobs:
+  # Build the decoder stack with CUDAQ_QEC_DECODERS_ONLY=ON: no CUDA-Q
+  # install, no LLVM/MLIR, no cuStabilizer. Guards the decoders-only
+  # configuration against rot and demonstrates a decoder call through the
+  # decoders-only python module.
+  decoders-only-build:
+    name: Decoders-only build (no CUDA-Q)
+    strategy:
+      fail-fast: false
+      matrix:
+        platform: ['amd64', 'arm64']
+    runs-on: ${{ startsWith(github.repository, 'NVIDIA/cudaqx') && format('linux-{0}-cpu8', matrix.platform) || 'ubuntu-latest' }}
+    container:
+      image: ghcr.io/nvidia/cuda-quantum-devcontainer:${{ matrix.platform }}-cu13.0-gcc12-main
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          set-safe-directory: true
+
+      - name: Configure and build (decoders only)
+        run: |
+          cmake -S libs/qec -B build_decoders_only \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCUDAQ_QEC_DECODERS_ONLY=ON \
+            -DCUDAQX_QEC_BINDINGS_PYTHON=ON
+          cmake --build build_decoders_only -j$(nproc)
+
+      - name: Smoke test (pymatching decode, no cudaq import)
+        run: |
+          PYTHONPATH=build_decoders_only/python python3 - <<'EOF'
+          import sys
+          assert "cudaq" not in sys.modules
+          import numpy as np
+          import _qec_decoders_standalone
+          qec = _qec_decoders_standalone.qecrt
+          # Distance-4 repetition code (pymatching needs a matching graph:
+          # every H column with at most 2 ones).
+          H = np.array([[1, 1, 0, 0],
+                        [0, 1, 1, 0],
+                        [0, 0, 1, 1]], dtype=np.uint8)
+          decoder = qec.get_decoder("pymatching", H)
+          result = decoder.decode([1, 1, 0])
+          assert result.converged
+          correction = (np.asarray(result.result) >= 0.5).astype(np.uint8)
+          np.testing.assert_array_equal((H @ correction) % 2, [1, 1, 0])
+          assert "cudaq" not in sys.modules
+          print("pymatching decode OK without CUDA-Q:", correction.tolist())
+          EOF
+
   build-and-test:
     name: Build and test
     strategy:

--- a/Building.md
+++ b/Building.md
@@ -66,6 +66,8 @@ Additionally, the following CMake options can be configured:
 - `CUDAQX_ENABLE_LIBS`: Specify which libraries to build (`all`, `qec`)
 - `CUDAQX_INCLUDE_TESTS`: Enable building of tests
 - `CUDAQX_BINDINGS_PYTHON`: Enable Python bindings
+- `CUDAQ_QEC_DECODERS_ONLY`: Build only the QEC decoder stack, with no CUDA-Q
+  install required (see [Decoders-only Build](#decoders-only-build-no-cuda-q-required))
 
 If you want to change which version of CUDA-Q that CUDA-QX is paired with, you
 will need to rebuild CUDA-Q from source. This is achievable by going to the
@@ -82,6 +84,49 @@ contributing to CUDA-QX, but it should be noted that while this environment
 will have many GPU-accelerated simulators installed in it, it won't contain the
 *highest* performing CUDA-Q simulators. See [this note](https://nvidia.github.io/cuda-quantum/latest/using/install/data_center_install.html)
 for more details.
+
+## Decoders-only Build (no CUDA-Q required)
+
+If you only need the decoders -- for example to run a decoder as a standalone
+process, or to develop a decoder plugin -- you can build the decoder stack on
+its own, without a CUDA-Q install. Configure `libs/qec` as the top-level
+project with `CUDAQ_QEC_DECODERS_ONLY=ON`:
+
+```bash
+cmake -S libs/qec -B build_decoders_only \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DCUDAQ_QEC_DECODERS_ONLY=ON \
+  -DCUDAQX_QEC_BINDINGS_PYTHON=ON
+cmake --build build_decoders_only -j$(nproc)
+```
+
+This builds the decoder interface (`libcudaq-qec-decoders.so`), the built-in
+decoders, and the decoder plugins. Neither a CUDA-Q install nor LLVM/MLIR is
+required; a CUDA toolkit still is, since the decoder API links `cudart`. The
+following are skipped because they are the only parts that need CUDA-Q:
+`libcudaq-qec.so` (codes, experiments, DEM sampling), cuStabilizer, the tools,
+the realtime library, and the unit tests.
+
+The option must be set on a build configured with `libs/qec` as the top-level
+directory (`-S libs/qec`); configuring the whole repository with it set is an
+error.
+
+With `CUDAQX_QEC_BINDINGS_PYTHON=ON` you also get a decoders-only Python
+module, with the bindings under `module.qecrt`:
+
+```bash
+PYTHONPATH=build_decoders_only/python python3 -c '
+import numpy as np, _qec_decoders_standalone
+qec = _qec_decoders_standalone.qecrt
+H = np.array([[1, 1, 0, 0], [0, 1, 1, 0], [0, 0, 1, 1]], dtype=np.uint8)
+print(qec.get_decoder("pymatching", H).decode([1, 1, 0]).result)
+'
+```
+
+Note that this module is intentionally not packaged or installed: it is only
+importable as the bare `_qec_decoders_standalone` module from
+`<build>/python`, not as `cudaq_qec`. Use the normal build above if you want
+the installable `cudaq_qec` package.
 
 ## Building CUDA-QX Documentation from Source
 

--- a/libs/qec/CMakeLists.txt
+++ b/libs/qec/CMakeLists.txt
@@ -71,6 +71,21 @@ set(CUDAQ_QEC_BUILD_TRT_DECODER "AUTO" CACHE STRING
 set_property(CACHE CUDAQ_QEC_BUILD_TRT_DECODER
              PROPERTY STRINGS "AUTO" "ON" "OFF")
 
+# Decoders-only build: the decoder interface (libcudaq-qec-decoders.so), the
+# built-in decoders, and the decoder plugins, with no CUDA-Q install and no
+# LLVM/MLIR required. Skips libcudaq-qec.so (codes, experiments, DEM
+# sampling), tools, and unit tests; with CUDAQX_QEC_BINDINGS_PYTHON=ON it
+# builds a decoders-only python module instead of the full cudaq_qec one.
+# A CUDA toolkit is still required (the decoder API links cudart).
+option(CUDAQ_QEC_DECODERS_ONLY
+       "Build only the decoder stack; no CUDA-Q install required."
+       OFF)
+if (CUDAQ_QEC_DECODERS_ONLY AND NOT CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
+  message(FATAL_ERROR
+    "CUDAQ_QEC_DECODERS_ONLY requires configuring libs/qec as the top-level "
+    "project: cmake -S libs/qec -B <build-dir> -DCUDAQ_QEC_DECODERS_ONLY=ON")
+endif()
+
 # Find and configure LLVM, Clang and MLIR
 # ==============================================================================
 # The user can specify the path to LLVM cmake directory using
@@ -79,6 +94,9 @@ set_property(CACHE CUDAQ_QEC_BUILD_TRT_DECODER
 # using `LLVM_VERSION_MAJOR`, e.g. "-LLVM_VERSION_MAJOR=16".  Note that this
 # version variable is set to the latest LLVM version by default, and setting it
 # to an older version might break the project.
+# Skipped entirely in decoders-only mode: nothing on the decoder path needs
+# LLVM, MLIR, or Clang.
+if(NOT CUDAQ_QEC_DECODERS_ONLY)
 if(NOT LLVM_VERSION_MAJOR)
   set(LLVM_VERSION_MAJOR 22)
 endif()
@@ -191,6 +209,7 @@ include_directories(SYSTEM
 
 link_directories(${LLVM_BUILD_LIBRARY_DIR})
 add_definitions(${LLVM_DEFINITIONS})
+endif() # NOT CUDAQ_QEC_DECODERS_ONLY
 
 # Check for CUDA Support (ref: cuda-quantum/CMakeLists.txt)
 # ==============================================================================
@@ -243,10 +262,25 @@ endif()
 # ==============================================================================
 
 if (CUDAQX_QEC_STANDALONE_BUILD)
-  cudaqx_import_cudaq_targets()
+  if (CUDAQ_QEC_DECODERS_ONLY)
+    # The only CUDA-Q-provided target the decoder stack consumes is fmt
+    # (normally imported via NVQIRConfig.cmake); fetch the same pinned commit
+    # directly instead of importing the CUDA-Q targets.
+    include(FetchContent)
+    set(FMT_INSTALL OFF CACHE BOOL "Generate the fmt install target." FORCE)
+    FetchContent_Declare(
+      fmt
+      GIT_REPOSITORY https://github.com/fmtlib/fmt
+      GIT_TAG fc8d07cfe54ba9f5019453dfdb112491246ee017
+      EXCLUDE_FROM_ALL
+    )
+    FetchContent_MakeAvailable(fmt)
+  else()
+    cudaqx_import_cudaq_targets()
 
-  if (CUDAQX_QEC_BINDINGS_PYTHON)
-    find_package(CUDAQPythonInterop CONFIG)
+    if (CUDAQX_QEC_BINDINGS_PYTHON)
+      find_package(CUDAQPythonInterop CONFIG)
+    endif()
   endif()
   # FIXME
   add_subdirectory(../core core_build)
@@ -287,13 +321,15 @@ configure_file("${CMAKE_CURRENT_SOURCE_DIR}/lib/version.cpp.in"
 # ==============================================================================
 
 add_subdirectory(lib)
-add_subdirectory(tools)
+if (NOT CUDAQ_QEC_DECODERS_ONLY)
+  add_subdirectory(tools)
+endif()
 
 if (CUDAQX_QEC_BINDINGS_PYTHON)
   add_subdirectory(python)
 endif()
 
-if (CUDAQX_QEC_INCLUDE_TESTS)
+if (CUDAQX_QEC_INCLUDE_TESTS AND NOT CUDAQ_QEC_DECODERS_ONLY)
   add_custom_target(CUDAQXQECUnitTests)
   if (CUDAQX_QEC_STANDALONE_BUILD)
     include(CTest)

--- a/libs/qec/lib/CMakeLists.txt
+++ b/libs/qec/lib/CMakeLists.txt
@@ -22,6 +22,8 @@ find_package(CUDAToolkit REQUIRED)
 # (FindcuStabilizer auto-discovers it from the active Python environment).
 # If it is missing, surface a clear, actionable error rather than CMake's
 # default "Could NOT find cuStabilizer" message.
+# Decoders-only builds skip it: only libcudaq-qec.so (DEM sampling) needs it.
+if(NOT CUDAQ_QEC_DECODERS_ONLY)
 find_package(cuStabilizer QUIET)
 if(NOT cuStabilizer_FOUND)
   set(_cuda_major "${CUDAToolkit_VERSION_MAJOR}")
@@ -41,6 +43,7 @@ if(NOT cuStabilizer_FOUND)
     "    -DCUSTABILIZER_ROOT=/path/to/custabilizer\n"
     "(both are also honored as environment variables).")
 endif()
+endif() # NOT CUDAQ_QEC_DECODERS_ONLY
 
 set(DEM_SOURCES
   dem_chunks_memory.cpp
@@ -90,8 +93,10 @@ set_target_properties(${DECODERS_LIBRARY_NAME} PROPERTIES
   VISIBILITY_INLINES_HIDDEN ON
   LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 
-# FIXME?: This must be a shared library. Trying to build a static one will fail.
-add_library(${LIBRARY_NAME} SHARED ${QEC_SOURCES})
+if(NOT CUDAQ_QEC_DECODERS_ONLY)
+  # FIXME?: This must be a shared library. Trying to build a static one will fail.
+  add_library(${LIBRARY_NAME} SHARED ${QEC_SOURCES})
+endif()
 
 if(NOT TARGET libstim)
   FetchContent_Declare(
@@ -107,9 +112,11 @@ if(NOT TARGET libstim)
   message(FATAL_ERROR
     "Stim FetchContent did not provide the libstim target.")
 endif()
-set_target_properties(${LIBRARY_NAME} PROPERTIES
-  VISIBILITY_INLINES_HIDDEN ON
-  LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
+if(TARGET ${LIBRARY_NAME})
+  set_target_properties(${LIBRARY_NAME} PROPERTIES
+    VISIBILITY_INLINES_HIDDEN ON
+    LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
+endif()
 
 target_link_libraries(${DEM_LIBRARY_NAME} PRIVATE libstim)
 target_link_options(${DECODERS_LIBRARY_NAME} PRIVATE
@@ -135,13 +142,17 @@ else()
       "Whether the TRT decoder plugin is being built")
 endif()
 
-add_subdirectory(codes)
-add_subdirectory(device) 
+if(NOT CUDAQ_QEC_DECODERS_ONLY)
+  add_subdirectory(codes)
+  add_subdirectory(device)
+endif()
 
 if (CUDAQX_QEC_USE_FLOAT)
    target_compile_definitions(${DEM_LIBRARY_NAME} PUBLIC -DCUDAQX_QEC_FLOAT_TYPE=float)
    target_compile_definitions(${DECODERS_LIBRARY_NAME} PUBLIC -DCUDAQX_QEC_FLOAT_TYPE=float)
-   target_compile_definitions(${LIBRARY_NAME} PUBLIC -DCUDAQX_QEC_FLOAT_TYPE=float)
+   if(TARGET ${LIBRARY_NAME})
+     target_compile_definitions(${LIBRARY_NAME} PUBLIC -DCUDAQX_QEC_FLOAT_TYPE=float)
+   endif()
 endif()
 
 target_include_directories(${DEM_LIBRARY_NAME}
@@ -163,18 +174,7 @@ target_include_directories(${DECODERS_LIBRARY_NAME}
     $<INSTALL_INTERFACE:include>
 )
 
-target_include_directories(${LIBRARY_NAME}
-  PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
-  PUBLIC 
-    $<BUILD_INTERFACE:${CUDAQX_QEC_INCLUDE_DIR}>
-    $<INSTALL_INTERFACE:${CUDAQ_INCLUDE_DIR}>
-    $<INSTALL_INTERFACE:include>
-)
-
 target_link_options(${DECODERS_LIBRARY_NAME} PRIVATE
-  $<$<CXX_COMPILER_ID:GNU>:-Wl,--no-as-needed>
-)
-target_link_options(${LIBRARY_NAME} PUBLIC
   $<$<CXX_COMPILER_ID:GNU>:-Wl,--no-as-needed>
 )
 
@@ -189,27 +189,43 @@ target_link_libraries(${DECODERS_LIBRARY_NAME}
     CUDA::cudart
 )
 
-target_link_libraries(${LIBRARY_NAME}
-  PUBLIC 
-    ${DECODERS_LIBRARY_NAME}
-    cudaq::cudaq-operator
-  PRIVATE
-    cudaq::cudaq-common
-)
+if(TARGET ${LIBRARY_NAME})
+  target_include_directories(${LIBRARY_NAME}
+    PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
+    PUBLIC
+      $<BUILD_INTERFACE:${CUDAQX_QEC_INCLUDE_DIR}>
+      $<INSTALL_INTERFACE:${CUDAQ_INCLUDE_DIR}>
+      $<INSTALL_INTERFACE:include>
+  )
 
-target_link_libraries(${LIBRARY_NAME} PRIVATE
-  cuStabilizer::cuStabilizer
-  CUDA::cudart
-)
-set_source_files_properties(
-  dem_sampling/dem_sampling_utils.cu
-  PROPERTIES LANGUAGE CUDA
-)
+  target_link_options(${LIBRARY_NAME} PUBLIC
+    $<$<CXX_COMPILER_ID:GNU>:-Wl,--no-as-needed>
+  )
+
+  target_link_libraries(${LIBRARY_NAME}
+    PUBLIC
+      ${DECODERS_LIBRARY_NAME}
+      cudaq::cudaq-operator
+    PRIVATE
+      cudaq::cudaq-common
+  )
+
+  target_link_libraries(${LIBRARY_NAME} PRIVATE
+    cuStabilizer::cuStabilizer
+    CUDA::cudart
+  )
+  set_source_files_properties(
+    dem_sampling/dem_sampling_utils.cu
+    PROPERTIES LANGUAGE CUDA
+  )
+endif()
 
 # RPATH configuration 
 # ==============================================================================
 
-if (NOT SKBUILD)
+if (NOT TARGET ${LIBRARY_NAME})
+  # Decoders-only build: no libcudaq-qec.so to configure RPATHs for.
+elseif (NOT SKBUILD)
   # Append the cuStabilizer library directory (typically inside a
   # cuquantum-python pip wheel) so the loader can find libcustabilizer.so.0
   # at run-time without requiring LD_LIBRARY_PATH.
@@ -248,7 +264,11 @@ endif()
 # cudaq-qec-dem.a is intentionally omitted: it is a private build artifact
 # folded into cudaq-qec-decoders.so.
 
-install(TARGETS ${DECODERS_LIBRARY_NAME} ${LIBRARY_NAME}
+set(_qec_install_targets ${DECODERS_LIBRARY_NAME})
+if(TARGET ${LIBRARY_NAME})
+  list(APPEND _qec_install_targets ${LIBRARY_NAME})
+endif()
+install(TARGETS ${_qec_install_targets}
   COMPONENT qec-lib
   LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
 )
@@ -259,4 +279,6 @@ install(DIRECTORY ${CUDAQX_QEC_INCLUDE_DIR}/cudaq
   FILES_MATCHING PATTERN "*.h"
 )
 
-add_subdirectory(realtime)
+if(NOT CUDAQ_QEC_DECODERS_ONLY)
+  add_subdirectory(realtime)
+endif()

--- a/libs/qec/python/CMakeLists.txt
+++ b/libs/qec/python/CMakeLists.txt
@@ -25,6 +25,30 @@ endif()
 
 # ==============================================================================
 
+# Decoders-only module: binds the decoder API (py_decoder.cpp is cudaq-free;
+# the CUDA-Q result-type casters live in cudaq_type_casters.h, which only the
+# full module below compiles). Bindings land under `module.qecrt`.
+if (CUDAQ_QEC_DECODERS_ONLY)
+  set(MODULE_NAME _qec_decoders_standalone)
+
+  cudaqx_add_pymodule(${MODULE_NAME}
+    bindings/cudaqx_qec_decoders_only.cpp
+    bindings/py_decoder.cpp
+  )
+
+  target_link_libraries(${MODULE_NAME} PRIVATE cudaq-qec-decoders)
+
+  find_package(CUDAToolkit REQUIRED)
+  target_link_libraries(${MODULE_NAME} PRIVATE CUDA::cudart)
+  target_include_directories(${MODULE_NAME} PRIVATE ${CUDAToolkit_INCLUDE_DIRS})
+
+  set_target_properties(${MODULE_NAME} PROPERTIES
+    LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/python"
+    BUILD_RPATH "$ORIGIN/../lib")
+
+  return()
+endif()
+
 set(MODULE_NAME _pycudaqx_qec_the_suffix_matters_cudaq_qec)
 
 cudaqx_add_pymodule(${MODULE_NAME}

--- a/libs/qec/python/bindings/cudaq_type_casters.h
+++ b/libs/qec/python/bindings/cudaq_type_casters.h
@@ -1,0 +1,117 @@
+/****************************************************************-*- C++ -*-****
+ * Copyright (c) 2022 - 2026 NVIDIA Corporation & Affiliates.                  *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+#pragma once
+
+// Casters for CUDA-Q runtime result types (spin_op, sample_result,
+// observe_result). These need CUDA-Q headers and the cudaq python module at
+// runtime, so they live apart from type_casters.h: translation units that
+// bind only the decoder API (and are built without a CUDA-Q install) include
+// type_casters.h alone.
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+#include "common/ObserveResult.h"
+#include <nanobind/nanobind.h>
+#include <nanobind/stl/string.h>
+#include <nanobind/stl/vector.h>
+
+namespace nanobind {
+namespace detail {
+
+template <>
+struct type_caster<cudaq::spin_op> {
+  NB_TYPE_CASTER(cudaq::spin_op, const_name("SpinOperator"))
+
+  bool from_python(handle src, uint8_t, cleanup_list *) noexcept {
+    if (!src)
+      return false;
+    try {
+      auto data = nanobind::cast<std::vector<double>>(src.attr("serialize")());
+      value = cudaq::spin_op(data);
+      return true;
+    } catch (...) {
+      return false;
+    }
+  }
+
+  static handle from_cpp(cudaq::spin_op v, rv_policy, cleanup_list *) noexcept {
+    try {
+      nanobind::object tv_py =
+          nanobind::module_::import_("cudaq").attr("SpinOperator")(
+              v.get_data_representation());
+      return tv_py.release();
+    } catch (...) {
+      return handle();
+    }
+  }
+};
+
+template <>
+struct type_caster<cudaq::sample_result> {
+  NB_TYPE_CASTER(cudaq::sample_result, const_name("SampleResult"))
+
+  bool from_python(handle src, uint8_t, cleanup_list *) noexcept {
+    if (!src)
+      return false;
+    try {
+      auto data =
+          nanobind::cast<std::vector<std::size_t>>(src.attr("serialize")());
+      value = cudaq::sample_result();
+      value.deserialize(data);
+      return true;
+    } catch (...) {
+      return false;
+    }
+  }
+
+  static handle from_cpp(cudaq::sample_result v, rv_policy,
+                         cleanup_list *) noexcept {
+    try {
+      nanobind::object tv_py =
+          nanobind::module_::import_("cudaq").attr("SampleResult")();
+      tv_py.attr("deserialize")(v.serialize());
+      return tv_py.release();
+    } catch (...) {
+      return handle();
+    }
+  }
+};
+
+template <>
+struct type_caster<cudaq::observe_result> {
+  NB_TYPE_CASTER(cudaq::observe_result, const_name("ObserveResult"))
+
+  bool from_python(handle src, uint8_t, cleanup_list *) noexcept {
+    if (!src)
+      return false;
+    try {
+      auto e = nanobind::cast<double>(src.attr("expectation")());
+      value = cudaq::observe_result(e, cudaq::spin_op());
+      return true;
+    } catch (...) {
+      return false;
+    }
+  }
+
+  static handle from_cpp(cudaq::observe_result v, rv_policy,
+                         cleanup_list *) noexcept {
+    try {
+      nanobind::object tv_py =
+          nanobind::module_::import_("cudaq").attr("ObserveResult")(
+              v.expectation(), v.get_spin(), v.raw_data());
+      return tv_py.release();
+    } catch (...) {
+      return handle();
+    }
+  }
+};
+
+} // namespace detail
+} // namespace nanobind

--- a/libs/qec/python/bindings/cudaq_type_casters.h
+++ b/libs/qec/python/bindings/cudaq_type_casters.h
@@ -43,9 +43,8 @@ struct type_caster<cudaq::spin_op> {
 
   static handle from_cpp(cudaq::spin_op v, rv_policy, cleanup_list *) noexcept {
     try {
-      nanobind::object tv_py =
-          nanobind::module_::import_("cudaq").attr("SpinOperator")(
-              v.get_data_representation());
+      nanobind::object tv_py = nanobind::module_::import_("cudaq").attr(
+          "SpinOperator")(v.get_data_representation());
       return tv_py.release();
     } catch (...) {
       return handle();
@@ -103,9 +102,8 @@ struct type_caster<cudaq::observe_result> {
   static handle from_cpp(cudaq::observe_result v, rv_policy,
                          cleanup_list *) noexcept {
     try {
-      nanobind::object tv_py =
-          nanobind::module_::import_("cudaq").attr("ObserveResult")(
-              v.expectation(), v.get_spin(), v.raw_data());
+      nanobind::object tv_py = nanobind::module_::import_("cudaq").attr(
+          "ObserveResult")(v.expectation(), v.get_spin(), v.raw_data());
       return tv_py.release();
     } catch (...) {
       return handle();

--- a/libs/qec/python/bindings/cudaqx_qec_decoders_only.cpp
+++ b/libs/qec/python/bindings/cudaqx_qec_decoders_only.cpp
@@ -1,0 +1,21 @@
+/*******************************************************************************
+ * Copyright (c) 2026 NVIDIA Corporation & Affiliates.                         *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+// Decoders-only python module: binds the decoder API from py_decoder.cpp
+// without importing cudaq and without the code/experiment/realtime bindings.
+
+#include "py_decoder.h"
+
+#include <nanobind/nanobind.h>
+
+NB_MODULE(_qec_decoders_standalone, mod) {
+  mod.doc() = "Decoders-only python bindings for CUDA-Q QEC (no CUDA-Q "
+              "install required).";
+  cudaq::qec::bindDecoder(mod);
+  nanobind::set_leak_warnings(false);
+}

--- a/libs/qec/python/bindings/py_code.cpp
+++ b/libs/qec/python/bindings/py_code.cpp
@@ -22,6 +22,7 @@
 #include "cudaq/qec/version.h"
 
 #include "cuda-qx/core/kwargs_utils.h"
+#include "cudaq_type_casters.h"
 #include "type_casters.h"
 
 namespace nb = nanobind;

--- a/libs/qec/python/bindings/py_decoder.cpp
+++ b/libs/qec/python/bindings/py_decoder.cpp
@@ -9,7 +9,6 @@
 #include "cuda-qx/core/library_utils.h"
 #include "sparse_matrix_casters.h"
 #include "type_casters.h"
-#include "cudaq/platform.h"
 #include "cudaq/qec/decoder.h"
 #include "cudaq/qec/detector_error_model.h"
 #include "cudaq/qec/logger.h"

--- a/libs/qec/python/bindings/py_surface_code.cpp
+++ b/libs/qec/python/bindings/py_surface_code.cpp
@@ -7,6 +7,7 @@
  ******************************************************************************/
 
 #include "py_surface_code.h"
+#include "cudaq_type_casters.h"
 #include "type_casters.h"
 
 #include <nanobind/nanobind.h>

--- a/libs/qec/python/bindings/type_casters.h
+++ b/libs/qec/python/bindings/type_casters.h
@@ -10,7 +10,6 @@
 #include <cstring>
 #include <stdexcept>
 
-#include "common/ObserveResult.h"
 #include "cuda-qx/core/heterogeneous_map.h"
 #include "cuda-qx/core/kwargs_utils.h"
 #include "cuda-qx/core/tensor.h"
@@ -21,92 +20,12 @@
 
 namespace nb = nanobind;
 
+// Casters for CUDA-Q runtime result types (spin_op, sample_result,
+// observe_result) live in cudaq_type_casters.h; they need CUDA-Q headers,
+// which decoder-only translation units must not depend on.
+
 namespace nanobind {
 namespace detail {
-
-template <>
-struct type_caster<cudaq::spin_op> {
-  NB_TYPE_CASTER(cudaq::spin_op, const_name("SpinOperator"))
-
-  bool from_python(handle src, uint8_t, cleanup_list *) noexcept {
-    if (!src)
-      return false;
-    try {
-      auto data = nb::cast<std::vector<double>>(src.attr("serialize")());
-      value = cudaq::spin_op(data);
-      return true;
-    } catch (...) {
-      return false;
-    }
-  }
-
-  static handle from_cpp(cudaq::spin_op v, rv_policy, cleanup_list *) noexcept {
-    try {
-      nb::object tv_py = nb::module_::import_("cudaq").attr("SpinOperator")(
-          v.get_data_representation());
-      return tv_py.release();
-    } catch (...) {
-      return handle();
-    }
-  }
-};
-
-template <>
-struct type_caster<cudaq::sample_result> {
-  NB_TYPE_CASTER(cudaq::sample_result, const_name("SampleResult"))
-
-  bool from_python(handle src, uint8_t, cleanup_list *) noexcept {
-    if (!src)
-      return false;
-    try {
-      auto data = nb::cast<std::vector<std::size_t>>(src.attr("serialize")());
-      value = cudaq::sample_result();
-      value.deserialize(data);
-      return true;
-    } catch (...) {
-      return false;
-    }
-  }
-
-  static handle from_cpp(cudaq::sample_result v, rv_policy,
-                         cleanup_list *) noexcept {
-    try {
-      nb::object tv_py = nb::module_::import_("cudaq").attr("SampleResult")();
-      tv_py.attr("deserialize")(v.serialize());
-      return tv_py.release();
-    } catch (...) {
-      return handle();
-    }
-  }
-};
-
-template <>
-struct type_caster<cudaq::observe_result> {
-  NB_TYPE_CASTER(cudaq::observe_result, const_name("ObserveResult"))
-
-  bool from_python(handle src, uint8_t, cleanup_list *) noexcept {
-    if (!src)
-      return false;
-    try {
-      auto e = nb::cast<double>(src.attr("expectation")());
-      value = cudaq::observe_result(e, cudaq::spin_op());
-      return true;
-    } catch (...) {
-      return false;
-    }
-  }
-
-  static handle from_cpp(cudaq::observe_result v, rv_policy,
-                         cleanup_list *) noexcept {
-    try {
-      nb::object tv_py = nb::module_::import_("cudaq").attr("ObserveResult")(
-          v.expectation(), v.get_spin(), v.raw_data());
-      return tv_py.release();
-    } catch (...) {
-      return handle();
-    }
-  }
-};
 
 template <>
 struct type_caster<cudaqx::heterogeneous_map> {


### PR DESCRIPTION
cmake -S libs/qec -B build -DCUDAQ_QEC_DECODERS_ONLY=ON builds the decoder interface (libcudaq-qec-decoders.so), the built-in decoders, and the decoder plugins with no CUDA-Q install and no LLVM/MLIR required; with CUDAQX_QEC_BINDINGS_PYTHON=ON it also builds a decoders-only python module (_qec_decoders_standalone, bindings under module.qecrt). fmt is fetched at the pin NVQIRConfig.cmake uses; cuStabilizer, libcudaq-qec.so (codes, experiments, DEM sampling), tools, realtime, and unit tests are skipped because only they need CUDA-Q. When the option is OFF every guard reduces to the existing behavior.

To let py_decoder.cpp compile without a CUDA-Q install, the CUDA-Q result-type casters (spin_op, sample_result, observe_result) move from type_casters.h into a new cudaq_type_casters.h, included by their only two consumers (py_code.cpp, py_surface_code.cpp), and py_decoder.cpp drops its unused cudaq/platform.h include. No behavior change for the full cudaq_qec module.

In decoders-only mode libs/qec/python/CMakeLists.txt returns early, so no cudaq_qec package files or install rules are generated: the module is only importable as bare _qec_decoders_standalone from <build>/python. That is intentional for now.

CI: a decoders-only build job in lib_qec.yaml (amd64 + arm64, cu13 devcontainer, no CUDA-Q build step) plus a smoke test that decodes a repetition-code syndrome via get_decoder("pymatching") through the decoders-only module and asserts cudaq is never imported.