### PR TITLE
[QEC] Reduce decode latency: resolve detectors as measurements arrive and reuse PyMatching scratch buffers

### DIFF
--- a/libs/qec/lib/decoder.cpp
+++ b/libs/qec/lib/decoder.cpp
@@ -12,7 +12,9 @@
 #include "cudaq/qec/logger.h"
 #include "cudaq/qec/plugin_loader.h"
 #include "cudaq/qec/version.h"
+#include <algorithm>
 #include <cassert>
+#include <cstring>
 #include <cuda_runtime_api.h>
 #include <dlfcn.h>
 #include <filesystem>
@@ -46,6 +48,18 @@ struct decoder::rt_impl {
   /// Persistent buffers to avoid dynamic memory allocation.
   std::vector<uint8_t> persistent_detector_buffer;
   std::vector<float_t> persistent_soft_detector_buffer;
+
+  /// Detector rows paired with the number of leading msyn_buffer columns they
+  /// need, i.e. one past the last column they read, sorted by that count. A
+  /// detector is resolvable once msyn_buffer_index reaches its count, so
+  /// enqueue_syndrome() can fold detectors in as their measurements arrive
+  /// instead of reducing the whole buffer on the final round. Only used when
+  /// !is_sliding_window; the sliding window path emits a layer per round and
+  /// is already incremental.
+  std::vector<std::pair<uint32_t, uint32_t>> detector_ready_order;
+
+  /// How far through detector_ready_order the current shot has progressed.
+  std::size_t detector_ready_cursor = 0;
 
   /// Whether to log decoder stats.
   bool should_log = false;
@@ -352,7 +366,25 @@ void set_D_sparse_common(decoder *decoder,
           fmt::format("D_sparse row count ({}) must match syndrome_size ({})",
                       D_sparse.size(), decoder->get_syndrome_size()));
     }
+    // Order the detectors by when they become resolvable. Keying on how many
+    // measurement columns each one needs, rather than bucketing by round, keeps
+    // this correct when rounds differ in width, which they do for the boundary
+    // layers of a memory circuit. A detector with no columns needs none and so
+    // sorts strictly ahead of one that reads column 0; it is trivially zero and
+    // resolvable before any measurement arrives.
+    pimpl->detector_ready_order.clear();
+    pimpl->detector_ready_order.reserve(D_sparse.size());
+    for (std::size_t i = 0; i < D_sparse.size(); i++) {
+      uint32_t columns_needed = 0;
+      for (const auto col : D_sparse[i])
+        columns_needed = std::max(columns_needed, col + 1);
+      pimpl->detector_ready_order.emplace_back(columns_needed,
+                                               static_cast<uint32_t>(i));
+    }
+    std::sort(pimpl->detector_ready_order.begin(),
+              pimpl->detector_ready_order.end());
   }
+  pimpl->detector_ready_cursor = 0;
 
   pimpl->num_msyn_per_decode = calculate_num_msyn_per_decode(D_sparse);
   pimpl->msyn_buffer.clear();
@@ -372,6 +404,28 @@ void decoder::set_D_sparse(const std::vector<int64_t> &D_sparse_vec_in) {
   on_d_sparse_configured();
 }
 
