### PR TITLE
QA image option to download CUDA-Q wheels from cudaqx wheel build

### DIFF
--- a/.github/workflows/build_qa_wheel_test.yaml
+++ b/.github/workflows/build_qa_wheel_test.yaml
@@ -17,7 +17,12 @@ on:
         required: false
       cudaq_assets_tag:
         type: string
-        description: Retrieve CUDA-Q assets from this release (e.g. 0.11.0)
+        description: Retrieve CUDA-Q assets from this release (e.g. 0.11.0). Mutually exclusive with use_custom_cudaq_wheels.
+        required: false
+      use_custom_cudaq_wheels:
+        type: boolean
+        description: Instead of a CUDA-Q release, use the custom-built CUDA-Q wheels (cudaq-wheels-* artifacts) from the wheels_run_id run itself (requires that run to have been built with cudaq_wheels=Custom). Use when no CUDA-Q release exists yet to pull from. Mutually exclusive with cudaq_assets_tag.
+        default: false
         required: false
 
 jobs:
@@ -62,10 +67,21 @@ jobs:
           # gh release download -R NVIDIA/cudaq-private cuquantum-25.03 -p '*cu12*.whl'
           # Fetch the CUDA-Q wheels
           # gh release download -R NVIDIA/cudaq-private staging-0.10.0 -p '*cu12*.whl'
+          if [[ -n "${{ inputs.cudaq_assets_tag }}" ]] && [[ "${{ inputs.use_custom_cudaq_wheels }}" == "true" ]]; then
+            echo "::error::cudaq_assets_tag and use_custom_cudaq_wheels are mutually exclusive; provide only one CUDA-Q wheel source."
+            exit 1
+          fi
           if [[ -n "${{ inputs.cudaq_assets_tag }}" ]]; then
             gh release download -R ${{ inputs.cudaq_repo }} ${{ inputs.cudaq_assets_tag }} -p 'wheelhouse-*.zip'
             for f in wheelhouse-*.zip; do unzip $f; done
             mv wheelhouse-*/*.whl .
+          elif [[ "${{ inputs.use_custom_cudaq_wheels }}" == "true" ]]; then
+            # Use the custom-built CUDA-Q wheels (cudaq-wheels-<platform>-cu<major>
+            # artifacts) produced by the same "Build wheels" run as the CUDA-QX
+            # wheels, when no CUDA-Q release exists yet to pull from. The blanket
+            # `mv */*.whl .` below moves these into place along with the CUDA-QX
+            # wheels.
+            gh run download -R ${{ inputs.wheels_repo }} ${{ inputs.wheels_run_id }} -p 'cudaq-wheels-*'
           fi
 
           # Fetch the CUDA-QX wheels


### PR DESCRIPTION
<!--
Thanks for contributing to CUDA-Q Libraries!

Please read the full Pull Request Guidelines in Contributing.md:
https://github.com/NVIDIA/cudaqx/blob/main/Contributing.md#pull-request-guidelines
-->

## Description

Add boolean parameter to download CUDA-Q wheels from the cudaqx wheel build, rather than from a cuda-quantum tag.

<!-- What does this PR change, and why? Link related issues. -->

## Runtime / performance impact

<!--
If this change affects performance, paste benchmark numbers here.
Otherwise write "N/A".
-->

## Self-review checklist

Please confirm each item before requesting review. Check `[x]` or strike
through and explain.

### Before requesting review
- [x] I reviewed my own full diff in GitHub or my editor.
- [x] PR is in Draft if it is not yet ready for review.
- [x] Temporary / debugging changes have been removed.
- [x] Local test logs reviewed; no unexplained warnings or errors.
- [x] CI logs reviewed; no unexplained warnings or errors.
- [x] Full CI has been run.

### Scope and size
- [x] PR is under ~1000 lines, or an exception is justified in the description.
- [x] Refactoring-only changes are isolated in their own PR(s).
- [x] No existing tests were disabled or modified just to make this PR pass
      (if so, an issue has been raised).

### Tests
- [x] New functionality has new tests.
- [x] Tests fail if the new functionality is broken (including crashes), not
      just when it is missing.
- [x] Negative tests added where exceptions are expected.
- [x] Truth data added where simple `EXPECT_*` / `assert` checks are
      insufficient for algorithmic correctness.
- [x] CI runtime impact considered; team notified if significant.

### Documentation
- [x] Public-facing APIs have Doxygen docs.
- [x] User-visible behavior changes have public docs, or a follow-up is
      tracked.

### Code style
- [x] Naming follows the existing convention (`snake_case` vs `camelCase`) for
      the area being modified.

### Dependencies
- [x] No new third-party dependencies, **or** the team has been notified and
      OSRB tickets filed.
