### PR TITLE
Add relay_solutions post-processing helper for nv-qldpc-decoder

### DIFF
--- a/docs/sphinx/api/qec/nv_qldpc_decoder_api.rst
+++ b/docs/sphinx/api/qec/nv_qldpc_decoder_api.rst
@@ -179,6 +179,41 @@
             iterations. Introduced in 0.4.0. Note: Not supported for `composition=1`.
           - `num_iter` (bool): If true, return the number of BP iterations run.
             Introduced in 0.5.0.
+          - `relay_solutions` (bool or int): Record every relay convergence
+            ("solution"), not just the winning one. `True` records all of
+            them; a positive integer caps the number of records kept per shot
+            (convergences beyond the cap still increment the per-shot total
+            but are not stored). Requires `composition=1` (sequential relay)
+            on the sparse GPU path (`use_sparsity=True`); other backends
+            reject the option at construction. Not yet supported with
+            `gamma_ensemble_size > 1`. Compatible with `use_osd=True` (OSD
+            post-processes non-converged shots and does not affect the
+            records). Introduced in 0.8.0.
+
+            Each record holds the cumulative BP iteration count at which the
+            convergence occurred, the LLR weight of its hard decision (the sum
+            of error-rate LLRs over bits decoded as 1), and the hard decision
+            itself, bit-packed 32 bits per little-endian word. The hard
+            decision is the correction vector, or its observable flips when
+            the decoder was constructed with `O`.
+
+            The records describe a batch as a whole, so `decode_batch()`
+            returns them through its batch-level results (the
+            `BatchDecoderResult.batch_opt_results` attribute in Python; the
+            optional `batch_opt_results` output parameter in C++) as flat
+            arrays under the keys `relay_solutions_width`,
+            `relay_solutions_max_records`, `relay_solutions_counts`,
+            `relay_solutions_totals`, `relay_solutions_iters`,
+            `relay_solutions_weight`, and `relay_solutions_result`.
+            (`decode()` returns the same keys through
+            `DecoderResult.opt_results`, with scalar `relay_solutions_count` /
+            `relay_solutions_total`.) The `cudaq_qec.relay_solutions` Python
+            module post-processes the records: `unpack()` reconstructs the
+            per-shot record axes, and `stop_nconv_sweep()` replays an entire
+            RelayBP-N `stop_nconv` sweep — logical error rate, mean
+            iterations, and iteration percentiles for every N — from a single
+            recording run. See :ref:`relay_solutions_user_guide` for a usage
+            and performance walkthrough.
         - `gamma_ensemble_size` (int): Number of parallel gamma trajectories
           ("lanes") run per sequential-relay BP iteration. Allowed values are
           1, 2, 4, and 8 (defaults to 1, which disables the ensemble). Each

--- a/docs/sphinx/api/qec/python_api.rst
+++ b/docs/sphinx/api/qec/python_api.rst
@@ -197,6 +197,18 @@ NVIDIA QLDPC Decoder
 
 .. include:: nv_qldpc_decoder_api.rst
 
+Relay Solutions Post-Processing
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. automodule:: cudaq_qec.relay_solutions
+
+.. autofunction:: cudaq_qec.relay_solutions.unpack
+.. autofunction:: cudaq_qec.relay_solutions.stop_nconv_sweep
+.. autoclass:: cudaq_qec.relay_solutions.RelaySolutionRecords
+    :members:
+.. autoclass:: cudaq_qec.relay_solutions.StopNConvSweep
+    :members:
+
 Sliding Window Decoder
 ----------------------
 

--- a/docs/sphinx/performance/index.rst
+++ b/docs/sphinx/performance/index.rst
@@ -8,7 +8,12 @@ The first study shows how **gamma ensembling** narrows the Relay BP decode-laten
 tail, improving the logical error rate under hard decode deadlines by up to **~89x**
 on bivariate-bicycle codes (measured on a single GB200 with CUDA-Q QEC 0.7.0).
 
+The second study shows how **relay solution recording** replaces a per-``stop_nconv``
+sweep of full decode runs with a single recording run plus offline post-processing,
+reproducing every RelayBP-N result exactly from one GPU pass.
+
 .. toctree::
    :maxdepth: 1
 
    Improving Relay BP Decoding With Gamma Ensembles <nv_qldpc_gamma_ensemble_user_guide>
+   Sweeping Relay BP Stopping Criteria From a Single Run <nv_qldpc_relay_solutions_user_guide>

