### PR TITLE
fix: update validation wheels script

### DIFF
--- a/scripts/validation/wheel/validate_wheels.sh
+++ b/scripts/validation/wheel/validate_wheels.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # ============================================================================ #
-# Copyright (c) 2024 - 2025 NVIDIA Corporation & Affiliates.                   #
+# Copyright (c) 2024 - 2026 NVIDIA Corporation & Affiliates.                   #
 # All rights reserved.                                                         #
 #                                                                              #
 # This source code and the accompanying materials are made available under     #
@@ -35,7 +35,7 @@ done
 
 CURRENT_ARCH=$(uname -m)
 PYTHON_VERSIONS=("3.11" "3.12" "3.13")
-TARGETS=("nvidia" "nvidia --option fp64", "qpp-cpu")
+TARGETS=("nvidia" "nvidia --option fp64" "qpp-cpu")
 
 # OpenBLAS can get bogged down on some machines if using too many threads.
 export OMP_NUM_THREADS=8
@@ -82,18 +82,36 @@ test_examples() {
         cuda_major=$(echo ${CUDA_VERSION} | cut -d '.' -f 1)
         cuda_minor=$(echo ${CUDA_VERSION} | cut -d '.' -f 2)
         cuda_no_dot="${cuda_major}${cuda_minor}"
-        pip install torch==2.9.0 --index-url https://download.pytorch.org/whl/cu${cuda_no_dot}
-        if [ "$(uname -m)" == "x86_64" ]; then
-          pip install "tensorrt-cu${cuda_major}==10.13.*" "cuda_toolkit[cudart]==${cuda_major}.${cuda_minor}.*"
-          pip install onnxscript
+        # cu126 torch wheels lack sm_100 (Blackwell) kernels; use the cu128 build
+        # on the 12.x path (runs on 12.6, supports newer GPUs). 13.x keeps its tag.
+        torch_cuda_no_dot="${cuda_no_dot}"
+        if [ "${cuda_major}" == "12" ]; then torch_cuda_no_dot="128"; fi
+        pip install torch==2.9.0 --index-url https://download.pytorch.org/whl/cu${torch_cuda_no_dot}
+        # TensorRT supports CUDA 12+ on x86 and CUDA 13+ on ARM.
+        qec_extras="tensor_network_decoder"
+        if [[ "$(uname -m)" == "x86_64" || "${cuda_major}" == "13" ]]; then
+            qec_extras+=",trt_decoder"
+            if [ "${cuda_major}" == "12" ]; then
+                toolkit_version="12.8.*"
+            else
+                # Keep cudart at the 13.0.48 version required by torch cu130.
+                # 13.0.* currently resolves to toolkit 13.0.3.0 and cudart 13.0.96, conflicting with torch 2.9.0+cu130’s exact cudart 13.0.48.
+                # Toolkit 13.0.0 supplies the compatible 13.0.48.
+                toolkit_version="13.0.0"
+            fi
+            pip install "tensorrt-cu${cuda_major}==10.13.*" "cuda_toolkit[cudart]==${toolkit_version}"
+            pip install onnxscript
         fi
-        pip install cudaq-qec[tensor_network_decoder,trt_decoder] --find-links /root/wheels
+        # Select the intended CUDA-major wheel explicitly. The unsuffixed
+        # metapackage can detect the driver CUDA version and choose cu13 here.
+        pip install "cudaq-qec-cu${cuda_major}[${qec_extras}]" --find-links /root/wheels
         source $CONDA_PREFIX/lib/python${python_version}/site-packages/distributed_interfaces/activate_custom_mpi.sh
         export OMPI_MCA_opal_cuda_support=true OMPI_MCA_btl='^openib'
 
         # Needed for tests:
         pip install pytest
-        # Needed by docs/sphinx/examples/qec/python/pseudo_threshold.py.
+        # matplotlib is only pulled in transitively on x86 (via beliefmatching);
+        # install it explicitly so ARM has it (pseudo_threshold.py imports it).
         pip install matplotlib
 
         if [[ "$(uname -m)" == "x86_64" ]]; then


### PR DESCRIPTION
This PR is to update the validation script for wheels to resolve some package compatibility issues:
1. `cuda_toolkit[cudart]==${cuda_major}.${cuda_minor}.*` is a little bit tricky. For the CUDA12 part (major 12, minor 6), it replaces our cu128 cudart, and also, pip downgrades torch 2.9.0 to 2.7.1 when installing QEC extras, still causing problems of cu126+sm_100 and more. In the CUDA13 path, `13.0.*` resolves to cudart 13.0.96, conflicting with torch 2.9.0+cu130’s exact 13.0.48.
2. On ARM, the original script still requests `trt_decoder`; `tensorrt-cu12` is unsupported on ARM, giving pip hard-fails. Also, for the ARM CUDA13 path, TRT never installed (x86-only gate), but `trt_decoder` is still requested - we can install TRT and enable the extra here.
