### PR TITLE
Add ubuntu:24.04 build-env Dockerfiles for decoders-only and decoding server

### DIFF
--- a/.github/workflows/lib_qec.yaml
+++ b/.github/workflows/lib_qec.yaml
@@ -17,19 +17,28 @@ on:
         required: false
 
 jobs:
-  # Build the decoder stack with CUDAQ_QEC_DECODERS_ONLY=ON: no CUDA-Q
-  # install, no LLVM/MLIR, no cuStabilizer. Guards the decoders-only
-  # configuration against rot and demonstrates a decoder call through the
-  # decoders-only python module.
+  # Prove the decoders-only build environment: build the ubuntu:24.04
+  # build-env image (docker/build_env/cudaqx.decoders.Dockerfile) from scratch,
+  # then build the decoder stack with CUDAQ_QEC_DECODERS_ONLY=ON inside it. This
+  # guards both the decoders-only CMake configuration (no CUDA-Q, no LLVM/MLIR,
+  # no cuStabilizer) and the build-env image itself -- proving the decoders can
+  # be built on a bare ubuntu with only the documented apt dependencies. The
+  # image is a local tag, built and consumed on this runner only; nothing is
+  # pushed. verify_build_env.sh runs the build and all assertions (decoding
+  # server correctly skipped, standalone python decode with no cudaq import, no
+  # CUDA-Q/LLVM linkage, and the opt-in TensorRT decoder plugin).
   decoders-only-build:
-    name: Decoders-only build (no CUDA-Q)
+    name: Decoders-only build (CUDA ${{ matrix.cuda_version }}, TensorRT ${{ matrix.install_tensorrt }}, ${{ matrix.platform }})
     strategy:
       fail-fast: false
       matrix:
-        platform: ['amd64', 'arm64']
+        # One run per platform. amd64 exercises the opt-in TensorRT path
+        # (TensorRT resolves to a +cuda13 build, so pair it with 13.0); arm64
+        # covers the default (no TensorRT, plugin auto-disabled).
+        include:
+          - { platform: amd64, cuda_version: '13.0', install_tensorrt: 'on' }
+          - { platform: arm64, cuda_version: '13.0', install_tensorrt: 'off' }
     runs-on: ${{ startsWith(github.repository, 'NVIDIA/cudaqx') && format('linux-{0}-cpu8', matrix.platform) || 'ubuntu-latest' }}
-    container:
-      image: ghcr.io/nvidia/cuda-quantum-devcontainer:${{ matrix.platform }}-cu13.0-gcc12-main
     permissions:
       contents: read
     steps:
@@ -38,52 +47,20 @@ jobs:
         with:
           set-safe-directory: true
 
-      - name: Configure and build (decoders only)
-        shell: bash
+      - name: Build decoders-only build-env image
         run: |
-          set -o pipefail
-          cmake -S libs/qec -B build_decoders_only \
-            -DCMAKE_BUILD_TYPE=Release \
-            -DCUDAQ_QEC_DECODERS_ONLY=ON \
-            -DCUDAQX_QEC_BINDINGS_PYTHON=ON 2>&1 | tee configure.log
-          cmake --build build_decoders_only -j$(nproc)
+          docker build \
+            -f docker/build_env/cudaqx.decoders.Dockerfile \
+            --build-arg cuda_version=${{ matrix.cuda_version }} \
+            --build-arg install_tensorrt=${{ matrix.install_tensorrt }} \
+            -t cudaqx-decoders-build:ci .
 
-      # This image has no cudaq-realtime, so this run also covers the
-      # not-found half of the decoding-server gate: warn, and build the
-      # decoders anyway.
-      - name: Check the decoding server was skipped, not fatal
+      - name: Build decoders-only stack and verify
         run: |
-          grep -q "cudaq-realtime not found" configure.log || {
-            echo "ERROR: expected a warning that cudaq-realtime was not found"
-            exit 1
-          }
-          if [ -e build_decoders_only/bin/decoding_server ]; then
-            echo "ERROR: decoding_server was built without cudaq-realtime"
-            exit 1
-          fi
-          test -e build_decoders_only/lib/libcudaq-qec-decoders.so
-
-      - name: Smoke test (pymatching decode, no cudaq import)
-        run: |
-          PYTHONPATH=build_decoders_only/python python3 - <<'EOF'
-          import sys
-          assert "cudaq" not in sys.modules
-          import numpy as np
-          import _qec_decoders_standalone
-          qec = _qec_decoders_standalone.qecrt
-          # Distance-4 repetition code (pymatching needs a matching graph:
-          # every H column with at most 2 ones).
-          H = np.array([[1, 1, 0, 0],
-                        [0, 1, 1, 0],
-                        [0, 0, 1, 1]], dtype=np.uint8)
-          decoder = qec.get_decoder("pymatching", H)
-          result = decoder.decode([1, 1, 0])
-          assert result.converged
-          correction = (np.asarray(result.result) >= 0.5).astype(np.uint8)
-          np.testing.assert_array_equal((H @ correction) % 2, [1, 1, 0])
-          assert "cudaq" not in sys.modules
-          print("pymatching decode OK without CUDA-Q:", correction.tolist())
-          EOF
+          docker run --rm \
+            -v "$PWD":/workspaces/cudaqx -w /workspaces/cudaqx \
+            cudaqx-decoders-build:ci \
+            bash .github/workflows/scripts/verify_build_env.sh ${{ matrix.install_tensorrt }}
 
   build-and-test:
     name: Build and test