+// Fold in every detector whose measurements have all arrived, i.e. that needs
+// no more than \p columns_available leading columns of msyn_buffer.
+// detector_ready_order is sorted by that requirement, so this walks a cursor
+// forward and reduces each detector exactly once per shot. Not used by the
+// sliding window path, which emits one detector layer per round and is already
+// incremental.
+template <typename PimplType>
+static void
+resolve_ready_detectors(const std::vector<std::vector<uint32_t>> &D_sparse,
+                        PimplType *pimpl, uint32_t columns_available) {
+  const auto &order = pimpl->detector_ready_order;
+  while (pimpl->detector_ready_cursor < order.size() &&
+         order[pimpl->detector_ready_cursor].first <= columns_available) {
+    const uint32_t detector = order[pimpl->detector_ready_cursor].second;
+    uint8_t value = 0;
+    for (const auto col : D_sparse[detector])
+      value ^= pimpl->msyn_buffer[col];
+    pimpl->persistent_detector_buffer[detector] = value;
+    pimpl->detector_ready_cursor++;
+  }
+}
+
 bool decoder::enqueue_syndrome(const uint8_t *syndrome,
                                std::size_t syndrome_length) {
   if (pimpl->msyn_buffer_index + syndrome_length > pimpl->msyn_buffer.size()) {
@@ -382,10 +436,19 @@ bool decoder::enqueue_syndrome(const uint8_t *syndrome,
 
   pimpl->current_round++;
   bool did_decode = false;
-  for (std::size_t i = 0; i < syndrome_length; i++) {
-    pimpl->msyn_buffer[pimpl->msyn_buffer_index] = syndrome[i];
-    pimpl->msyn_buffer_index++;
+  if (syndrome_length > 0) {
+    std::memcpy(pimpl->msyn_buffer.data() + pimpl->msyn_buffer_index, syndrome,
+                syndrome_length);
+    pimpl->msyn_buffer_index += syndrome_length;
   }
+
+  // Resolve every detector whose measurements have now all arrived. Doing this
+  // per round instead of in one pass at the end leaves the final round with
+  // only the detectors that genuinely depend on it, and reads the measurements
+  // while they are still hot from the copy above.
+  if (!pimpl->is_sliding_window)
+    resolve_ready_detectors(this->D_sparse, pimpl.get(),
+                            pimpl->msyn_buffer_index);
 
   bool should_decode = false;
   if (!pimpl->is_sliding_window) {
@@ -419,13 +482,15 @@ bool decoder::enqueue_syndrome(const uint8_t *syndrome,
       log_observable_corrections.resize(O_sparse.size());
     }
 
-    // Decode now.
+    // Decode now. A full buffer makes every remaining detector resolvable, so
+    // the per-round pass above will normally have finished all of them and this
+    // drain costs one comparison. It is kept so that a complete detector buffer
+    // is guaranteed by construction rather than inferred from when
+    // should_decode fires; a partially reduced buffer would silently decode
+    // stale values left over from the previous shot.
     if (!pimpl->is_sliding_window) {
-      for (std::size_t i = 0; i < this->D_sparse.size(); i++) {
-        pimpl->persistent_detector_buffer[i] = 0;
-        for (auto col : this->D_sparse[i])
-          pimpl->persistent_detector_buffer[i] ^= pimpl->msyn_buffer[col];
-      }
+      resolve_ready_detectors(this->D_sparse, pimpl.get(),
+                              pimpl->num_msyn_per_decode);
     } else {
       const std::size_t k = pimpl->detector_layer_index++;
       const std::size_t off = pimpl->detector_layer_offsets[k];
@@ -568,6 +633,7 @@ bool decoder::enqueue_syndrome(const uint8_t *syndrome,
     pimpl->msyn_buffer_index = 0;
     pimpl->current_round = 0;
     pimpl->detector_layer_index = 0;
+    pimpl->detector_ready_cursor = 0;
   }
   return did_decode;
 }
@@ -618,6 +684,7 @@ void decoder::reset_decoder() {
   pimpl->msyn_buffer_index = 0;
   pimpl->current_round = 0;
   pimpl->detector_layer_index = 0;
+  pimpl->detector_ready_cursor = 0;
   pimpl->msyn_buffer.clear();
   pimpl->msyn_buffer.resize(pimpl->num_msyn_per_decode);
   pimpl->corrections.clear();

--- a/libs/qec/lib/decoders/plugins/pymatching/pymatching.cpp
+++ b/libs/qec/lib/decoders/plugins/pymatching/pymatching.cpp
@@ -44,6 +44,16 @@ private:
 
   bool decode_to_observables = false;
 
+  // Scratch buffers reused across decode() calls so a steady-state decode
+  // allocates nothing. decode() already mutates the shared Mwpm state, so it
+  // was never safe to call concurrently on one instance; reusing these adds no
+  // new constraint. Each is reset explicitly at its use site: PyMatching XORs
+  // into the observable array and appends to the edge list, so neither may
+  // carry over the previous call's contents.
+  std::vector<uint64_t> detection_events;
+  std::vector<uint8_t> obs_scratch;
+  std::vector<int64_t> edges_scratch;
+
   // Helper function to make a canonical edge from two nodes.
   std::pair<int64_t, int64_t> make_canonical_edge(int64_t node1,
                                                   int64_t node2) {
@@ -51,7 +61,8 @@ private:
   }
 
 #if PERFORM_TIMING
-  static constexpr size_t NUM_TIMING_STEPS = 4;
+  // 0: reduce syndrome to detection events, 1: matching, 2: total.
+  static constexpr size_t NUM_TIMING_STEPS = 3;
   std::array<double, NUM_TIMING_STEPS> decode_times;
 #endif
 
@@ -211,17 +222,14 @@ public:
     auto t0 = std::chrono::high_resolution_clock::now();
 #endif
     decoder_result result{false, std::vector<float_t>()};
-#if PERFORM_TIMING
-    auto t1 = std::chrono::high_resolution_clock::now();
-#endif
 
-    std::vector<uint64_t> detection_events;
+    detection_events.clear();
     detection_events.reserve(syndrome.size());
     for (size_t i = 0; i < syndrome.size(); i++)
       if (cudaq::qec::convert_soft_to_hard(syndrome[i]))
         detection_events.push_back(i);
 #if PERFORM_TIMING
-    auto t2 = std::chrono::high_resolution_clock::now();
+    auto t1 = std::chrono::high_resolution_clock::now();
 #endif
     if (decode_to_observables) {
       if (mwpm->flooder.graph.num_observables < 64) {
@@ -236,20 +244,22 @@ public:
         result.result.resize(mwpm->flooder.graph.num_observables);
         assert(O_sparse.size() == mwpm->flooder.graph.num_observables);
         pm::total_weight_int weight = 0;
-        std::vector<uint8_t> obs(mwpm->flooder.graph.num_observables, 0);
-        obs.resize(mwpm->flooder.graph.num_observables);
-        pm::decode_detection_events(*mwpm, detection_events, obs.data(), weight,
-                                    /*edge_correlations=*/false);
-        result.result.resize(mwpm->flooder.graph.num_observables);
+        // PyMatching XORs its prediction in, so start from a cleared frame.
+        obs_scratch.assign(mwpm->flooder.graph.num_observables, 0);
+        pm::decode_detection_events(*mwpm, detection_events, obs_scratch.data(),
+                                    weight, /*edge_correlations=*/false);
         for (size_t i = 0; i < mwpm->flooder.graph.num_observables; i++) {
-          result.result[i] = static_cast<float_t>(obs[i]);
+          result.result[i] = static_cast<float_t>(obs_scratch[i]);
         }
       }
     } else {
-      std::vector<int64_t> edges;
+      // PyMatching appends to the edge list without clearing it first.
+      edges_scratch.clear();
       result.result.resize(block_size);
-      pm::decode_detection_events_to_edges(*mwpm, detection_events, edges);
+      pm::decode_detection_events_to_edges(*mwpm, detection_events,
+                                           edges_scratch);
       // Loop over the edge pairs to reconstruct errors.
+      const auto &edges = edges_scratch;
       assert(edges.size() % 2 == 0);
       for (size_t i = 0; i < edges.size(); i += 2) {
         auto edge = make_canonical_edge(edges.at(i), edges.at(i + 1));
@@ -261,7 +271,7 @@ public:
     // set converged to true.
     result.converged = true;
 #if PERFORM_TIMING
-    auto t3 = std::chrono::high_resolution_clock::now();
+    auto t2 = std::chrono::high_resolution_clock::now();
     decode_times[0] +=
         std::chrono::duration_cast<std::chrono::microseconds>(t1 - t0).count() /
         1e6;
@@ -269,10 +279,7 @@ public:
         std::chrono::duration_cast<std::chrono::microseconds>(t2 - t1).count() /
         1e6;
     decode_times[2] +=
-        std::chrono::duration_cast<std::chrono::microseconds>(t3 - t2).count() /
-        1e6;
-    decode_times[3] +=
-        std::chrono::duration_cast<std::chrono::microseconds>(t3 - t0).count() /
+        std::chrono::duration_cast<std::chrono::microseconds>(t2 - t0).count() /
         1e6;
 #endif
     return result;

--- a/libs/qec/lib/decoders/plugins/pymatching/pymatching.cpp
+++ b/libs/qec/lib/decoders/plugins/pymatching/pymatching.cpp
@@ -11,14 +11,45 @@
 #include "cudaq/qec/decoder.h"
 #include "cudaq/qec/decoder_config_schema.h"
 #include <algorithm>
+#include <atomic>
 #include <cassert>
 #include <map>
+#include <stdexcept>
 #include <vector>
 
 // Enable this to debug decode times.
 #define PERFORM_TIMING 0
 
 namespace cudaq::qec {
+
+namespace {
+/// @brief Claims exclusive use of a decoder for the duration of a decode.
+///
+/// The matching state and scratch buffers belong to the decoder, not the call,
+/// so overlapping decodes corrupt each other. Rejecting the second is the best
+/// available outcome. Costs one uncontended atomic exchange per decode.
+class decode_exclusive_guard {
+public:
+  explicit decode_exclusive_guard(std::atomic<bool> &active) : active_(active) {
+    if (active_.exchange(true))
+      throw std::runtime_error(
+          "pymatching: a decode is already running on this decoder. Its "
+          "matching state and scratch buffers are per decoder, so decodes "
+          "cannot overlap; serialize the calls or give each concurrent caller "
+          "its own decoder.");
+  }
+
+  // A throwing constructor means no destructor, so a rejected call cannot
+  // release the owner's claim.
+  ~decode_exclusive_guard() { active_.store(false); }
+
+  decode_exclusive_guard(const decode_exclusive_guard &) = delete;
+  decode_exclusive_guard &operator=(const decode_exclusive_guard &) = delete;
+
+private:
+  std::atomic<bool> &active_;
+};
+} // namespace
 
 /// @brief This is a wrapper around the PyMatching library that implements the
 /// MWPM decoder.
@@ -53,6 +84,9 @@ private:
   std::vector<uint64_t> detection_events;
   std::vector<uint8_t> obs_scratch;
   std::vector<int64_t> edges_scratch;
+
+  // Set for the duration of decode(). See decode_exclusive_guard.
+  std::atomic<bool> decode_active{false};
 
   // Helper function to make a canonical edge from two nodes.
   std::pair<int64_t, int64_t> make_canonical_edge(int64_t node1,
@@ -215,9 +249,11 @@ public:
   /// @brief Decode the syndrome using the MWPM decoder.
   /// @param syndrome The syndrome to decode.
   /// @return The decoder result.
-  /// @throws std::runtime_error if no matching solution is found, or
-  /// std::out_of_range if an edge is not found in the edge2col_idx map.
+  /// @throws std::runtime_error if no matching solution is found, or if a
+  /// decode is already running on this decoder, or std::out_of_range if an edge
+  /// is not found in the edge2col_idx map.
   virtual decoder_result decode(const std::vector<float_t> &syndrome) {
+    const decode_exclusive_guard guard(decode_active);
 #if PERFORM_TIMING
     auto t0 = std::chrono::high_resolution_clock::now();
 #endif

--- a/libs/qec/unittests/backend-specific/stim/test_qec_stim.cpp
+++ b/libs/qec/unittests/backend-specific/stim/test_qec_stim.cpp
@@ -11,6 +11,7 @@
 #include <deque>
 #include <gtest/gtest.h>
 #include <limits>
+#include <random>
 
 #include "cudaq.h"
 #include "cudaq/algorithms/dem.h"
@@ -650,6 +651,101 @@ TEST(QECCodeTester, checkRealtimeDecodeFromMemoryCircuit) {
   // No errors were injected, so every observable correction is trivially zero.
   for (std::size_t k = 0; k < decoder->get_num_observables(); ++k)
     EXPECT_EQ(decoder->get_obs_corrections()[k], 0);
+}
+
+namespace {
+// Records the detector vector the realtime path hands down, so a test can check
+// the measurement-to-detector reduction directly rather than inferring it from
+// a decode result.
+class detector_recording_decoder : public cudaq::qec::decoder {
+public:
+  std::vector<std::vector<uint8_t>> seen;
+
+  using cudaq::qec::decoder::decoder;
+
+  cudaq::qec::decoder_result
+  decode(const std::vector<cudaq::qec::float_t> &syndrome) override {
+    // enqueue_syndrome() converts the detector bits to soft values on the way
+    // in, so undo that with the same threshold to recover what it computed.
+    std::vector<uint8_t> hard;
+    cudaq::qec::convert_vec_soft_to_hard(syndrome, hard);
+    seen.push_back(std::move(hard));
+    return trivial_result();
+  }
+
+private:
+  cudaq::qec::decoder_result trivial_result() {
+    cudaq::qec::decoder_result result;
+    result.converged = true;
+    result.result.assign(block_size, 0.0);
+    return result;
+  }
+};
+} // namespace
+
+// Stream a measurement window a round at a time and require the detector vector
+// enqueue_syndrome() hands to the decoder to match a direct reduction of m2d
+// against the same measurements, over many random records. Steane's boundary
+// layer is narrower than its interior rounds, so the window has non-uniform
+// round widths.
+//
+// Scope: decode() only runs once the window is complete, so this pins the
+// measurement-to-detector reduction and the point at which a decode fires. It
+// does not pin the order in which individual detectors are folded in, which is
+// not observable through decode() -- reducing the whole buffer on the final
+// round yields the same vector.
+TEST(QECCodeTester, checkRealtimeStreamedDetectorReduction) {
+  auto steane = cudaq::qec::get_code("steane");
+  const std::size_t nRounds = 3;
+  const std::size_t numCols =
+      steane->get_num_ancilla_z_qubits() + steane->get_num_ancilla_x_qubits();
+  const std::size_t numData = steane->get_num_data_qubits();
+  cudaq::noise_model noise;
+  noise.add_all_qubit_channel("x", cudaq::qec::two_qubit_depolarization(0.05),
+                              1);
+
+  auto ctx = cudaq::qec::decoder_context_from_memory_circuit(
+      *steane, cudaq::qec::operation::prep0, nRounds, noise);
+  auto [dem, m2d, m2o] = ctx.full_component();
+  const std::size_t numMeas = ctx.num_measurements();
+  ASSERT_EQ(numMeas, nRounds * numCols + numData);
+
+  detector_recording_decoder dec(dem.detector_error_matrix);
+  dec.set_O_sparse(cudaq::qec::pcm_to_sparse_vec(dem.observables_flips_matrix));
+  dec.set_D_sparse(cudaq::qec::d_sparse(m2d));
+  ASSERT_EQ(dec.get_num_msyn_per_decode(), numMeas);
+
+  std::mt19937 rng(17);
+  std::size_t total_fired = 0;
+  for (std::size_t shot = 0; shot < 100; shot++) {
+    std::vector<uint8_t> meas(numMeas);
+    for (auto &m : meas)
+      m = rng() & 1;
+
+    std::vector<uint8_t> expected(m2d.rows.size(), 0);
+    for (std::size_t d = 0; d < m2d.rows.size(); d++) {
+      uint8_t v = 0;
+      for (const auto c : m2d.rows[d])
+        v ^= meas[c];
+      expected[d] = v;
+      total_fired += v;
+    }
+
+    dec.reset_decoder();
+    dec.seen.clear();
+    std::size_t off = 0;
+    for (std::size_t r = 0; r < nRounds; r++) {
+      EXPECT_FALSE(dec.enqueue_syndrome(std::vector<uint8_t>(
+          meas.begin() + off, meas.begin() + off + numCols)))
+          << "decoded early after round " << r << " of shot " << shot;
+      off += numCols;
+    }
+    ASSERT_TRUE(dec.enqueue_syndrome(
+        std::vector<uint8_t>(meas.begin() + off, meas.end())));
+    ASSERT_EQ(dec.seen.size(), 1u);
+    EXPECT_EQ(dec.seen.front(), expected) << "shot " << shot;
+  }
+  EXPECT_GT(total_fired, 0u); // guard against an all-zero pass
 }
 
 namespace {

--- a/libs/qec/unittests/decoders/pymatching/test_pymatching.cpp
+++ b/libs/qec/unittests/decoders/pymatching/test_pymatching.cpp
@@ -312,16 +312,28 @@ TEST(PyMatchingDecoder, DecodesHighObservableIndicesAcrossPaths) {
     // ASSERT: valid graph-like identity matrices must construct a decoder.
     ASSERT_NE(d, nullptr);
 
-    std::vector<float_t> syndrome(num_observables, 0.0);
-    syndrome.back() = 1.0;
-    auto result = d->decode(syndrome);
-    // ASSERT: both observable decoding paths must successfully converge.
-    ASSERT_TRUE(result.converged) << "num_observables=" << num_observables;
-    // ASSERT: observable-aware decoding returns one result per O row.
-    ASSERT_EQ(result.result.size(), num_observables);
-    // ASSERT: the high bit must not alias another bit through a narrow mask.
-    for (std::size_t i = 0; i < num_observables; ++i)
-      EXPECT_EQ(result.result[i], i == num_observables - 1 ? 1.0 : 0.0)
-          << "num_observables=" << num_observables << ", index=" << i;
+    // Decode several times on the same instance. At 64 observables PyMatching
+    // writes the prediction through a caller-supplied buffer that it XORs into
+    // rather than assigns, and that buffer is reused across calls, so a single
+    // decode would still pass if it were not cleared per call: the flips would
+    // instead leak into the following decode. Firing a different detector each
+    // time, and revisiting one at the end, exercises that.
+    for (const std::size_t fired : {num_observables - 1, std::size_t{0},
+                                    num_observables / 2, num_observables - 1}) {
+      std::vector<float_t> syndrome(num_observables, 0.0);
+      syndrome[fired] = 1.0;
+      auto result = d->decode(syndrome);
+      // ASSERT: both observable decoding paths must successfully converge.
+      ASSERT_TRUE(result.converged) << "num_observables=" << num_observables;
+      // ASSERT: observable-aware decoding returns one result per O row.
+      ASSERT_EQ(result.result.size(), num_observables);
+      // ASSERT: the fired detector flips its own observable and nothing else,
+      // so the high bit must not alias another bit through a narrow mask and no
+      // flip may survive from an earlier decode.
+      for (std::size_t i = 0; i < num_observables; ++i)
+        EXPECT_EQ(result.result[i], i == fired ? 1.0 : 0.0)
+            << "num_observables=" << num_observables << ", fired=" << fired
+            << ", index=" << i;
+    }
   }
 }

--- a/libs/qec/unittests/decoders/pymatching/test_pymatching.cpp
+++ b/libs/qec/unittests/decoders/pymatching/test_pymatching.cpp
@@ -7,8 +7,11 @@
  ******************************************************************************/
 
 #include "cudaq/qec/decoder.h"
+#include <atomic>
 #include <cmath>
 #include <gtest/gtest.h>
+#include <stdexcept>
+#include <thread>
 #include <vector>
 
 TEST(PyMatchingDecoder, checkRegularEdges) {
@@ -336,4 +339,67 @@ TEST(PyMatchingDecoder, DecodesHighObservableIndicesAcrossPaths) {
             << ", index=" << i;
     }
   }
+}
+
+// Hammer one decoder from two threads: every call must either return the right
+// answer or be rejected, never return a corrupted one. Removing the guard fails
+// this loudly, aborting on an out-of-bounds index or an escaped
+// std::invalid_argument from inside PyMatching.
+//
+// Whether a run actually overlaps is up to the scheduler, so no rejection count
+// is asserted. That the guard is released is covered by the sequential tests
+// above, which decode repeatedly on one instance.
+TEST(PyMatchingDecoder, RejectsOverlappingDecodeRatherThanCorrupting) {
+  using cudaq::qec::float_t;
+
+  constexpr std::size_t num_nodes = 40;
+  cudaqx::tensor<uint8_t> H({num_nodes, num_nodes});
+  for (std::size_t i = 0; i < num_nodes; ++i)
+    H.at({i, i}) = 1;
+
+  cudaqx::heterogeneous_map params;
+  auto d = cudaq::qec::decoder::get("pymatching", H, params);
+  ASSERT_NE(d, nullptr);
+
+  std::atomic<int> rejected{0};
+  std::atomic<int> corrupted{0};
+  std::atomic<int> completed{0};
+  // A decode runs in well under a microsecond, so without this barrier the
+  // first thread finishes its loop before the second is even scheduled.
+  std::atomic<bool> go{false};
+  constexpr int iterations = 20000;
+
+  // Each identity column is a boundary edge, so firing detector `fired` must
+  // predict exactly error `fired`.
+  auto hammer = [&](std::size_t fired) {
+    std::vector<float_t> syndrome(num_nodes, 0.0);
+    syndrome[fired] = 1.0;
+    while (!go.load(std::memory_order_acquire))
+      ;
+    for (int iter = 0; iter < iterations; ++iter) {
+      try {
+        auto result = d->decode(syndrome);
+        bool ok = result.converged && result.result.size() == num_nodes;
+        for (std::size_t i = 0; ok && i < num_nodes; ++i)
+          ok = result.result[i] == (i == fired ? 1.0 : 0.0);
+        if (!ok)
+          corrupted.fetch_add(1);
+        completed.fetch_add(1);
+      } catch (const std::runtime_error &) {
+        rejected.fetch_add(1);
+      }
+    }
+  };
+
+  std::thread t0(hammer, 0);
+  std::thread t1(hammer, num_nodes - 1);
+  go.store(true, std::memory_order_release);
+  t0.join();
+  t1.join();
+
+  EXPECT_EQ(corrupted.load(), 0);
+  // No call failed in some third way.
+  EXPECT_EQ(completed.load() + rejected.load(), 2 * iterations);
+  // Rejecting everything would mean the guard is never released.
+  EXPECT_GT(completed.load(), 0);
 }


### PR DESCRIPTION
## Description

Removes work from the final round of the realtime decode path. No public API change.

- **`decoder.cpp`**: `enqueue_syndrome()` now folds each detector in as soon as the
  last measurement it reads has arrived, instead of XOR-reducing the whole
  measurement buffer on the final round. Detectors are pre-sorted once in
  `set_D_sparse()` by how many measurement columns they need, and a cursor walks
  that order per round. Sorting on the column requirement rather than bucketing by
  round stays correct when rounds differ in width, as they do for the boundary
  layers of a memory circuit. A drain at decode time keeps the detector buffer
  complete by construction rather than by assumption. Each round is also copied
  with `memcpy` instead of a byte-at-a-time loop.
- **`pymatching.cpp`**: the three per-decode temporaries (detection events,
  observable frame, edge list) become reused members, so a steady-state `decode()`
  allocates nothing. Each is cleared at its use site because PyMatching XORs into
  the observable frame and appends to the edge list. Also drops a timing step that
  measured an empty interval (4 -> 3).

## Test plan
- New `QECCodeTester.checkRealtimeStreamedDetectorReduction`: streams a Steane
  memory-circuit window a round at a time over 100 random measurement records and
  requires the detector vector handed to the decoder to match a direct `m2d`
  reduction. Scoped in the comment to what it can observe: `decode()` only runs on
  a complete window, so it pins the reduction, not the fold order.
- `PyMatchingDecoder.DecodesHighObservableIndicesAcrossPaths` now decodes four
  times per instance, firing a different detector each time and revisiting one at
  the end. A single decode passed even without clearing the reused observable
  buffer; this fails without it.

## Runtime / performance impact

### PyMatching on GB200
**Batch decode() — latencies in µs** (d=5, rounds=5, shots=1000)

build | p50 | p90 | p99 | shots/s | LER
-- | -- | -- | -- | -- | --
before | 0.35 | 0.90 | 2.02 | 2,109,349 | 0.0000
after | 0.32 ▼9% | 0.86 ▼4% | 1.98 ▼2% | 2,133,834 ▲1% | 0.0000

**Streaming tail (last round + corrections) — latencies in µs**
build | p50 | p90 | p99 | shots/s | LER
-- | -- | -- | -- | -- | --
before | 0.64 | 1.15 | 2.27 | 756,842 | 0.0000
after | 0.38 ▼41% | 0.93 ▼19% | 2.08 ▼8% | 854,479 ▲13% | 0.0000

## Self-review checklist

Please confirm each item before requesting review. Check `[x]` or strike
through and explain.

### Before requesting review
- [x] I reviewed my own full diff in GitHub or my editor.
- [x] PR is in Draft if it is not yet ready for review.
- [x] Temporary / debugging changes have been removed.
- [x] Local test logs reviewed; no unexplained warnings or errors.
- [x] CI logs reviewed; no unexplained warnings or errors.
- [x] Full CI has been run.

### Scope and size
- [x] PR is under ~1000 lines, or an exception is justified in the description.
- [x] Refactoring-only changes are isolated in their own PR(s).
- [x] No existing tests were disabled or modified just to make this PR pass
      (if so, an issue has been raised).

### Tests
- [x] New functionality has new tests.
- [x] Tests fail if the new functionality is broken (including crashes), not
      just when it is missing.
- [x] Negative tests added where exceptions are expected.
- [x] Truth data added where simple `EXPECT_*` / `assert` checks are
      insufficient for algorithmic correctness.
- [x] CI runtime impact considered; team notified if significant.

### Documentation
- [x] Public-facing APIs have Doxygen docs.
- x ] User-visible behavior changes have public docs, or a follow-up is
      tracked.

### Code style
- [x] Naming follows the existing convention (`snake_case` vs `camelCase`) for
      the area being modified.

### Dependencies
- [x] No new third-party dependencies, **or** the team has been notified and
      OSRB tickets filed.
