### PR TITLE
Add new binary to wheel and all libs builds

### DIFF
--- a/.github/workflows/all_libs_release.yaml
+++ b/.github/workflows/all_libs_release.yaml
@@ -80,11 +80,15 @@ jobs:
             ls
             # Show release info (and save to summary)
             gh release view -R ${{ inputs.assets_repo }} ${{ inputs.assets_tag }} >> $GITHUB_STEP_SUMMARY
-            # Extract the decoder that needs to be embedded in the release
+            # Extract the decoders that need to be embedded in the release.
+            # QEC_EXTERNAL_DECODERS is consumed as a CMake list
+            # (libs/qec/CMakeLists.txt), so multiple paths are
+            # semicolon-separated.
             mkdir -p tmp
             tar -C tmp -xzvf nv-qldpc-decoder-${{ matrix.runner.arch }}_ubuntu24.04_cuda${{ matrix.cuda_version }}_release.tar.gz
             test -f tmp/libcudaq-qec-nv-qldpc-decoder.so
-            echo "QEC_EXTERNAL_DECODERS=$(pwd)/tmp/libcudaq-qec-nv-qldpc-decoder.so" >> $GITHUB_ENV
+            test -f tmp/libcudaq-qec-nv-fusion-decoder.so
+            echo "QEC_EXTERNAL_DECODERS=$(pwd)/tmp/libcudaq-qec-nv-qldpc-decoder.so;$(pwd)/tmp/libcudaq-qec-nv-fusion-decoder.so" >> $GITHUB_ENV
             # The proprietary cudevice archive is optional: it only enables
             # device_graph dispatch in the decoding_server binary and the
             # device-graph realtime tests, neither of which ships in the

--- a/.github/workflows/build_wheels.yaml
+++ b/.github/workflows/build_wheels.yaml
@@ -231,10 +231,15 @@ jobs:
         shell: bash
         run: |
           if [[ -n "${{ inputs.assets_repo }}" ]] && [[ -n "${{ inputs.assets_tag }}" ]]; then
-            # Extract the decoder that needs to be embedded in the wheel
+            # Extract the decoders that need to be embedded in the wheel.
+            # QEC_EXTERNAL_DECODERS is consumed as a CMake list
+            # (libs/qec/CMakeLists.txt), so multiple paths are
+            # semicolon-separated.
             mkdir -p tmp
             tar -C tmp -xzvf nv-qldpc-decoder-${{ matrix.platform }}_ubuntu24.04_cuda${{ matrix.cuda_version }}_py${{ matrix.python }}_release.tar.gz
-            export QEC_EXTERNAL_DECODERS=$(pwd)/tmp/libcudaq-qec-nv-qldpc-decoder.so
+            test -f tmp/libcudaq-qec-nv-qldpc-decoder.so
+            test -f tmp/libcudaq-qec-nv-fusion-decoder.so
+            export QEC_EXTERNAL_DECODERS="$(pwd)/tmp/libcudaq-qec-nv-qldpc-decoder.so;$(pwd)/tmp/libcudaq-qec-nv-fusion-decoder.so"
           fi
           # This is needed to allow the "git rev-parse" commands in the build
           # scripts to work.


### PR DESCRIPTION
<!--
Thanks for contributing to CUDA-Q Libraries!

Please read the full Pull Request Guidelines in Contributing.md:
https://github.com/NVIDIA/cudaqx/blob/main/Contributing.md#pull-request-guidelines
-->

## Description

Add new binary to `build_wheels` and `all_libs_release` workflows, so it can be used when provided.

<!-- What does this PR change, and why? Link related issues. -->

## Runtime / performance impact

<!--
If this change affects performance, paste benchmark numbers here.
Otherwise write "N/A".
-->

## Self-review checklist

Please confirm each item before requesting review. Check `[x]` or strike
through and explain.

### Before requesting review
- [x] I reviewed my own full diff in GitHub or my editor.
- [x] PR is in Draft if it is not yet ready for review.
- [x] Temporary / debugging changes have been removed.
- [x] Local test logs reviewed; no unexplained warnings or errors.
- [ ] CI logs reviewed; no unexplained warnings or errors.
- [ ] Full CI has been run.

### Scope and size
- [x] PR is under ~1000 lines, or an exception is justified in the description.
- [x] Refactoring-only changes are isolated in their own PR(s).
- [x] No existing tests were disabled or modified just to make this PR pass
      (if so, an issue has been raised).

### Tests
- [x] New functionality has new tests.
- [x] Tests fail if the new functionality is broken (including crashes), not
      just when it is missing.
- [x] Negative tests added where exceptions are expected.
- [x] Truth data added where simple `EXPECT_*` / `assert` checks are
      insufficient for algorithmic correctness.
- [x] CI runtime impact considered; team notified if significant.

### Documentation
- [x] Public-facing APIs have Doxygen docs.
- [x] User-visible behavior changes have public docs, or a follow-up is
      tracked.

### Code style
- [x] Naming follows the existing convention (`snake_case` vs `camelCase`) for
      the area being modified.

### Dependencies
- [x] No new third-party dependencies, **or** the team has been notified and
      OSRB tickets filed.