--- a/.github/workflows/pr_workflow.yaml
+++ b/.github/workflows/pr_workflow.yaml
@@ -66,6 +66,8 @@ jobs:
               - '.github/actions/build-lib/build_qec.sh'
               - '.github/actions/build-lib/setup_custabilizer.sh'
               - '.github/workflows/lib_qec.yaml'
+              - '.github/workflows/scripts/verify_build_env.sh'
+              - 'docker/build_env/cudaqx.decoders.Dockerfile'
               - 'cmake/Modules/**'
               - 'libs/core/**/*.cpp'
               - 'libs/core/**/*.h'

--- a/.github/workflows/scripts/verify_build_env.sh
+++ b/.github/workflows/scripts/verify_build_env.sh
@@ -1,0 +1,109 @@
+#!/bin/bash
+set -euo pipefail
+
+# ============================================================================ #
+# Copyright (c) 2026 NVIDIA Corporation & Affiliates.                          #
+# All rights reserved.                                                         #
+#                                                                              #
+# This source code and the accompanying materials are made available under     #
+# the terms of the Apache License 2.0 which accompanies this distribution.     #
+# ============================================================================ #
+
+# Prove the decoders-only build environment works: configure and build the
+# decoder stack (CUDAQ_QEC_DECODERS_ONLY=ON) with Python bindings, then assert
+# the invariants that make it "decoders only". Meant to run *inside* the
+# docker/build_env/cudaqx.decoders.Dockerfile image, with the repo mounted at
+# the current working directory.
+#
+# Usage: verify_build_env.sh [install_tensorrt]
+#   install_tensorrt: on|off (default off) -- whether the image has TensorRT,
+#                     which decides whether the TRT decoder plugin must build.
+
+TRT="${1:-off}"
+BUILD_DIR="${BUILD_DIR:-/tmp/build_decoders_only}"
+CONFIGURE_LOG="${CONFIGURE_LOG:-/tmp/decoders_configure.log}"
+
+log() { printf '\033[1;34m==>\033[0m %s\n' "$*"; }
+die() { printf '\033[1;31merror:\033[0m %s\n' "$*" >&2; exit 1; }
+
+trt_enabled=false
+case "$TRT" in
+  on|ON|1|true|TRUE|yes|YES) trt_enabled=true ;;
+esac
+
+cmake_args=(
+  -S libs/qec -B "$BUILD_DIR" -G Ninja
+  -DCMAKE_BUILD_TYPE=Release
+  -DCUDAQ_QEC_DECODERS_ONLY=ON
+  -DCUDAQX_QEC_BINDINGS_PYTHON=ON
+)
+# When TensorRT is present, hard-require the plugin so a silent AUTO skip cannot
+# hide a regression; when it is absent, leave the default (AUTO) so it is
+# skipped and we can assert its absence below.
+if $trt_enabled; then
+  cmake_args+=(-DCUDAQ_QEC_BUILD_TRT_DECODER=ON)
+fi
+
+log "Configuring decoders-only build (tensorrt=$TRT)"
+cmake "${cmake_args[@]}" 2>&1 | tee "$CONFIGURE_LOG"
+
+log "Building"
+cmake --build "$BUILD_DIR" -j"$(nproc)"
+
+# 1. This image has no cudaq-realtime, so configuring must WARN (not fail) that
+#    the decoding server is skipped, and no decoding_server may be produced --
+#    covers the not-found half of the decoding-server gate.
+log "Checking the decoding server was skipped, not fatal"
+grep -q "cudaq-realtime not found" "$CONFIGURE_LOG" \
+  || die "expected a warning that cudaq-realtime was not found"
+[ ! -e "$BUILD_DIR/bin/decoding_server" ] \
+  || die "decoding_server was built without cudaq-realtime"
+lib="$BUILD_DIR/lib/libcudaq-qec-decoders.so"
+[ -f "$lib" ] || die "expected decoder library not found: $lib"
+
+# 2. The standalone Python module must import and decode without ever pulling in
+#    cudaq (it is importable as the bare _qec_decoders_standalone module).
+log "Python smoke test (pymatching decode, no cudaq import)"
+PYTHONPATH="$BUILD_DIR/python" python3 - <<'PY'
+import sys
+assert "cudaq" not in sys.modules
+import numpy as np
+import _qec_decoders_standalone
+qec = _qec_decoders_standalone.qecrt
+# Distance-4 repetition code (pymatching needs a matching graph: every H column
+# with at most 2 ones).
+H = np.array([[1, 1, 0, 0],
+              [0, 1, 1, 0],
+              [0, 0, 1, 1]], dtype=np.uint8)
+decoder = qec.get_decoder("pymatching", H)
+result = decoder.decode([1, 1, 0])
+assert result.converged
+correction = (np.asarray(result.result) >= 0.5).astype(np.uint8)
+np.testing.assert_array_equal((H @ correction) % 2, [1, 1, 0])
+assert "cudaq" not in sys.modules
+print("pymatching decode OK without CUDA-Q:", correction.tolist())
+PY
+
+# 3. libcudaq-qec-decoders.so must not link CUDA-Q, LLVM or MLIR -- that is the
+#    whole point of the decoders-only build.
+needed=$(readelf -d "$lib" | awk '/NEEDED/ {print $NF}' | tr -d '[]')
+log "libcudaq-qec-decoders.so NEEDED:"
+echo "$needed" | sed 's/^/    /'
+if echo "$needed" | grep -Eiq 'libcudaq|libLLVM|libMLIR|libnvqir'; then
+  die "libcudaq-qec-decoders.so links an unexpected CUDA-Q/LLVM/MLIR library"
+fi
+
+# 4. The TRT decoder plugin must be built iff TensorRT was provided.
+trt_plugin="$BUILD_DIR/lib/decoder-plugins/libcudaq-qec-trt-decoder.so"
+if $trt_enabled; then
+  [ -f "$trt_plugin" ] || die "TensorRT present but the TRT decoder plugin was not built"
+  readelf -d "$trt_plugin" | grep -q 'libnvinfer' \
+    || die "TRT decoder plugin is not linked against libnvinfer"
+  log "TRT decoder plugin built and linked to TensorRT"
+else
+  [ ! -f "$trt_plugin" ] \
+    || die "TensorRT absent but the TRT decoder plugin was built"
+  log "TRT decoder plugin correctly auto-disabled"
+fi
+
+log "Decoders-only build environment verified (tensorrt=$TRT)"

