### PR TITLE
Make proprietary cudevice archive optional and don't ship decoding_server

### DIFF
--- a/.github/workflows/all_libs_release.yaml
+++ b/.github/workflows/all_libs_release.yaml
@@ -84,9 +84,14 @@ jobs:
             mkdir -p tmp
             tar -C tmp -xzvf nv-qldpc-decoder-${{ matrix.runner.arch }}_ubuntu24.04_cuda${{ matrix.cuda_version }}_release.tar.gz
             test -f tmp/libcudaq-qec-nv-qldpc-decoder.so
-            test -f tmp/libcudaq-qec-realtime-cudevice-proprietary.a
             echo "QEC_EXTERNAL_DECODERS=$(pwd)/tmp/libcudaq-qec-nv-qldpc-decoder.so" >> $GITHUB_ENV
-            echo "CUDAQ_QEC_REALTIME_CUDEVICE_PROPRIETARY_ARCHIVE=$(pwd)/tmp/libcudaq-qec-realtime-cudevice-proprietary.a" >> $GITHUB_ENV
+            # The proprietary cudevice archive is optional: it only enables
+            # device_graph dispatch in the decoding_server binary and the
+            # device-graph realtime tests, neither of which ships in the
+            # official release yet.
+            if [[ -f tmp/libcudaq-qec-realtime-cudevice-proprietary.a ]]; then
+              echo "CUDAQ_QEC_REALTIME_CUDEVICE_PROPRIETARY_ARCHIVE=$(pwd)/tmp/libcudaq-qec-realtime-cudevice-proprietary.a" >> $GITHUB_ENV
+            fi
           fi
         shell: bash
 
@@ -141,6 +146,15 @@ jobs:
 
       - name: Save build artifacts
         run: |
+          # The decoding server is not shipped in the official release, so
+          # remove it (and its example configs) from the install prefix and
+          # the install manifest before zipping.
+          for f in /usr/local/cudaq/bin/decoding_server*; do
+            [ -e "$f" ] || continue
+            rm -f "$f"
+            sed -i "\#^$f\$#d" \
+              ${{ steps.build.outputs.build-dir }}/install_manifest.txt
+          done
           cmake --build ${{ steps.build.outputs.build-dir }} --target zip_installed_files --parallel
           cd ${{ steps.build.outputs.build-dir }}
           mv installed_files.zip installed_files-${{ matrix.runner.arch }}-cu${{ matrix.cuda_version }}.zip


### PR DESCRIPTION
…in release

The decoding server is not part of the official release yet, so also strip bin/decoding_server* from the install prefix and install manifest before zipping the release artifacts. Wheels are unaffected: the qec-tools component was already excluded from install.components.