### PR TITLE
Include the standalone decoders module in the cudaq_qec wheel

### DIFF
--- a/libs/qec/python/CMakeLists.txt
+++ b/libs/qec/python/CMakeLists.txt
@@ -126,3 +126,28 @@ install(TARGETS ${MODULE_NAME}
   COMPONENT qec-python
   DESTINATION cudaq_qec/
 )
+
+# Undocumented: also ship the cudaq-free decoders module (_qec_decoders_standalone,
+# the same one the decoders-only build produces) inside the wheel, so the
+# decoders can be used without importing cudaq: `import _qec_decoders_standalone`.
+# It links only cudaq-qec-decoders + cudart. It is installed at the wheel root,
+# NOT under cudaq_qec/: importing anything under cudaq_qec runs cudaq_qec/__init__
+# -> patch.py -> `from cudaq import qvector`, which would pull in cudaq. Wheel
+# (SKBUILD) only; $ORIGIN/${CMAKE_INSTALL_LIBDIR} resolves the in-package
+# libcudaq-qec-decoders.so (with its decoder-plugins/ sibling) in cudaq_qec/lib.
+if (SKBUILD)
+  cudaqx_add_pymodule(_qec_decoders_standalone
+    bindings/cudaqx_qec_decoders_only.cpp
+    bindings/py_decoder.cpp
+  )
+  target_link_libraries(_qec_decoders_standalone PRIVATE
+    cudaq-qec-decoders CUDA::cudart)
+  target_include_directories(_qec_decoders_standalone PRIVATE
+    ${CUDAToolkit_INCLUDE_DIRS})
+  set_target_properties(_qec_decoders_standalone PROPERTIES
+    LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/python"
+    INSTALL_RPATH "$ORIGIN/${CMAKE_INSTALL_LIBDIR}")
+  install(TARGETS _qec_decoders_standalone
+    COMPONENT qec-python
+    DESTINATION .)
+endif()

--- a/scripts/ci/test_wheels.sh
+++ b/scripts/ci/test_wheels.sh
@@ -133,19 +133,15 @@ if [ "$cuda_major" = "12" ]; then
 else
   ${python} -m pip install "nvidia-cuda-runtime" || true
 fi
-${python} - <<'EOF'
-import ctypes, glob, os, sys
-# Preload libcudart if the CUDA runtime wheel is present (its layout varies by
-# CUDA major: nvidia/cuda_runtime/lib for cu12, nvidia/cu13/lib for cu13), so
-# the module's DT_NEEDED libcudart resolves; otherwise fall back to a system
-# cudart already on the loader path.
-try:
-    import nvidia
-    for base in list(nvidia.__path__):
-        for so in sorted(glob.glob(os.path.join(base, "**", "libcudart.so*"), recursive=True)):
-            ctypes.CDLL(so, mode=ctypes.RTLD_GLOBAL)
-except Exception:
-    pass
+# libcudart's location in the CUDA runtime wheel differs by CUDA major
+# (nvidia/cuda_runtime/lib for cu12, nvidia/cu13/lib for cu13), so discover it
+# rather than hard-coding, and put it on LD_LIBRARY_PATH. Images that already
+# ship a system cudart leave this empty and rely on the default loader path.
+cudart_so=$(${python} -c "import glob, os, nvidia; print(next(iter(glob.glob(os.path.join(list(nvidia.__path__)[0], '**', 'libcudart.so*'), recursive=True)), ''))" 2>/dev/null || true)
+cudart_dir=""
+if [ -n "$cudart_so" ]; then cudart_dir=$(dirname "$cudart_so"); fi
+LD_LIBRARY_PATH="${cudart_dir}${cudart_dir:+:}${LD_LIBRARY_PATH}" ${python} - <<'EOF'
+import sys
 import numpy as np
 import _qec_decoders_standalone as m
 assert "cudaq" not in sys.modules, "importing _qec_decoders_standalone pulled in cudaq"

--- a/scripts/ci/test_wheels.sh
+++ b/scripts/ci/test_wheels.sh
@@ -121,15 +121,31 @@ fi
 # sys.modules check is meaningful.
 #
 # The module links libcudart. Normally `import cudaq` puts the CUDA runtime on
-# the loader path, but this test (and any cudaq-free user) skips cudaq, so the
-# wheel does not bring cudart. Install the CUDA runtime wheel and add it to
-# LD_LIBRARY_PATH -- this is exactly what a cudaq-free user must do.
+# the loader path, but this test (and any cudaq-free user) skips cudaq, so
+# provide cudart from the CUDA runtime wheel -- what a cudaq-free user must do.
+# The package name differs by CUDA major (cu12 keeps the -cu12 suffix; cu13+
+# uses the unsuffixed nvidia-cuda-runtime), and installing is best-effort since
+# some images already ship a system cudart.
 # ======================================
 echo "Smoke testing standalone decoders module (_qec_decoders_standalone)"