--- a/.github/workflows/scripts/verify_build_env.sh
+++ b/.github/workflows/scripts/verify_build_env.sh
@@ -1,6 +1,4 @@
 #!/bin/bash
-set -euo pipefail
-
 # ============================================================================ #
 # Copyright (c) 2026 NVIDIA Corporation & Affiliates.                          #
 # All rights reserved.                                                         #
@@ -18,6 +16,8 @@ set -euo pipefail
 # Usage: verify_build_env.sh [install_tensorrt]
 #   install_tensorrt: on|off (default off) -- whether the image has TensorRT,
 #                     which decides whether the TRT decoder plugin must build.
+
+set -euo pipefail
 
 TRT="${1:-off}"
 BUILD_DIR="${BUILD_DIR:-/tmp/build_decoders_only}"

--- a/docker/build_env/cudaqx.decoders.Dockerfile
+++ b/docker/build_env/cudaqx.decoders.Dockerfile
@@ -1,0 +1,100 @@
+# ============================================================================ #
+# Copyright (c) 2026 NVIDIA Corporation & Affiliates.                          #
+# All rights reserved.                                                         #
+#                                                                              #
+# This source code and the accompanying materials are made available under     #
+# the terms of the Apache License 2.0 which accompanies this distribution.     #
+# ============================================================================ #
+
+# Minimal build environment for the CUDA-QX QEC *decoders-only* build
+# (CUDAQ_QEC_DECODERS_ONLY=ON), built on a plain ubuntu:24.04 base -- no
+# CUDA-Q and no LLVM/MLIR/Clang required.
+#
+# What the decoders-only build actually needs (see Building.md, "Decoders-only
+# Build"):
+#   * a C/C++ toolchain + CMake (>= 3.28, which ubuntu:24.04 ships) + Ninja
+#   * git/wget/curl + CA certs: the build FetchContent's Stim, fmt, nanobind,
+#     and xtl/xtensor/xtensor-blas from GitHub at configure time
+#   * a CUDA toolkit for cudart: libcudaq-qec-decoders.so links CUDA::cudart
+#     because decoder::get() validates and pins the "cuda_device_id"
+#     construction parameter (cudaGetDeviceCount / cudaSetDevice). This is a
+#     real dependency, not just NVTX. nvcc is not used (no .cu is compiled in
+#     decoders-only mode) but it is installed so find_package(CUDAToolkit)
+#     resolves the toolkit robustly.
+#   * BLAS/LAPACK: libcudaqx-core (whole-archived into the decoders .so) uses
+#     xtensor-blas (xlinalg.hpp), which links BLAS + LAPACK.
+#   * Python dev headers + nanobind (fetched) for the optional
+#     CUDAQX_QEC_BINDINGS_PYTHON module; numpy is only for the smoke test.
+#
+# LLVM/MLIR/Clang are deliberately absent: libs/qec/CMakeLists.txt gates them
+# out entirely under CUDAQ_QEC_DECODERS_ONLY. (LLVMSupport re-enters only when
+# the decoding server is built, which needs a cudaq-realtime install and is not
+# part of this image.)
+#
+# Build the image:
+#   docker build -f docker/build_env/cudaqx.decoders.Dockerfile \
+#     --build-arg cuda_version=12.6 -t cudaqx-decoders-build .
+#
+# Then, with the repo mounted at /workspaces/cudaqx:
+#   cmake -S libs/qec -B build_decoders_only -G Ninja \
+#     -DCMAKE_BUILD_TYPE=Release \
+#     -DCUDAQ_QEC_DECODERS_ONLY=ON \
+#     -DCUDAQX_QEC_BINDINGS_PYTHON=ON
+#   cmake --build build_decoders_only -j$(nproc)
+
+FROM ubuntu:24.04
+
+# CUDA toolkit version to install (cudart + nvcc). Any version present in the
+# NVIDIA ubuntu2404 repo works; 12.6 matches the repo's primary target.
+ARG cuda_version=12.6
+
+LABEL org.opencontainers.image.description="Ubuntu 24.04 build env for the CUDA-QX QEC decoders-only build (no CUDA-Q, no LLVM)"
+LABEL org.opencontainers.image.source="https://github.com/NVIDIA/cudaqx"
+LABEL org.opencontainers.image.title="cudaqx-decoders-build"
+LABEL org.opencontainers.image.url="https://github.com/NVIDIA/cudaqx"
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Base build tooling and the decoder stack's link-time deps.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      ca-certificates \
+      git \
+      wget \
+      curl \
+      gnupg \
+      build-essential \
+      gcc \
+      g++ \
+      ninja-build \
+      cmake \
+      patchelf \
+      python3 \
+      python3-dev \
+      python3-pip \
+      python3-numpy \
+      libopenblas-dev \
+      liblapack-dev \
+  && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# CUDA cudart (+ nvcc for robust toolkit discovery) from the NVIDIA apt repo.
+RUN CUDA_DASH=$(echo "${cuda_version}" | tr '.' '-') \
+  && arch=$(dpkg --print-architecture) \
+  && case "${arch}" in \
+       amd64) repo_arch=x86_64 ;; \
+       arm64) repo_arch=sbsa ;; \
+       *) echo "unsupported architecture: ${arch}" >&2; exit 1 ;; \
+     esac \
+  && wget -q -O /tmp/cuda-keyring.deb \
+       "https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2404/${repo_arch}/cuda-keyring_1.1-1_all.deb" \
+  && dpkg -i /tmp/cuda-keyring.deb \
+  && rm -f /tmp/cuda-keyring.deb \
+  && apt-get update && apt-get install -y --no-install-recommends \
+       cuda-nvcc-${CUDA_DASH} \
+       cuda-cudart-dev-${CUDA_DASH} \
+  && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# Make the toolkit discoverable to CMake's find_package(CUDAToolkit).
+ENV PATH=/usr/local/cuda-${cuda_version}/bin:${PATH}
+ENV CUDAToolkit_ROOT=/usr/local/cuda-${cuda_version}
+
+WORKDIR /workspaces/cudaqx

