### PR TITLE
Update buildx setup for NVIDIA runners

### DIFF
--- a/.github/workflows/build_qa_wheel_test.yaml
+++ b/.github/workflows/build_qa_wheel_test.yaml
@@ -5,7 +5,7 @@ on:
     inputs:
       wheels_repo:
         type: string
-        description: Retrieve assets from a draft release from this repo (e.g. NVIDIA/cudaqx)
+        description: Retrieve assets from a GitHub Actions run in this repo (e.g. NVIDIA/cudaqx)
         required: true
       wheels_run_id:
         type: string
@@ -46,6 +46,7 @@ jobs:
           driver-opts: |
             network=host
             image=moby/buildkit:v0.19.0
+          buildkitd-config: /etc/buildkit/buildkitd.toml # hardcoded for NVIDIA runner
 
       - name: Log in to GitHub CR
         uses: docker/login-action@v3


### PR DESCRIPTION
<!--
Thanks for contributing to CUDA-Q Libraries!

Please read the full Pull Request Guidelines in Contributing.md:
https://github.com/NVIDIA/cudaqx/blob/main/Contributing.md#pull-request-guidelines
-->

## Description

Update the QA wheel workflow's buildx setup to use the NVIDIA runner's preconfigured BuildKit config file to reduce the chance of 429 errors from Docker.

<!-- What does this PR change, and why? Link related issues. -->

## Runtime / performance impact

<!--
If this change affects performance, paste benchmark numbers here.
Otherwise write "N/A".
-->

## Self-review checklist

Please confirm each item before requesting review. Check `[x]` or strike
through and explain.

### Before requesting review
- [x] I reviewed my own full diff in GitHub or my editor.
- [x] PR is in Draft if it is not yet ready for review.
- [x] Temporary / debugging changes have been removed.
- [x] Local test logs reviewed; no unexplained warnings or errors.
- [x] CI logs reviewed; no unexplained warnings or errors.
- [x] Full CI has been run.

### Scope and size
- [x] PR is under ~1000 lines, or an exception is justified in the description.
- [x] Refactoring-only changes are isolated in their own PR(s).
- [x] No existing tests were disabled or modified just to make this PR pass
      (if so, an issue has been raised).

### Tests
- [x] New functionality has new tests.
- [x] Tests fail if the new functionality is broken (including crashes), not
      just when it is missing.
- [x] Negative tests added where exceptions are expected.
- [x] Truth data added where simple `EXPECT_*` / `assert` checks are
      insufficient for algorithmic correctness.
- [x] CI runtime impact considered; team notified if significant.

### Documentation
- [x] Public-facing APIs have Doxygen docs.
- [x] User-visible behavior changes have public docs, or a follow-up is
      tracked.

### Code style
- [x] Naming follows the existing convention (`snake_case` vs `camelCase`) for
      the area being modified.

### Dependencies
- [x] No new third-party dependencies, **or** the team has been notified and
      OSRB tickets filed.