-${python} -m pip install "nvidia-cuda-runtime-cu${cuda_major}"
-cudart_libdir=$(${python} -c "import os, nvidia; print(os.path.join(list(nvidia.__path__)[0], 'cuda_runtime', 'lib'))")
-LD_LIBRARY_PATH="${cudart_libdir}:${LD_LIBRARY_PATH}" ${python} - <<'EOF'
-import sys
+if [ "$cuda_major" = "12" ]; then
+  ${python} -m pip install "nvidia-cuda-runtime-cu12" || true
+else
+  ${python} -m pip install "nvidia-cuda-runtime" || true
+fi
+${python} - <<'EOF'
+import ctypes, glob, os, sys
+# Preload libcudart if the CUDA runtime wheel is present (its layout varies by
+# CUDA major: nvidia/cuda_runtime/lib for cu12, nvidia/cu13/lib for cu13), so
+# the module's DT_NEEDED libcudart resolves; otherwise fall back to a system
+# cudart already on the loader path.
+try:
+    import nvidia
+    for base in list(nvidia.__path__):
+        for so in sorted(glob.glob(os.path.join(base, "**", "libcudart.so*"), recursive=True)):
+            ctypes.CDLL(so, mode=ctypes.RTLD_GLOBAL)
+except Exception:
+    pass
 import numpy as np
 import _qec_decoders_standalone as m
 assert "cudaq" not in sys.modules, "importing _qec_decoders_standalone pulled in cudaq"

--- a/scripts/ci/test_wheels.sh
+++ b/scripts/ci/test_wheels.sh
@@ -119,9 +119,16 @@ fi
 # it is importable as the bare top-level `_qec_decoders_standalone` and must
 # decode without ever pulling in cudaq. Run in a fresh interpreter so the
 # sys.modules check is meaningful.
+#
+# The module links libcudart. Normally `import cudaq` puts the CUDA runtime on
+# the loader path, but this test (and any cudaq-free user) skips cudaq, so the
+# wheel does not bring cudart. Install the CUDA runtime wheel and add it to
+# LD_LIBRARY_PATH -- this is exactly what a cudaq-free user must do.
 # ======================================
 echo "Smoke testing standalone decoders module (_qec_decoders_standalone)"
-${python} - <<'EOF'
+${python} -m pip install "nvidia-cuda-runtime-cu${cuda_major}"
+cudart_libdir=$(${python} -c "import os, nvidia; print(os.path.join(list(nvidia.__path__)[0], 'cuda_runtime', 'lib'))")
+LD_LIBRARY_PATH="${cudart_libdir}:${LD_LIBRARY_PATH}" ${python} - <<'EOF'
 import sys
 import numpy as np
 import _qec_decoders_standalone as m

--- a/scripts/ci/test_wheels.sh
+++ b/scripts/ci/test_wheels.sh
@@ -115,6 +115,23 @@ if [ "$package_installed" != "$package_expected" ]; then
   exit 1
 fi
 
+# Smoke test the (undocumented) standalone decoders module shipped in the wheel:
+# it is importable as the bare top-level `_qec_decoders_standalone` and must
+# decode without ever pulling in cudaq. Run in a fresh interpreter so the
+# sys.modules check is meaningful.
+# ======================================
+echo "Smoke testing standalone decoders module (_qec_decoders_standalone)"
+${python} - <<'EOF'
+import sys
+import numpy as np
+import _qec_decoders_standalone as m
+assert "cudaq" not in sys.modules, "importing _qec_decoders_standalone pulled in cudaq"
+H = np.array([[1, 1, 0, 0], [0, 1, 1, 0], [0, 0, 1, 1]], dtype=np.uint8)
+assert m.qecrt.get_decoder("pymatching", H).decode([1, 1, 0]).converged
+assert "cudaq" not in sys.modules, "using the standalone decoder pulled in cudaq"
+print("standalone decoders module OK (no cudaq import)")
+EOF
+
 # Test the libraries with examples
 # ======================================
 echo "Testing libraries with examples"


### PR DESCRIPTION
Builds on #803

Add a small SKBUILD-only block that also builds _qec_decoders_standalone (the same cudaq-free module the decoders-only build produces) and installs it into the wheel at the site-packages root. It links only cudaq-qec-decoders + cudart (no cudaq), giving an undocumented way to use the decoders without importing cudaq: `import _qec_decoders_standalone`. It is installed top-level, not under cudaq_qec/, on purpose -- importing anything under cudaq_qec runs cudaq_qec/__init__ -> patch.py -> `from cudaq import qvector`.

Purely additive and gated on SKBUILD, so non-wheel and decoders-only builds are unchanged. Add a small smoke test to the wheel test (test_wheels.sh): in a fresh interpreter, import the standalone module, decode with pymatching, and assert cudaq was never imported.

Note: the wheel does not bundle cudart, so this still needs a CUDA runtime present (from cuda-quantum, nvidia-cuda-runtime-cuXX, or a system CUDA).