--- a/docker/build_env/cudaqx.decoders.Dockerfile
+++ b/docker/build_env/cudaqx.decoders.Dockerfile
@@ -22,7 +22,9 @@
 #     decoders-only mode) but it is installed so find_package(CUDAToolkit)
 #     resolves the toolkit robustly.
 #   * BLAS/LAPACK: libcudaqx-core (whole-archived into the decoders .so) uses
-#     xtensor-blas (xlinalg.hpp), which links BLAS + LAPACK.
+#     xtensor-blas (xlinalg.hpp), which links BLAS + LAPACK. libopenblas-dev
+#     supplies both (it provides the libblas.so and liblapack.so alternatives),
+#     so a separate liblapack-dev is not needed.
 #   * Python dev headers + nanobind (fetched) for the optional
 #     CUDAQX_QEC_BINDINGS_PYTHON module; numpy is only for the smoke test.
 #
@@ -50,7 +52,7 @@ ARG cuda_version=12.6
 
 LABEL org.opencontainers.image.description="Ubuntu 24.04 build env for the CUDA-QX QEC decoders-only build (no CUDA-Q, no LLVM)"
 LABEL org.opencontainers.image.source="https://github.com/NVIDIA/cudaqx"
-LABEL org.opencontainers.image.title="cudaqx-decoders-build"
+LABEL org.opencontainers.image.title="cudaq-decoders-build"
 LABEL org.opencontainers.image.url="https://github.com/NVIDIA/cudaqx"
 
 ENV DEBIAN_FRONTEND=noninteractive