--- a/docs/sphinx/performance/nv_qldpc_relay_solutions_user_guide.rst
+++ b/docs/sphinx/performance/nv_qldpc_relay_solutions_user_guide.rst
@@ -1,0 +1,159 @@
+.. The data on this page is reproducible with the parameter table below and
+   the code snippets on this page, using the vendored Z-only gross-code
+   circuit assets/benchmarks/bb144_memory_Z.stim (from the Relay-BP
+   reference implementation, https://github.com/trmue/relay; run
+   `git lfs pull` if it appears as a pointer stub). Syndromes sampled with
+   stim's compile_detector_sampler(seed=13).
+   Tested at:
+     cudaqx  73b8fcec
+
+.. _relay_solutions_user_guide:
+
+Sweeping Relay BP Stopping Criteria From a Single Run
+=====================================================
+
+The NV-qLDPC Relay BP decoder walks through a schedule of gamma sets ("legs") and can converge to a valid solution multiple times along the way; the ``stopping_criterion`` and ``stop_nconv`` parameters decide how many of those convergences to collect before returning the minimum-weight one (the RelayBP-N algorithm). ``stop_nconv`` is a genuine tuning knob: a larger N can lower the logical error rate (more candidate solutions to pick the minimum-weight answer from) but costs more BP iterations per shot, so choosing it means measuring the whole accuracy/latency trade-off curve.
+
+Measured directly, that curve is expensive: every candidate N requires re-decoding the same syndromes in a separate full GPU run, and each run discards everything about the convergences except the single winning solution. The ``relay_solutions`` option removes this waste. When the decoder is constructed with ``opt_results={"relay_solutions": True}``, one run records *every* relay convergence — the cumulative iteration count at which it happened, the LLR weight of its hard decision, and the hard decision itself — and the :mod:`cudaq_qec.relay_solutions` post-processing helper replays the entire ``stop_nconv`` sweep offline from that recording. One GPU run, plus milliseconds of NumPy, answers every N at once. The reconstruction is exact, not approximate: with ``repeatable=True`` the reconstructed logical error rate and iteration statistics match a real ``stop_nconv=N`` run bit-for-bit, for every N.
+
+Recording a run
++++++++++++++++
+
+The recording run must not itself stop early — it uses ``stopping_criterion="All"`` so every convergence in the schedule is observed — and it should return per-shot iteration counts (``num_iter``), which the sweep uses for shots that exhaust the schedule. Everything else is the decoder configuration you are tuning. The example below uses the ``[[144,12,12]]`` bivariate-bicycle (gross) code with the canonical Relay BP settings for that code:
+
+.. code-block:: python
+
+    import cudaq_qec as qec
+    from cudaq_qec import relay_solutions
+
+    # H, O, error_rates, syndromes, obs_truth come from a circuit-level DEM
+    decoder = qec.get_decoder(
+        "nv-qldpc-decoder", H, error_rate_vec=error_rates,
+        use_sparsity=True, bp_method=3, composition=1, max_iterations=60,
+        gamma0=0.125, gamma_dist=[-0.24, 0.66], clip_value=200.0,
+        repeatable=True, proc_float="fp32",
+        O=O,                                      # records become obs flips
+        srelay_config={"pre_iter": 80, "num_sets": 60,
+                       "stopping_criterion": "All"},   # observe every leg
+        opt_results={"relay_solutions": True,          # record all solutions
+                     "num_iter": True},
+        bp_batch_size=1000)
+
+    results = decoder.decode_batch(syndromes)
+
+    # Replay the whole RelayBP-N sweep from the one recording. n_values
+    # defaults to every N up to the deepest recording (the largest number
+    # of convergences any shot produced).
+    sweep = relay_solutions.stop_nconv_sweep(
+        results, obs_truth, percentiles=[50, 99])
+
+    for j, n in enumerate(sweep.n):
+        print(f"stop_nconv={n}: LER={sweep.ler[j]:.2e}, "
+              f"mean iters={sweep.avg_iters[j]:.1f}, "
+              f"p99 iters={sweep.iters_percentiles[1, j]:.0f}")
+
+For every N, :func:`~cudaq_qec.relay_solutions.stop_nconv_sweep` reproduces exactly what ``stopping_criterion="NConv", stop_nconv=N`` would have returned per shot: the prediction is the minimum-weight record among the first N convergences, and the iteration count is the cumulative count at the Nth convergence (or the shot's full-schedule ``num_iter`` when it produced fewer than N). It returns the logical error rate, mean iterations, any requested iteration percentiles, and the fraction of shots that exhausted the schedule, for each N. The raw records are also available directly — :func:`~cudaq_qec.relay_solutions.unpack` reconstructs the per-shot record axes from ``results.batch_opt_results`` — for custom analyses such as weight-spectrum or convergence-time studies.
+
+Example: RelayBP-N on the gross code
+++++++++++++++++++++++++++++++++++++
+
+We decode the ``[[144,12,12]]`` gross code at ``p = 0.002`` with the configuration above, using split decoding: the Z-only memory circuit from the Relay-BP reference implementation (vendored under ``assets/benchmarks/``), whose detector error model covers the Z-stabilizer detectors only.
+
+.. list-table:: Decoder and experiment parameters
+   :header-rows: 1
+   :widths: 32 68
+
+   * - Parameter
+     - Value
+   * - GPU
+     - NVIDIA RTX PRO 3000 (Blackwell, laptop)
+   * - Code
+     - ``[[144,12,12]]`` (Z-only split circuit), 12 rounds
+   * - Noise model
+     - uniform circuit-level, ``p = 0.002``
+   * - Shots
+     - 100,000
+   * - ``bp_method``
+     - 3
+   * - ``composition``
+     - 1
+   * - ``gamma0``
+     - 0.125
+   * - ``gamma_dist``
+     - ``[-0.24, 0.66]``
+   * - ``clip_value``
+     - 200.0
+   * - ``max_iterations``
+     - 60 (per leg)
+   * - ``use_sparsity`` / ``repeatable``
+     - True / True
+   * - ``proc_float``
+     - ``"fp32"``
+   * - ``pre_iter`` / ``num_sets``
+     - 80 / 60
+   * - ``bp_batch_size``
+     - 1,000
+
+The single recording run took **256 s** (2.6 ms/shot) for the 100,000 shots, and the offline sweep over every N from 1 to 61 took **414 ms**. A few points on the curve:
+
+.. list-table:: RelayBP-N sweep, all reconstructed from the one recording run
+   :header-rows: 1
+
+   * - ``stop_nconv``
+     - Logical errors (of 100,000)
+     - Mean iterations
+     - p50 iterations
+     - p99 iterations
+     - Schedule exhausted
+   * - 1
+     - 5
+     - 12.9
+     - 10
+     - 51
+     - 0%
+   * - 2
+     - 3
+     - 26.6
+     - 20
+     - 118
+     - 0%
+   * - 3
+     - 2
+     - 39.5
+     - 31
+     - 162
+     - 0%
+   * - 5
+     - 1
+     - 65.5
+     - 52
+     - 243
+     - 0.01%
+   * - 15
+     - 1
+     - 193.0
+     - 164
+     - 646
+     - 0.06%
+   * - 50
+     - 1
+     - 622.5
+     - 554
+     - 1890
+     - 1.51%
+
+The sweep shows the trade-off directly: the logical error rate falls roughly 5x between N = 1 and N = 5 (5e-5 to 1e-5) and then saturates, while the iteration cost keeps growing linearly in N — so for this code and noise, ``stop_nconv=5`` buys all of the measured accuracy at a small fraction of the cost of larger N. Every row of this table — and the 55 other N values on the curve — comes from the same single GPU run. Measuring the curve directly would instead cost one full decode of the same 100,000 syndromes per N — cheap for small N, increasingly close to the recording run's cost as N grows, and always another full GPU pass for every additional point on the curve. The recording also captures strictly more information than the sweep consumes — per-record weights and convergence times for every shot — so later questions (a different percentile, a subset of shots, a custom tie-breaking rule) are answered from the same data with no further GPU time.
+
+Practical notes
++++++++++++++++
+
+* **Record observables, not corrections.** Constructing the decoder with the observables matrix ``O`` makes each record ``O @ correction (mod 2)`` — for the gross-code DEM above this is 12 bits per record instead of 8,784, shrinking readback and post-processing cost by orders of magnitude. Without ``O``, pass the matrix to ``stop_nconv_sweep(..., observables=O)`` instead so it can score the logical error rate.
+* **Memory.** ``relay_solutions=True`` records every convergence, bounded by ``num_sets`` (+1 if ``pre_iter > 0``) records per shot. To bound memory on long schedules, pass an integer cap (e.g. ``relay_solutions=16``); the sweep will refuse N values beyond a cap that actually truncated records, so cap at or above the largest N you intend to sweep.
+* **Repeatability.** With ``repeatable=True`` (and a non-zero ``clip_value``) the reconstruction is bit-for-bit identical to real ``stop_nconv=N`` runs. Without it, runs differ by floating-point non-determinism, and the reconstruction matches a real run only statistically.
+
+See Also
+++++++++
+
+* :ref:`Quantum Low-Density Parity-Check Decoder <qldpc_decoder>` -- the nv-qldpc-decoder overview
+* :ref:`C++ <nv_qldpc_decoder_api_cpp>` and :ref:`Python <nv_qldpc_decoder_api_python>` API reference -- the ``relay_solutions`` option under ``opt_results``
+* :ref:`ensemble_gamma_user_guide` -- a complementary Relay BP performance study

--- a/libs/qec/include/cudaq/qec/decoder.h
+++ b/libs/qec/include/cudaq/qec/decoder.h
@@ -199,6 +199,30 @@ public:
   virtual std::vector<decoder_result>
   decode_batch(const std::vector<std::vector<float_t>> &syndrome);
 
+  /// @brief Decode multiple independent syndromes, additionally returning
+  /// results that describe the batch as a whole rather than any single shot.
+  ///
+  /// Per-shot data belongs in `decoder_result::opt_results`. This overload
+  /// exists for data that is naturally batch-wide: returning it once as flat
+  /// batch-indexed arrays is more efficient to produce and to consume than
+  /// splitting it into one small map entry per shot.
+  ///
+  /// The default implementation forwards to the single-argument overload and
+  /// leaves @p batch_opt_results empty, so decoders that have no batch-level
+  /// data need not override this. Decoders that override either overload
+  /// should pull both into scope with `using decoder::decode_batch;` to avoid
+  /// overload hiding.
+  ///
+  /// @param syndrome A vector of `N` syndrome measurements where the floating
+  /// point value is the probability that the syndrome measurement is a |1>.
+  /// @param batch_opt_results Output parameter receiving batch-level results,
+  /// or left unset if the decoder produces none.
+  /// @returns 2-D vector of size `N` x `block_size` with soft probabilities of
+  /// errors in each index.
+  virtual std::vector<decoder_result>
+  decode_batch(const std::vector<std::vector<float_t>> &syndrome,
+               std::optional<cudaqx::heterogeneous_map> &batch_opt_results);
+
   /// @brief Construct a registered decoder by name.
   /// @param name The registered decoder name.
   /// @param init A parity-check matrix or raw Stim DEM string.

--- a/libs/qec/lib/decoder.cpp
+++ b/libs/qec/lib/decoder.cpp
@@ -123,6 +123,15 @@ decoder::decode_batch(const std::vector<std::vector<float_t>> &syndrome) {
   return result;
 }
 
+// Decoders with no batch-level results inherit this: run the ordinary batch
+// decode and leave the out-param unset.
+std::vector<decoder_result> decoder::decode_batch(
+    const std::vector<std::vector<float_t>> &syndrome,
+    std::optional<cudaqx::heterogeneous_map> &batch_opt_results) {
+  batch_opt_results.reset();
+  return decode_batch(syndrome);
+}
+
 std::string decoder::get_version() const {
   std::stringstream ss;
   ss << "CUDA-Q QEC Base Decoder Interface " << cudaq::qec::getVersion() << " ("

--- a/libs/qec/lib/decoders/plugins/trt_decoder/trt_decoder.cpp
+++ b/libs/qec/lib/decoders/plugins/trt_decoder/trt_decoder.cpp
@@ -425,6 +425,7 @@ public:
 
   virtual decoder_result decode(const std::vector<float_t> &syndrome) override;
 
+  using decoder::decode_batch; // keep the batch_opt_results overload visible
   virtual std::vector<decoder_result>
   decode_batch(const std::vector<std::vector<float_t>> &syndromes) override;
 

--- a/libs/qec/lib/decoders/sliding_window.h
+++ b/libs/qec/lib/decoders/sliding_window.h
@@ -115,6 +115,7 @@ public:
   /// @brief Decode multiple syndromes in batch
   /// @param syndromes Multiple syndrome measurements to decode
   /// @return The decoded error corrections
+  using decoder::decode_batch; // keep the batch_opt_results overload visible
   std::vector<decoder_result>
   decode_batch(const std::vector<std::vector<float_t>> &syndromes) override;
 

--- a/libs/qec/python/bindings/py_decoder.cpp
+++ b/libs/qec/python/bindings/py_decoder.cpp
@@ -106,7 +106,8 @@ struct batch_decoder_result {
   // checked here since nanobind cannot see them.
   batch_decoder_result(nb::ndarray<nb::numpy, float_t, nb::ndim<2>> result_arr,
                        nb::ndarray<nb::numpy, bool, nb::ndim<1>> converged_arr,
-                       nb::object opt_results) {
+                       nb::object opt_results, nb::object batch_opt_results)
+      : batch_opt_results(batch_opt_results) {
     size = converged_arr.shape(0);
     if (result_arr.shape(0) != size)
       throw std::runtime_error(
@@ -139,13 +140,17 @@ struct batch_decoder_result {
   // Trusted internal constructor: callers guarantee shape/dtype invariants.
   // Used by makeBatchDecoderResult and batchSliceToBatchDecoderResult.
   batch_decoder_result(nb::object result, nb::object converged,
-                       nb::list opt_results, std::size_t size)
+                       nb::list opt_results, std::size_t size,
+                       nb::object batch_opt_results = nb::none())
       : result(result), converged(converged), opt_results(opt_results),
-        size(size) {}
+        batch_opt_results(batch_opt_results), size(size) {}
 
   nb::object result;
   nb::object converged;
   nb::list opt_results;
+  // Batch-level results, or None. Describes the batch as a whole, so it is
+  // deliberately not sliced or indexed alongside the per-shot arrays.
+  nb::object batch_opt_results;
   std::size_t size = 0;
 };
 
@@ -191,6 +196,9 @@ batchSliceToBatchDecoderResult(const batch_decoder_result &batch,
   nb::object converged = batch.converged.attr("__getitem__")(slice);
   nb::list opt_results =
       nb::cast<nb::list>(batch.opt_results.attr("__getitem__")(slice));
+  // batch_opt_results is dropped: its arrays are indexed by position in the
+  // full batch, so carrying them onto a slice unchanged would silently
+  // misalign them with the sliced per-shot rows.
   return batch_decoder_result(result, converged, opt_results,
                               nb::len(converged));
 }
@@ -275,13 +283,15 @@ decoderResultsOptResultsToList(const std::vector<decoder_result> &results) {
   return opt_results;
 }
 
-batch_decoder_result
-makeBatchDecoderResult(const std::vector<decoder_result> &results) {
+batch_decoder_result makeBatchDecoderResult(
+    const std::vector<decoder_result> &results,
+    const std::optional<cudaqx::heterogeneous_map> &batch_opt_results) {
   return batch_decoder_result{
       decoderResultsToNumpy(results),
       decoderResultsConvergedToNumpy(results),
       decoderResultsOptResultsToList(results),
       results.size(),
+      batch_opt_results.has_value() ? nb::cast(*batch_opt_results) : nb::none(),
   };
 }
 
@@ -390,7 +400,8 @@ void bindDecoder(nb::module_ &mod) {
     constructor to produce one. `result` should be a 2-D NumPy array of the
     configured QEC floating point dtype (float64 in standard wheels);
     `converged` should be a 1-D NumPy bool array; `opt_results` is a list of
-    per-shot dicts or None entries. The constructor coerces `result` and
+    per-shot dicts or None entries; `batch_opt_results` is an optional dict of
+    batch-level results. The constructor coerces `result` and
     `converged` to C-contiguous storage of the expected dtype (via
     `np.ascontiguousarray`), copying when the input doesn't already satisfy
     those invariants. Wrong rank (e.g. 1-D `result`) is rejected with
@@ -422,9 +433,11 @@ void bindDecoder(nb::module_ &mod) {
          incompatible. Avoid in hot loops; prefer pattern 1.
 )pbdoc")
       .def(nb::init<nb::ndarray<nb::numpy, float_t, nb::ndim<2>>,
-                    nb::ndarray<nb::numpy, bool, nb::ndim<1>>, nb::object>(),
+                    nb::ndarray<nb::numpy, bool, nb::ndim<1>>, nb::object,
+                    nb::object>(),
            nb::arg("result"), nb::arg("converged"),
-           nb::arg("opt_results") = nb::none())
+           nb::arg("opt_results") = nb::none(),
+           nb::arg("batch_opt_results") = nb::none())
       .def_prop_ro(
           "result",
           [](const batch_decoder_result &self) { return self.result; },
@@ -445,6 +458,23 @@ void bindDecoder(nb::module_ &mod) {
           [](const batch_decoder_result &self) { return self.opt_results; },
           R"pbdoc(
         A list of per-shot optional result dictionaries, or None entries.
+    )pbdoc")
+      .def_prop_ro(
+          "batch_opt_results",
+          [](const batch_decoder_result &self) {
+            return self.batch_opt_results;
+          },
+          R"pbdoc(
+        A dict of batch-level optional results, or None.
+
+        Unlike `opt_results`, this describes the batch as a whole rather than
+        any single shot: its arrays are indexed by position in the batch. Most
+        decoders produce None here. It is the fast path for data that would
+        otherwise cost one Python dict and several small arrays per shot.
+
+        Because its arrays are indexed by position in the full batch, slicing a
+        BatchDecoderResult drops this field rather than carrying it through
+        misaligned.
     )pbdoc")
       .def(
           "__getitem__",
@@ -532,8 +562,11 @@ void bindDecoder(nb::module_ &mod) {
           "decode_batch",
           [](decoder &decoder,
              const std::vector<std::vector<float_t>> &syndrome) {
-            auto results = decoder.decode_batch(syndrome);
-            return makeBatchDecoderResult(results);
+            // Always the two-argument overload: decoders with no batch-level
+            // results inherit the base implementation and leave it unset.
+            std::optional<cudaqx::heterogeneous_map> batch_opt_results;
+            auto results = decoder.decode_batch(syndrome, batch_opt_results);
+            return makeBatchDecoderResult(results, batch_opt_results);
           },
           "Decode multiple syndromes and return the results",
           nb::arg("syndrome"))

--- a/libs/qec/python/cudaq_qec/__init__.py
+++ b/libs/qec/python/cudaq_qec/__init__.py
@@ -146,6 +146,7 @@ role_to_str = qecrt.role_to_str
 sc_orientation = qecrt.sc_orientation
 
 from .dem_sampling import dem_sampling
+from . import relay_solutions
 
 from .plugins import decoders, codes
 import pkgutil, importlib

--- a/libs/qec/python/cudaq_qec/relay_solutions.py
+++ b/libs/qec/python/cudaq_qec/relay_solutions.py
@@ -1,0 +1,332 @@
+# ============================================================================ #
+# Copyright (c) 2026 NVIDIA Corporation & Affiliates.                          #
+# All rights reserved.                                                         #
+#                                                                              #
+# This source code and the accompanying materials are made available under    #
+# the terms of the Apache License 2.0 which accompanies this distribution.    #
+# ============================================================================ #
+"""Post-processing for the nv-qldpc-decoder ``relay_solutions`` records.
+
+When the decoder is configured with ``opt_results={"relay_solutions": True}``
+(sequential relay, ``composition=1``), every relay convergence is recorded and
+returned through ``BatchDecoderResult.batch_opt_results`` as flat arrays. This
+module reconstructs, offline, what the decoder would have returned for any
+``stop_nconv`` setting, so a single recording run answers the whole
+RelayBP-N sweep.
+
+Public API:
+    unpack(batch_opt_results, num_shots) -> RelaySolutionRecords
+    stop_nconv_sweep(results, obs_truth, percentiles=..., n_values=None, observables=None) -> StopNConvSweep
+
+Requirements on the recording run (documented, not detectable from the data):
+the sweep is only meaningful if the run did not itself stop early, i.e.
+``srelay_config={"stopping_criterion": "All"}`` and ``relay_solutions=True``
+(uncapped). A capped run (``relay_solutions=<int>``) is detected and rejected
+for any N beyond the cap.
+"""
+
+from dataclasses import dataclass
+
+import numpy as np
+
+_WORD_BYTES = 4  # records are packed into 32-bit words, little-endian bits
+
+
+def _words_per_record(width):
+    return (int(width) + 31) // 32
+
+
+def _unpack_words(words, width):
+    """(..., W) int32 words -> (..., width) 0/1 uint8, little-endian bits."""
+    words = np.ascontiguousarray(np.asarray(words, dtype=np.int32))
+    as_bytes = words.view(np.uint8).reshape(words.shape[:-1] +
+                                            (words.shape[-1] * _WORD_BYTES,))
+    return np.unpackbits(as_bytes, axis=-1, bitorder="little")[..., :width]
+
+
+def _pack_words(bits, width):
+    """(..., width) 0/1 -> (..., W) int32 words, little-endian bits."""
+    bits = np.asarray(bits, dtype=np.uint8)
+    if bits.shape[-1] != width:
+        raise ValueError(f"expected {width} bits per row, got {bits.shape[-1]}")
+    as_bytes = np.packbits(bits, axis=-1, bitorder="little")
+    pad = _words_per_record(width) * _WORD_BYTES - as_bytes.shape[-1]
+    if pad:
+        pad_widths = [(0, 0)] * (as_bytes.ndim - 1) + [(0, pad)]
+        as_bytes = np.pad(as_bytes, pad_widths)
+    return np.ascontiguousarray(as_bytes).view(np.int32)
+
+
+@dataclass(frozen=True)
+class RelaySolutionRecords:
+    """The ``relay_solutions_*`` arrays with the record axes reconstructed.
+
+    Rows beyond a shot's own record count are padding: iteration count -1,
+    weight +inf, packed bits all zero.
+    """
+    width: int  #: bits per record (block_size, or num_obs when O was given)
+    max_records: int  #: the record axis (R) of the padded arrays
+    counts: np.ndarray  #: (num_shots,) records stored per shot
+    totals: np.ndarray  #: (num_shots,) convergences seen per shot (uncapped)
+    iters: np.ndarray  #: (num_shots, R) cumulative iterations at each record
+    weight: np.ndarray  #: (num_shots, R) LLR weight of each record
+    packed: np.ndarray  #: (num_shots, R, W) int32 words, 32 bits per word
+
+    def bits(self, shot, record):
+        """One record's hard decision as a 0/1 vector of length ``width``."""
+        return _unpack_words(self.packed[shot, record], self.width)
+
+
+def unpack(batch_opt_results, num_shots):
+    """Reshape the flat ``relay_solutions_*`` arrays.
+
+    Accepts either the batched key set (``relay_solutions_counts``/``totals``,
+    from decode_batch) or the single-shot one (``relay_solutions_count``/
+    ``total``, from decode, with ``num_shots == 1``).
+    """
+    m = batch_opt_results
+    if m is None:
+        raise ValueError("no relay_solutions records: run the decoder with "
+                         'opt_results={"relay_solutions": True} and read '
+                         "BatchDecoderResult.batch_opt_results")
+    width = int(m["relay_solutions_width"])
+    R = int(m["relay_solutions_max_records"])
+    W = _words_per_record(width)
+
+    if "relay_solutions_counts" in m:
+        counts = np.asarray(m["relay_solutions_counts"])
+        totals = np.asarray(m["relay_solutions_totals"])
+    else:
+        if num_shots != 1:
+            raise ValueError(
+                f"single-shot relay_solutions keys but num_shots={num_shots}")
+        counts = np.asarray([m["relay_solutions_count"]])
+        totals = np.asarray([m["relay_solutions_total"]])
+    if counts.shape != (num_shots,) or totals.shape != (num_shots,):
+        raise ValueError(
+            f"relay_solutions counts/totals have shape {counts.shape}/"
+            f"{totals.shape}, expected ({num_shots},)")
+
+    def reshape(key, shape):
+        arr = np.asarray(m[key])
+        expected = int(np.prod(shape))
+        if arr.shape != (expected,):
+            raise ValueError(
+                f"{key} has shape {arr.shape}, expected ({expected},)")
+        return arr.reshape(shape)
+
+    return RelaySolutionRecords(
+        width=width,
+        max_records=R,
+        counts=counts,
+        totals=totals,
+        iters=reshape("relay_solutions_iters", (num_shots, R)),
+        weight=reshape("relay_solutions_weight", (num_shots, R)),
+        packed=reshape("relay_solutions_result",
+                       (num_shots, R, W)).astype(np.int32),
+    )
+
+
+@dataclass(frozen=True)
+class StopNConvSweep:
+    """Per-N results of a ``stop_nconv`` sweep. Arrays are indexed by ``n``."""
+    n: np.ndarray  #: (n_N,) the stop_nconv values swept
+    ler: np.ndarray  #: (n_N,) logical error rate
+    num_errors: np.ndarray  #: (n_N,) raw logical error counts
+    avg_iters: np.ndarray  #: (n_N,) mean iterations run
+    #: iteration percentiles; (n_N,) for a scalar ``percentiles`` input,
+    #: (n_p, n_N) for a list (np.percentile convention)
+    iters_percentiles: np.ndarray
+    percentiles: np.ndarray  #: the percentile values requested
+    num_shots: int
+    num_unconverged: int  #: shots with zero recorded convergences
+    frac_exhausted: np.ndarray  #: (n_N,) shots with fewer than N convergences
+
+
+def _class_words(bits, observables, width, k):
+    """Hard decisions -> packed observable-class words.
+
+    ``bits`` is (..., width). With ``observables`` (k, width) the class is
+    ``observables @ bits % 2``; without, the bits already are the class.
+    """
+    if observables is None:
+        return _pack_words(bits, k)
+    cls = (bits.reshape(-1, width).astype(np.int64) @ observables.T) % 2
+    return _pack_words(cls.astype(np.uint8), k).reshape(bits.shape[:-1] + (-1,))
+
+
+def stop_nconv_sweep(results,
+                     obs_truth,
+                     *,
+                     percentiles,
+                     n_values=None,
+                     observables=None):
+    """Reconstruct LER and iteration statistics for a range of ``stop_nconv``.
+
+    For each N, each shot's prediction is the minimum-weight record among its
+    first ``min(N, count)`` convergences (weight ties resolve to the earliest
+    record), and its iteration count is the cumulative count at the Nth
+    convergence -- or the shot's full-schedule ``num_iter`` when it produced
+    fewer than N convergences, exactly what stop_nconv=N would have run.
+    Shots that never converged are scored with the decoder's returned
+    (fallback) result, which is identical for every N.
+
+    Args:
+        results: The ``BatchDecoderResult`` of a recording run. Beyond the
+            records themselves, per-shot ``num_iter`` is read from
+            ``results.opt_results`` when any shot exhausts the schedule
+            within the sweep range, and ``results.result`` supplies the
+            fallback prediction for never-converged shots.
+        obs_truth: (num_shots, k) 0/1 array of actual observable flips.
+        percentiles: Iteration percentile(s) to report, in (0, 100]. A scalar
+            yields ``iters_percentiles`` of shape (n_N,); a list yields
+            (n_p, n_N).
+        n_values: Iterable of stop_nconv values to sweep; defaults to
+            ``1..max_records``.
+        observables: (k, width) 0/1 observables matrix. Required when the
+            decoder ran without one (records are corrections); must be
+            omitted when it ran with one (records already are observable
+            classes).
+
+    Returns:
+        A :class:`StopNConvSweep`.
+    """
+    batch = getattr(results, "batch_opt_results", None)
+    obs_truth = np.asarray(obs_truth)
+    if obs_truth.ndim != 2:
+        raise ValueError(f"obs_truth must be 2-D (num_shots, k), got shape "
+                         f"{obs_truth.shape}")
+    num_shots, k = obs_truth.shape
+    recs = unpack(batch, num_shots)
+
+    if observables is not None:
+        observables = (np.asarray(observables) % 2).astype(np.int64)
+        if observables.shape != (k, recs.width):
+            raise ValueError(
+                f"observables has shape {observables.shape}, expected "
+                f"({k}, {recs.width}) for {k} observables over records of "
+                f"width {recs.width}")
+    elif recs.width != k:
+        raise ValueError(
+            f"records have width {recs.width} but obs_truth has {k} "
+            "observables: the decoder ran without an observables matrix, so "
+            "one must be passed as `observables` to compute the LER")
+
+    n_values = (np.arange(1, recs.max_records + 1) if n_values is None else
+                np.asarray(list(n_values), dtype=np.int64))
+    if n_values.size == 0 or np.any(n_values < 1):
+        raise ValueError(f"n_values must be positive integers, got {n_values}")
+    n_max = int(n_values.max())
+
+    percentiles_arr = np.atleast_1d(np.asarray(percentiles, dtype=np.float64))
+    if np.any((percentiles_arr <= 0) | (percentiles_arr > 100)):
+        raise ValueError(f"percentiles must be in (0, 100], got {percentiles}")
+
+    # A capped recording (relay_solutions=<int>) dropped records; the sweep is
+    # only faithful up to the cap.
+    truncated = recs.totals > recs.counts
+    if truncated.any():
+        cap = int(recs.counts[truncated].min())
+        if n_max > cap:
+            raise ValueError(
+                f"records were capped at {cap} but the sweep requests "
+                f"N={n_max}: rerun with relay_solutions=True (or a cap >= N)")
+
+    # Per-shot inputs beyond the records themselves.
+    unconverged = recs.counts == 0
+    exhausted_somewhere = bool((recs.counts < n_max).any())
+    num_iter = None
+    if exhausted_somewhere:
+        opt_results = list(results.opt_results)
+        num_iter = np.empty(num_shots, dtype=np.int64)
+        for i, opt in enumerate(opt_results):
+            if opt is None or "num_iter" not in opt:
+                raise ValueError(
+                    "some shots exhaust the relay schedule within the sweep "
+                    "range, so per-shot num_iter is needed: rerun with "
+                    'opt_results={"relay_solutions": True, "num_iter": True}')
+            num_iter[i] = int(opt["num_iter"])
+
+    truth_words = _pack_words((obs_truth % 2).astype(np.uint8), k)
+
+    # Observable class of every record, packed to words so a prediction
+    # comparison is a few int32 equalities. Chunk over shots to bound the
+    # unpacked-bits intermediate in correction mode (~width bytes per record).
+    R, W = recs.max_records, recs.packed.shape[2]
+    class_words = np.empty((num_shots, R, truth_words.shape[1]), np.int32)
+    chunk = max(1, (1 << 28) // max(1, R * recs.width))
+    for s in range(0, num_shots, chunk):
+        p = recs.packed[s:s + chunk]
+        class_words[s:s + chunk] = _class_words(_unpack_words(p, recs.width),
+                                                observables, recs.width, k)
+
+    # Never-converged shots return the fallback hard decision, which is not
+    # among the records; score it from the decoder's returned result.
+    fallback_err = None
+    if unconverged.any():
+        fb = np.asarray(results.result)[unconverged] > 0.5
+        if fb.shape[1] != recs.width:
+            raise ValueError(
+                f"results.result rows have length {fb.shape[1]}, expected "
+                f"{recs.width} to score never-converged shots")
+        fb_words = _class_words(fb.astype(np.uint8), observables, recs.width, k)
+        fallback_err = np.any(fb_words != truth_words[unconverged], axis=-1)
+
+    # One pass over the record axis maintains the prefix argmin (padding is
+    # +inf, so exhausted shots keep their own minimum); snapshots are taken at
+    # the requested N.
+    n_sorted = np.sort(np.unique(n_values))
+    best_idx_at = {}
+    best_idx = np.zeros(num_shots, dtype=np.int64)
+    next_snap = 0
+    if R > 0:
+        best_w = recs.weight[:, 0].copy()
+        for r in range(min(n_max, R)):
+            if r > 0:
+                better = recs.weight[:, r] < best_w
+                best_w[better] = recs.weight[better, r]
+                best_idx[better] = r
+            while next_snap < n_sorted.size and n_sorted[next_snap] == r + 1:
+                best_idx_at[r + 1] = best_idx.copy()
+                next_snap += 1
+    for n in n_sorted[next_snap:]:  # N > R: identical to the full-record min
+        best_idx_at[int(n)] = best_idx
+
+    shot_rows = np.arange(num_shots)
+    num_errors = np.empty(n_values.size, dtype=np.int64)
+    avg_iters = np.empty(n_values.size, dtype=np.float64)
+    iters_pcts = np.empty((percentiles_arr.size, n_values.size),
+                          dtype=np.float64)
+    frac_exhausted = np.empty(n_values.size, dtype=np.float64)
+    for j, n in enumerate(n_values):
+        if R > 0:
+            sel = class_words[shot_rows, best_idx_at[int(n)]]
+            err = np.any(sel != truth_words, axis=-1)
+        else:
+            err = np.zeros(num_shots, dtype=bool)
+        if fallback_err is not None:
+            err[unconverged] = fallback_err
+        num_errors[j] = int(err.sum())
+
+        reached = recs.counts >= n
+        it = (np.where(reached, recs.iters[:, min(int(n), R) - 1], 0)
+              if R > 0 else np.zeros(num_shots, dtype=np.int64))
+        if not reached.all():
+            it = np.where(reached, it, num_iter)
+        avg_iters[j] = it.mean()
+        iters_pcts[:, j] = np.percentile(it, percentiles_arr)
+        frac_exhausted[j] = 1.0 - reached.mean()
+
+    if np.isscalar(percentiles) or np.ndim(percentiles) == 0:
+        iters_pcts = iters_pcts[0]
+    return StopNConvSweep(
+        n=n_values,
+        ler=num_errors / num_shots,
+        num_errors=num_errors,
+        avg_iters=avg_iters,
+        iters_percentiles=iters_pcts,
+        percentiles=percentiles_arr,
+        num_shots=num_shots,
+        num_unconverged=int(unconverged.sum()),
+        frac_exhausted=frac_exhausted,
+    )

--- a/libs/qec/python/tests/test_decoder.py
+++ b/libs/qec/python/tests/test_decoder.py
@@ -207,6 +207,79 @@ def test_python_decoder_batch_preserves_opt_results():
     assert batch_result[1].opt_results["tag"] == "python"
 
 
+def test_batch_opt_results_defaults_to_none():
+    # Decoders that produce no batch-level results must report None rather
+    # than an empty dict, so callers can distinguish "not supported" from
+    # "supported but empty".
+    decoder = qec.get_decoder('example_byod', H)
+    batch_result = decoder.decode_batch(
+        [create_test_syndrome(), create_test_syndrome()])
+    assert hasattr(batch_result, 'batch_opt_results')
+    assert batch_result.batch_opt_results is None
+
+    # Same for a decoder whose per-shot opt_results are populated: the two
+    # channels are independent.
+    empty_result = decoder.decode_batch([])
+    assert empty_result.batch_opt_results is None
+
+
+def test_batch_opt_results_constructor_and_slicing():
+    result = np.zeros((3, 4), dtype=np.float64)
+    converged = np.ones(3, dtype=bool)
+
+    # Omitted -> None, keeping the pre-existing 2- and 3-argument forms valid.
+    assert qec.BatchDecoderResult(result, converged).batch_opt_results is None
+    assert qec.BatchDecoderResult(result, converged,
+                                  None).batch_opt_results is None
+
+    payload = {"counts": np.array([1, 2, 3], dtype=np.int32), "width": 12}
+    batch_result = qec.BatchDecoderResult(result, converged, None, payload)
+    assert batch_result.batch_opt_results["width"] == 12
+    np.testing.assert_array_equal(batch_result.batch_opt_results["counts"],
+                                  [1, 2, 3])
+
+    # Batch-level arrays are indexed by position in the full batch, so a slice
+    # drops them instead of carrying through values that no longer line up
+    # with the sliced rows.
+    assert batch_result[:2].batch_opt_results is None
+
+    # Integer indexing yields a DecoderResult, which has no batch-level
+    # channel at all.
+    assert not hasattr(batch_result[0], 'batch_opt_results')
+
+
+def test_python_decoder_can_return_batch_opt_results():
+
+    @qec.decoder("python_batch_opt_results_byod")
+    class PythonBatchOptResultsDecoder:
+
+        def __init__(self, H, **kwargs):
+            qec.Decoder.__init__(self, H)
+            self.H = H
+
+        def decode(self, syndrome):
+            res = qec.DecoderResult()
+            res.converged = True
+            res.result = np.zeros(self.H.shape[1], dtype=np.float64)
+            return res
+
+        def decode_batch(self, syndromes):
+            n = len(syndromes)
+            return qec.BatchDecoderResult(
+                np.zeros((n, self.H.shape[1]), dtype=np.float64),
+                np.ones(n, dtype=bool),
+                None,
+                {"weights": np.arange(n, dtype=np.float32)},
+            )
+
+    decoder = qec.get_decoder("python_batch_opt_results_byod", H)
+    batch_result = decoder.decode_batch(
+        [np.zeros(H.shape[0]), np.ones(H.shape[0])])
+    weights = batch_result.batch_opt_results["weights"]
+    assert weights.dtype == np.float32
+    np.testing.assert_array_equal(weights, [0.0, 1.0])
+
+
 def test_python_decoder_batch_override_must_return_batch_decoder_result():
 
     @qec.decoder("python_bad_batch_byod")

--- a/libs/qec/python/tests/test_relay_solutions.py
+++ b/libs/qec/python/tests/test_relay_solutions.py
@@ -1,0 +1,233 @@
+# ============================================================================ #
+# Copyright (c) 2026 NVIDIA Corporation & Affiliates.                          #
+# All rights reserved.                                                         #
+#                                                                              #
+# This source code and the accompanying materials are made available under    #
+# the terms of the Apache License 2.0 which accompanies this distribution.    #
+# ============================================================================ #
+
+# Pure-NumPy tests of the relay_solutions post-processing helper against
+# hand-computed expectations. The decoder itself is not needed: the wire
+# format is a plain dict of flat arrays, built synthetically here; GPU
+# end-to-end coverage lives elsewhere.
+
+import numpy as np
+import pytest
+
+import cudaq_qec as qec
+from cudaq_qec import relay_solutions as rs
+
+INF = np.inf
+
+
+def _pack_rows(bit_rows, width):
+    """Pack per-record bit vectors into the little-endian int32 word format."""
+    words = []
+    for bits in bit_rows:
+        value = 0
+        for i, b in enumerate(bits):
+            value |= int(b) << i
+        words.append(value)
+    assert width <= 32  # single-word records are enough for these tests
+    return np.asarray(words, dtype=np.int32)
+
+
+def _payload(width, max_records, counts, totals, iters, weight, packed_rows):
+    return {
+        "relay_solutions_width":
+            width,
+        "relay_solutions_max_records":
+            max_records,
+        "relay_solutions_counts":
+            np.asarray(counts, dtype=np.int32),
+        "relay_solutions_totals":
+            np.asarray(totals, dtype=np.int32),
+        "relay_solutions_iters":
+            np.asarray(iters, dtype=np.int32).ravel(),
+        "relay_solutions_weight":
+            np.asarray(weight, dtype=np.float64).ravel(),
+        "relay_solutions_result":
+            _pack_rows([b for shot in packed_rows for b in shot], width),
+    }
+
+
+# Correction-mode fixture: width 5, two observables, four shots, R = 3.
+#   shot 0: 3 records; the min-weight record changes class between N=1 and 2
+#   shot 1: 1 record, then exhausts the schedule
+#   shot 2: never converges (scored via the decoder's fallback result)
+#   shot 3: 2 records with a weight tie (earliest record must win)
+L = np.array([
+    [1, 0, 1, 0, 0],
+    [0, 1, 0, 0, 1],
+])
+WIDTH, K, N_SHOTS, R = 5, 2, 4, 3
+COUNTS = [3, 1, 0, 2]
+ITERS = [[3, 10, 20], [7, -1, -1], [-1, -1, -1], [5, 9, -1]]
+WEIGHT = [[5.0, 2.0, 9.0], [4.0, INF, INF], [INF, INF, INF], [3.0, 3.0, INF]]
+RECORD_BITS = [
+    [[1, 0, 0, 0, 0], [0, 1, 0, 0, 0], [0, 0, 1, 0, 0]],  # cls (1,0)(0,1)(1,0)
+    [[1, 1, 0, 0, 0], [0] * 5, [0] * 5],  # cls (1,1)
+    [[0] * 5, [0] * 5, [0] * 5],
+    [[0] * 5, [0, 1, 0, 0, 0], [0] * 5],  # cls (0,0), (0,1)
+]
+NUM_ITER = [20, 50, 60, 40]  # full-schedule iterations of the recording run
+RETURNED = np.array(
+    [
+        [0, 1, 0, 0, 0],  # shot 0: its overall min-weight record
+        [1, 1, 0, 0, 0],
+        [0, 0, 0, 0, 1],  # shot 2: fallback, not among the records
+        [0, 0, 0, 0, 0],
+    ],
+    dtype=np.float64)
+OBS_TRUTH = np.array([[1, 0], [1, 1], [0, 1], [0, 0]])
+
+
+def make_results(counts=COUNTS, totals=None, num_iter=NUM_ITER):
+    payload = _payload(WIDTH, R, counts, totals if totals else counts, ITERS,
+                       WEIGHT, RECORD_BITS)
+    opt_results = [{"num_iter": ni} for ni in num_iter]
+    return qec.BatchDecoderResult(RETURNED, np.asarray(COUNTS, dtype=bool),
+                                  opt_results, payload)
+
+
+def test_unpack_round_trip():
+    recs = rs.unpack(make_results().batch_opt_results, N_SHOTS)
+    assert recs.width == WIDTH and recs.max_records == R
+    np.testing.assert_array_equal(recs.counts, COUNTS)
+    np.testing.assert_array_equal(recs.iters, ITERS)
+    np.testing.assert_array_equal(recs.weight, WEIGHT)
+    for shot in range(N_SHOTS):
+        for record in range(COUNTS[shot]):
+            np.testing.assert_array_equal(recs.bits(shot, record),
+                                          RECORD_BITS[shot][record])
+
+
+def test_unpack_single_shot_keys():
+    payload = _payload(WIDTH, 2, [2], [2], [[3, 10]], [[5.0, 2.0]],
+                       [RECORD_BITS[0][:2]])
+    payload["relay_solutions_count"] = payload.pop("relay_solutions_counts")[0]
+    payload["relay_solutions_total"] = payload.pop("relay_solutions_totals")[0]
+    recs = rs.unpack(payload, 1)
+    np.testing.assert_array_equal(recs.counts, [2])
+    np.testing.assert_array_equal(recs.bits(0, 1), RECORD_BITS[0][1])
+
+
+def test_stop_nconv_sweep_correction_mode():
+    sweep = rs.stop_nconv_sweep(make_results(),
+                                OBS_TRUTH,
+                                percentiles=[50, 100],
+                                observables=L)
+
+    np.testing.assert_array_equal(sweep.n, [1, 2, 3])
+    # N=1: every shot's first record (or fallback) matches the truth.
+    # N>=2: shot 0's min-weight record changes to class (0,1) -> one error.
+    # Shot 3's N=2 weight tie must resolve to the EARLIEST record (correct
+    # class); shot 2's fallback matches the truth at every N.
+    np.testing.assert_array_equal(sweep.num_errors, [0, 1, 1])
+    np.testing.assert_allclose(sweep.ler, [0, 0.25, 0.25])
+
+    # Iterations: cumulative at the Nth convergence, or the shot's num_iter
+    # once it exhausts (shot 2 always, shot 1 from N=2, shot 3 at N=3).
+    expected = np.array([[3, 7, 60, 5], [10, 50, 60, 9], [20, 50, 60, 40]])
+    np.testing.assert_allclose(sweep.avg_iters, expected.mean(axis=1))
+    np.testing.assert_allclose(sweep.iters_percentiles,
+                               np.percentile(expected, [50, 100], axis=1))
+    assert sweep.iters_percentiles.shape == (2, 3)
+    assert sweep.num_unconverged == 1
+    np.testing.assert_allclose(sweep.frac_exhausted, [0.25, 0.5, 0.75])
+
+
+def test_scalar_percentile_and_n_values():
+    sweep = rs.stop_nconv_sweep(make_results(),
+                                OBS_TRUTH,
+                                percentiles=50,
+                                n_values=[2],
+                                observables=L)
+    assert sweep.iters_percentiles.shape == (1,)
+    np.testing.assert_allclose(sweep.iters_percentiles,
+                               [np.percentile([10, 50, 60, 9], 50)])
+    np.testing.assert_array_equal(sweep.num_errors, [1])
+
+
+def test_n_beyond_max_records_uses_full_schedule():
+    sweep = rs.stop_nconv_sweep(make_results(),
+                                OBS_TRUTH,
+                                percentiles=50,
+                                n_values=[5],
+                                observables=L)
+    # Every shot exhausts: predictions equal the full-record minimum and the
+    # iteration count is each shot's num_iter.
+    np.testing.assert_array_equal(sweep.num_errors, [1])
+    np.testing.assert_allclose(sweep.avg_iters, [np.mean(NUM_ITER)])
+    np.testing.assert_allclose(sweep.frac_exhausted, [1.0])
+
+
+def test_observables_required_in_correction_mode():
+    with pytest.raises(ValueError, match="observables"):
+        rs.stop_nconv_sweep(make_results(), OBS_TRUTH, percentiles=50)
+
+
+def test_capped_records_rejected_beyond_cap():
+    results = make_results(counts=[2, 1, 0, 2], totals=[3, 1, 0, 2])
+    with pytest.raises(ValueError, match="capped at 2"):
+        rs.stop_nconv_sweep(results, OBS_TRUTH, percentiles=50, observables=L)
+    # Within the cap the sweep is still faithful.
+    sweep = rs.stop_nconv_sweep(results,
+                                OBS_TRUTH,
+                                percentiles=50,
+                                n_values=[1, 2],
+                                observables=L)
+    np.testing.assert_array_equal(sweep.num_errors, [0, 1])
+
+
+def test_missing_num_iter_raises():
+    payload = _payload(WIDTH, R, COUNTS, COUNTS, ITERS, WEIGHT, RECORD_BITS)
+    results = qec.BatchDecoderResult(RETURNED, np.asarray(COUNTS, dtype=bool),
+                                     None, payload)
+    with pytest.raises(ValueError, match="num_iter"):
+        rs.stop_nconv_sweep(results, OBS_TRUTH, percentiles=50, observables=L)
+    # N=1 with no unconverged shots would not need it -- but shot 2 never
+    # converged, so its iteration count is still unavailable.
+    with pytest.raises(ValueError, match="num_iter"):
+        rs.stop_nconv_sweep(results,
+                            OBS_TRUTH,
+                            percentiles=50,
+                            n_values=[1],
+                            observables=L)
+
+
+def test_observables_mode_uses_records_directly():
+    # width == k: records already are observable classes.
+    width, k = 2, 2
+    payload = _payload(width, 2, [2, 1], [2, 1], [[4, 8], [6, -1]],
+                       [[3.0, 1.0], [2.0, INF]],
+                       [[[1, 0], [0, 1]], [[1, 1], [0, 0]]])
+    returned = np.array([[0, 1], [1, 1]], dtype=np.float64)
+    results = qec.BatchDecoderResult(returned, np.array([True, True]), [{
+        "num_iter": 9
+    }, {
+        "num_iter": 9
+    }], payload)
+    truth = np.array([[1, 0], [1, 1]])
+    sweep = rs.stop_nconv_sweep(results, truth, percentiles=50)
+    # N=1: both first records match. N=2: shot 0 flips to (0,1) -> error;
+    # shot 1 exhausts and keeps (1,1).
+    np.testing.assert_array_equal(sweep.num_errors, [0, 1])
+    np.testing.assert_allclose(sweep.avg_iters, [(4 + 6) / 2, (8 + 9) / 2])
+
+
+def test_percentile_validation():
+    with pytest.raises(ValueError, match="percentiles"):
+        rs.stop_nconv_sweep(make_results(),
+                            OBS_TRUTH,
+                            percentiles=0,
+                            observables=L)
+    with pytest.raises(ValueError, match="percentiles"):
+        rs.stop_nconv_sweep(make_results(),
+                            OBS_TRUTH,
+                            percentiles=[50, 101],
+                            observables=L)
+
+
+if __name__ == "__main__":
+    pytest.main()

--- a/libs/qec/unittests/test_decoders.cpp
+++ b/libs/qec/unittests/test_decoders.cpp
@@ -203,6 +203,33 @@ TEST(SampleDecoder, checkAPI) {
       ASSERT_EQ(x, 0.0f);
 }
 
+// A decoder that overrides only the single-argument decode_batch (i.e. every
+// decoder written before the overload existed) must still work through the
+// two-argument one, and must report no batch-level results.
+TEST(SampleDecoder, BatchOptResultsDefaultsToEmpty) {
+  constexpr std::size_t block_size = 10;
+  constexpr std::size_t syndrome_size = 4;
+  cudaqx::tensor<uint8_t> H({syndrome_size, block_size});
+  auto d = cudaq::qec::decoder::get("sample_decoder", H);
+  ASSERT_NE(d, nullptr);
+
+  std::vector<cudaq::qec::float_t> syndromes(syndrome_size, 0.0);
+  std::optional<cudaqx::heterogeneous_map> batch_opt_results;
+  auto dec_results = d->decode_batch({syndromes, syndromes}, batch_opt_results);
+
+  EXPECT_EQ(dec_results.size(), 2);
+  EXPECT_FALSE(batch_opt_results.has_value());
+  for (auto &m : dec_results)
+    EXPECT_EQ(m.result.size(), block_size);
+
+  // A stale value in the out-param must be cleared, not left for the caller to
+  // mistake for decoder output.
+  batch_opt_results = cudaqx::heterogeneous_map();
+  batch_opt_results->insert("stale", 1);
+  d->decode_batch({syndromes}, batch_opt_results);
+  EXPECT_FALSE(batch_opt_results.has_value());
+}
+
 TEST(SampleDecoder, RealtimeApiAndDefaultGraphHooks) {
   // CUDAQ_QEC_DEBUG_DECODER enables the base decoder's printf logging paths.
   ScopedEnv debugEnv("CUDAQ_QEC_DEBUG_DECODER", "1");


### PR DESCRIPTION
Adds a pure-NumPy module that reconstructs, offline, what the nv-qldpc-decoder's relay BP would have returned for any stop_nconv setting from a single uncapped recording run, plus the batch_opt_results plumbing needed to carry relay_solutions records through the decoder API.

To do anything useful, this must be paired with an updated nv-qldpc-decoder binary, which will come in the next release.