@@ -73,7 +75,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
       python3-pip \
       python3-numpy \
       libopenblas-dev \
-      liblapack-dev \
   && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # CUDA cudart (+ nvcc for robust toolkit discovery) from the NVIDIA apt repo.

--- a/docker/build_env/cudaqx.decoders.Dockerfile
+++ b/docker/build_env/cudaqx.decoders.Dockerfile
@@ -93,6 +93,23 @@ RUN CUDA_DASH=$(echo "${cuda_version}" | tr '.' '-') \
        cuda-cudart-dev-${CUDA_DASH} \
   && apt-get clean && rm -rf /var/lib/apt/lists/*
 
+# Optional TensorRT for the cudaq-qec-trt-decoder plugin (opt-in; default off).
+# The plugin's CUDAQ_QEC_BUILD_TRT_DECODER option is AUTO by default, so simply
+# having libnvinfer + libnvonnxparser installed (in /usr/{include,lib}/<triple>,
+# where these dev packages land and where the plugin searches) makes the build
+# pick it up; pass -DCUDAQ_QEC_BUILD_TRT_DECODER=ON at configure time to
+# hard-require it. TensorRT comes from the same NVIDIA CUDA apt repo added
+# above; apt resolves the latest build, whose CUDA tag must line up with
+# cuda_version for the plugin to load at runtime.
+ARG install_tensorrt=off
+RUN case "${install_tensorrt}" in \
+      on|ON|1|true|TRUE|yes|YES) \
+        apt-get update && apt-get install -y --no-install-recommends \
+          libnvinfer-dev libnvonnxparsers-dev \
+        && apt-get clean && rm -rf /var/lib/apt/lists/* ;; \
+      *) echo "install_tensorrt=${install_tensorrt}: skipping TensorRT; the cudaq-qec-trt-decoder plugin will be auto-disabled." ;; \
+    esac
+
 # Make the toolkit discoverable to CMake's find_package(CUDAToolkit).
 ENV PATH=/usr/local/cuda-${cuda_version}/bin:${PATH}
 ENV CUDAToolkit_ROOT=/usr/local/cuda-${cuda_version}

--- a/docker/build_env/cudaqx.decoding-server.Dockerfile
+++ b/docker/build_env/cudaqx.decoding-server.Dockerfile
@@ -156,6 +156,23 @@ RUN CUDA_DASH=$(echo "${cuda_version}" | tr '.' '-') \
        cuda-cudart-dev-${CUDA_DASH} \
   && apt-get clean && rm -rf /var/lib/apt/lists/*
 
+# Optional TensorRT for the cudaq-qec-trt-decoder plugin (opt-in; default off).
+# The plugin's CUDAQ_QEC_BUILD_TRT_DECODER option is AUTO by default, so simply
+# having libnvinfer + libnvonnxparser installed (in /usr/{include,lib}/<triple>,
+# where these dev packages land and where the plugin searches) makes the build
+# pick it up; pass -DCUDAQ_QEC_BUILD_TRT_DECODER=ON at configure time to
+# hard-require it. TensorRT comes from the same NVIDIA CUDA apt repo added
+# above; apt resolves the latest build, whose CUDA tag must line up with
+# cuda_version for the plugin to load at runtime.
+ARG install_tensorrt=off
+RUN case "${install_tensorrt}" in \
+      on|ON|1|true|TRUE|yes|YES) \
+        apt-get update && apt-get install -y --no-install-recommends \
+          libnvinfer-dev libnvonnxparsers-dev \
+        && apt-get clean && rm -rf /var/lib/apt/lists/* ;; \
+      *) echo "install_tensorrt=${install_tensorrt}: skipping TensorRT; the cudaq-qec-trt-decoder plugin will be auto-disabled." ;; \
+    esac
+
 # Pluck the cudaq-realtime install (headers + libs only) into a small prefix.
 COPY --from=cudaq_realtime \
        /opt/nvidia/cudaq/include/cudaq/realtime \

--- a/docker/build_env/cudaqx.decoding-server.Dockerfile
+++ b/docker/build_env/cudaqx.decoding-server.Dockerfile
@@ -1,0 +1,183 @@
+# ============================================================================ #
+# Copyright (c) 2026 NVIDIA Corporation & Affiliates.                          #
+# All rights reserved.                                                         #
+#                                                                              #
+# This source code and the accompanying materials are made available under     #
+# the terms of the Apache License 2.0 which accompanies this distribution.     #
+# ============================================================================ #
+
+# Build environment for the CUDA-QX QEC *decoding server*, built on a plain
+# ubuntu:24.04 base.  This is the decoders-only build
+# (CUDAQ_QEC_DECODERS_ONLY=ON) plus the one extra ingredient the server needs:
+# a cudaq-realtime install (libcudaq-realtime.so + the cudaq/realtime headers).
+# It still needs no CUDA-Q runtime, no simulators, and no MLIR/Clang.
+#
+# Where cudaq-realtime comes from
+# -------------------------------
+# cudaq-realtime is a CUDA-Q build artifact with no apt package, so we pluck
+# just its pieces out of the CUDA-Q nightly runtime image (first stage below)
+# and drop them into a small prefix at /opt/cudaq-realtime.  Only these files
+# make up the "cudaq-realtime installation" the server links against:
+#   * include/cudaq/realtime/**  -- the dispatcher, bridge and device_call
+#     headers (self-contained: they include nothing outside cudaq/realtime)
+#   * lib/libcudaq-realtime.so   -- the bridge loader + dispatcher C API
+#     (NEEDED: only libstdc++/libc; it does not even pull in cudart)
+#   * lib/libcudaq-realtime-dispatch.a -- device-graph scheduler shims, located
+#     (not linked here) so device_graph dispatch compiles
+#   * lib/libcudaq-realtime-bridge-{udp,cpu-roce}.so -- transport providers the
+#     server dlopen()s at runtime for --transport=udp / cpu_roce
+#   * lib/libcudaq-realtime-{host-dispatch,udp-transport,cpu-roce-transport}.a
+#     -- internal transport archives, copied to keep the prefix self-consistent
+# We deliberately do NOT copy the rest of the CUDA-Q prefix (~767M): no
+# simulators, no compiler, no cudaq runtime.
+#
+# LLVM
+# ----
+# The server's only LLVM use is llvm::yaml / llvm::json in the realtime config
+# parser (LLVMSupport) -- no MLIR, no Clang.  But config.cpp calls
+# llvm::yaml::IO::error(), which the base IO class only gained in LLVM 21+, so
+# Ubuntu's own llvm-dev (18/19/20) is too old.  We therefore install the
+# prebuilt llvm-22-dev from apt.llvm.org: still just the LLVMSupport library +
+# headers (not a from-source toolchain, not the NVIDIA LLVM fork), matching the
+# LLVM 22 the code was written against.  This relies on the relaxed (non-exact)
+# LLVM version requirement in libs/qec/lib/realtime/CMakeLists.txt.
+#
+# CUDA
+# ----
+# Unlike the decoders-only build, the server build compiles CUDA device code
+# (lib/realtime/gpu_kernels.cu), so it needs nvcc + cudart, not just cudart.
+#
+# Build the image:
+#   docker build -f docker/build_env/cudaqx.decoding-server.Dockerfile \
+#     -t cudaqx-decoding-server-build .
+#
+# Then, with the repo mounted at /workspaces/cudaqx:
+#   cmake -S libs/qec -B build_server -G Ninja \
+#     -DCMAKE_BUILD_TYPE=Release \
+#     -DCUDAQ_QEC_DECODERS_ONLY=ON \
+#     -DCUDAQ_REALTIME_ROOT=/opt/cudaq-realtime \
+#     -DLLVM_DIR="$LLVM_DIR" \
+#     -DLLVM_VERSION_MAJOR="$LLVM_VERSION_MAJOR" -DLLVM_VERSION_MINOR="$LLVM_VERSION_MINOR"
+#   cmake --build build_server -j$(nproc) --target decoding_server
+
+# Stage 1: source of the cudaq-realtime artifacts (COPY --from only).
+ARG cudaq_image=nvcr.io/nvidia/nightly/cuda-quantum:cu13-latest
+FROM ${cudaq_image} AS cudaq_realtime
+
+# Stage 2: the ubuntu:24.04 build environment.
+FROM ubuntu:24.04
+
+# CUDA toolkit version (cudart + nvcc). The realtime .so is CUDA-version
+# agnostic, so this only governs the device code we compile ourselves.
+ARG cuda_version=12.6
+# LLVM (from apt.llvm.org) used only for LLVMSupport (llvm::yaml / llvm::json).
+# Must be >= 21 for llvm::yaml::IO::error(); 22 matches the pinned version the
+# realtime config parser was written against.
+ARG llvm_version=22
+
+LABEL org.opencontainers.image.description="Ubuntu 24.04 build env for the CUDA-QX QEC decoding server (plucked cudaq-realtime, distro LLVM, no CUDA-Q)"
+LABEL org.opencontainers.image.source="https://github.com/NVIDIA/cudaqx"
+LABEL org.opencontainers.image.title="cudaqx-decoding-server-build"
+LABEL org.opencontainers.image.url="https://github.com/NVIDIA/cudaqx"
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Base build tooling, the decoder stack's link-time deps (BLAS/LAPACK for
+# xtensor-blas in core), Python for the optional bindings, and llvm-dev for
+# LLVMSupport.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      ca-certificates \
+      git \
+      wget \
+      curl \
+      gnupg \
+      build-essential \
+      gcc \
+      g++ \
+      ninja-build \
+      cmake \
+      patchelf \
+      python3 \
+      python3-dev \
+      python3-pip \
+      python3-numpy \
+      libopenblas-dev \
+      liblapack-dev \
+      libzstd-dev \
+      zlib1g-dev \
+      libz3-dev \
+  && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# LLVMSupport from apt.llvm.org (prebuilt; provides llvm::yaml::IO::error(),
+# absent from Ubuntu's own llvm <= 20). No MLIR/Clang -- just the dev package.
+#
+# llvm-<v>-dev is huge (~450MB of static component libs + a 143MB shared
+# libLLVM + 91MB of tools), but the server links only libLLVMSupport.a (~6MB)
+# and needs the headers + CMake package files.  We reclaim the rest by
+# TRUNCATING the unused files to 0 bytes -- not deleting them: LLVM's
+# LLVMExports*.cmake runs an existence check over every imported target's file
+# and FATAL_ERRORs on a missing one, even for components we never link, so the
+# files must still exist.  Truncating keeps them present but empty.  This is
+# done in the same RUN as the install so the layer only ever stores the
+# shrunken tree (a later-layer delete would leave the 450MB in the lower
+# layer).  Side effect: dpkg still believes those files are full-size; harmless
+# for a build image.  Net LLVM footprint drops from ~590MB to ~48MB (mostly the
+# 40MB of headers, which a build environment must keep).
+RUN wget -q -O /etc/apt/trusted.gpg.d/apt.llvm.org.asc \
+       https://apt.llvm.org/llvm-snapshot.gpg.key \
+  && . /etc/os-release \
+  && echo "deb http://apt.llvm.org/${VERSION_CODENAME}/ llvm-toolchain-${VERSION_CODENAME}-${llvm_version} main" \
+       > /etc/apt/sources.list.d/llvm.list \
+  && apt-get update && apt-get install -y --no-install-recommends \
+       llvm-${llvm_version}-dev \
+  && find /usr/lib/llvm-${llvm_version}/lib -type f ! -path '*/cmake/*' \
+       ! -name 'libLLVMSupport.a' ! -name 'libLLVMDemangle.a' \
+       -exec truncate -s 0 {} + \
+  && find /usr/lib/llvm-${llvm_version}/bin -type f -exec truncate -s 0 {} + \
+  && find /usr/lib -maxdepth 2 -type f -name 'libLLVM*.so*' \
+       -exec truncate -s 0 {} + \
+  && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# CUDA cudart + nvcc from the NVIDIA apt repo (nvcc is needed here: the server
+# build compiles lib/realtime/gpu_kernels.cu).
+RUN CUDA_DASH=$(echo "${cuda_version}" | tr '.' '-') \
+  && arch=$(dpkg --print-architecture) \
+  && case "${arch}" in \
+       amd64) repo_arch=x86_64 ;; \
+       arm64) repo_arch=sbsa ;; \
+       *) echo "unsupported architecture: ${arch}" >&2; exit 1 ;; \
+     esac \
+  && wget -q -O /tmp/cuda-keyring.deb \
+       "https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2404/${repo_arch}/cuda-keyring_1.1-1_all.deb" \
+  && dpkg -i /tmp/cuda-keyring.deb \
+  && rm -f /tmp/cuda-keyring.deb \
+  && apt-get update && apt-get install -y --no-install-recommends \
+       cuda-nvcc-${CUDA_DASH} \
+       cuda-cudart-dev-${CUDA_DASH} \
+  && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# Pluck the cudaq-realtime install (headers + libs only) into a small prefix.
+COPY --from=cudaq_realtime \
+       /opt/nvidia/cudaq/include/cudaq/realtime \
+       /opt/cudaq-realtime/include/cudaq/realtime
+COPY --from=cudaq_realtime \
+       /opt/nvidia/cudaq/lib/libcudaq-realtime.so \
+       /opt/nvidia/cudaq/lib/libcudaq-realtime-dispatch.a \
+       /opt/nvidia/cudaq/lib/libcudaq-realtime-bridge-udp.so \
+       /opt/nvidia/cudaq/lib/libcudaq-realtime-bridge-cpu-roce.so \
+       /opt/nvidia/cudaq/lib/libcudaq-realtime-host-dispatch.a \
+       /opt/nvidia/cudaq/lib/libcudaq-realtime-udp-transport.a \
+       /opt/nvidia/cudaq/lib/libcudaq-realtime-cpu-roce-transport.a \
+       /opt/cudaq-realtime/lib/
+
+# Make the toolkit, the plucked realtime install, and the distro LLVM
+# discoverable to CMake.
+ENV PATH=/usr/local/cuda-${cuda_version}/bin:${PATH}
+ENV CUDAToolkit_ROOT=/usr/local/cuda-${cuda_version}
+ENV CUDAQ_REALTIME_ROOT=/opt/cudaq-realtime
+ENV LLVM_DIR=/usr/lib/llvm-${llvm_version}/lib/cmake/llvm
+ENV LLVM_VERSION_MAJOR=${llvm_version}
+ENV LLVM_VERSION_MINOR=1
+ENV PATH=/usr/lib/llvm-${llvm_version}/bin:${PATH}
+
+WORKDIR /workspaces/cudaqx

--- a/docker/build_env/cudaqx.decoding-server.Dockerfile
+++ b/docker/build_env/cudaqx.decoding-server.Dockerfile
@@ -102,7 +102,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
       python3-pip \
       python3-numpy \
       libopenblas-dev \
-      liblapack-dev \
       libzstd-dev \
       zlib1g-dev \
       libz3-dev \

--- a/libs/qec/lib/realtime/CMakeLists.txt
+++ b/libs/qec/lib/realtime/CMakeLists.txt
@@ -6,7 +6,17 @@
 # the terms of the Apache License 2.0 which accompanies this distribution.     #
 # ============================================================================ #
 
-find_package(LLVM 22.1.4 EXACT REQUIRED CONFIG)
+# The realtime decoding config parser (config.cpp) uses only llvm::yaml,
+# llvm::json and llvm::raw_ostream from LLVMSupport, whose API is stable across
+# LLVM versions.  The top-level qec project already locates LLVM (honoring
+# LLVM_DIR / LLVM_VERSION_MAJOR / LLVM_VERSION_MINOR) before descending here, so
+# reuse that result rather than pinning an exact version -- any LLVM providing
+# the Support component works, e.g. a distro `llvm-dev`, with no NVIDIA LLVM
+# toolchain required.  Only fall back to a fresh lookup if LLVM was not already
+# found (e.g. this directory configured on its own).
+if(NOT LLVM_FOUND)
+  find_package(LLVM REQUIRED CONFIG)
+endif()
 
 # Enable CUDA for device code
 if(CMAKE_CUDA_COMPILER)


### PR DESCRIPTION
Adds two `docker/build_env` images (plain ubuntu:24.04, no CUDA-Q install):

- **cudaqx.decoders.Dockerfile** — the decoders-only build   (`CUDAQ_QEC_DECODERS_ONLY=ON`). Needs only a toolchain, CUDA cudart, and BLAS; no LLVM/MLIR.
- **cudaqx.decoding-server.Dockerfile** — decoders-only plus the decoding server. Plucks just the cudaq-realtime install (headers + `libcudaq-realtime*`) from the CUDA-Q nightly image; LLVMSupport comes from apt.llvm.org's llvm-22-dev (trimmed to ~48MB).

Also:
- Relax the `find_package(LLVM 22.1.4 EXACT)` pin in `libs/qec/lib/realtime/CMakeLists.txt` so a distro llvm-dev satisfies the server's LLVMSupport use.
- Opt-in `install_tensorrt` build-arg (default off) for the TRT decoder plugin.
- Per-PR CI job that builds the decoders-only image and verifies the build (Python smoke test + no-CUDA-Q/LLVM linkage + TRT plugin presence).