### PR TITLE
test: add verified HSB playback loop regression

### DIFF
--- a/.cudaq_version
+++ b/.cudaq_version
@@ -1,6 +1,6 @@
 {
   "cudaq": {
     "repository": "NVIDIA/cuda-quantum",
-    "ref": "ce8e04348dd1d39852fa92cc3ac5d53f7f497959"
+    "ref": "4ebc95cc1e216a278f53feaf0b5686ca8e6db57a"
   }
 }

--- a/.cudaq_version
+++ b/.cudaq_version
@@ -1,6 +1,6 @@
 {
   "cudaq": {
     "repository": "NVIDIA/cuda-quantum",
-    "ref": "f8af7d2c8e3a30f8f916390fca8db47c3ff37cb2"
+    "ref": "ce8e04348dd1d39852fa92cc3ac5d53f7f497959"
   }
 }

--- a/.cudaq_version
+++ b/.cudaq_version
@@ -1,6 +1,6 @@
 {
   "cudaq": {
     "repository": "NVIDIA/cuda-quantum",
-    "ref": "4ebc95cc1e216a278f53feaf0b5686ca8e6db57a"
+    "ref": "554e54283edbb65da90c02020af83e84f099e8dd"
   }
 }

--- a/libs/qec/unittests/utils/CMakeLists.txt
+++ b/libs/qec/unittests/utils/CMakeLists.txt
@@ -173,7 +173,9 @@ add_executable(hsb_fpga_syndrome_playback
 target_include_directories(hsb_fpga_syndrome_playback
   PRIVATE "${HOLOSCAN_SENSOR_BRIDGE_SOURCE_DIR}/src"
   # cudaq/qec/realtime/decoder_rpc_wire_format.h (per-round RPC wire format).
-  PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/../../include")
+  PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/../../include"
+  # decoding_config.h includes the CUDA-QX heterogeneous map API.
+  PRIVATE "${CMAKE_SOURCE_DIR}/libs/core/include")
 
 if (DEFINED CUDAQ_INCLUDE_DIR AND CUDAQ_INCLUDE_DIR)
   target_include_directories(hsb_fpga_syndrome_playback

--- a/libs/qec/unittests/utils/hsb_fpga_decoding_server_test.sh
+++ b/libs/qec/unittests/utils/hsb_fpga_decoding_server_test.sh
@@ -1470,9 +1470,29 @@ finish_loop_run() {
         _err "Decoding server exited with an error"
         return 1
     fi
-    if [[ -n "$emulator_pid" ]] && ! wait "$emulator_pid"; then
-        _err "FPGA emulator exited with an error"
-        return 1
+    # The server writes through a background tee process substitution. Wait for
+    # its final CPU decoder statistics to reach the log before parsing them.
+    # This is post-shutdown test bookkeeping, outside the playback and decode
+    # paths.
+    if [[ "$TRANSPORT" == "cpu_roce" ]]; then
+        wait_for_pattern "$server_log" \
+            '^QEC_DECODING_SERVER_DECODER_STATS id=0 ' 5 >/dev/null || {
+            _err "Decoding server statistics were not flushed after shutdown"
+            return 1
+        }
+    fi
+    if [[ -n "$emulator_pid" ]]; then
+        if ! wait "$emulator_pid"; then
+            _err "FPGA emulator exited with an error"
+            return 1
+        fi
+        # The emulator also writes through a tee process substitution. Its
+        # final marker follows the results block parsed below, so waiting for
+        # it makes that parse deterministic.
+        wait_for_pattern "$emulator_log" '^\*\*\* EMULATOR: ' 5 >/dev/null || {
+            _err "FPGA emulator results were not flushed after exit"
+            return 1
+        }
     fi
     verify_loop_statistics "$server_log" "$emulator_log"
 }

--- a/libs/qec/unittests/utils/hsb_fpga_decoding_server_test.sh
+++ b/libs/qec/unittests/utils/hsb_fpga_decoding_server_test.sh
@@ -220,7 +220,9 @@ Network options:
   --mtu N                MTU size (default: 4096)
 
 Run options:
-  --timeout N            Server timeout in seconds (default: 60)
+  --timeout N            Server watchdog grace in seconds (default: 60). In a
+                         bounded loop run, the requested loop duration is
+                         added so preflight does not consume loop time.
   --no-verify            Skip correction verification
   --loop-seconds N       Continuously replay the loaded BRAM windows for N
                          seconds after one finite ILA verification pass.
@@ -292,6 +294,11 @@ while [[ $# -gt 0 ]]; do
     shift
 done
 
+if [[ -n "$MIN_DECODES" && -z "$LOOP_SECONDS" ]]; then
+    echo "ERROR: --min-decodes requires --loop-seconds" >&2
+    exit 1
+fi
+
 if [[ -n "$LOOP_SECONDS" ]]; then
     if ! [[ "$LOOP_SECONDS" =~ ^[1-9][0-9]*$ ]]; then
         echo "ERROR: --loop-seconds must be a positive integer" >&2
@@ -305,8 +312,12 @@ if [[ -n "$LOOP_SECONDS" ]]; then
         echo "ERROR: --min-decodes must be a positive integer" >&2
         exit 1
     fi
-    if ! [[ "$TIMEOUT" =~ ^[1-9][0-9]*$ ]] || (( TIMEOUT <= LOOP_SECONDS )); then
-        echo "ERROR: --timeout must be greater than --loop-seconds" >&2
+    if ! [[ "$TIMEOUT" =~ ^[1-9][0-9]*$ ]]; then
+        echo "ERROR: --timeout must be a positive integer" >&2
+        exit 1
+    fi
+    if ! $VERIFY; then
+        echo "ERROR: --loop-seconds requires ILA verification; remove --no-verify" >&2
         exit 1
     fi
     if ! $EMULATE; then
@@ -1200,8 +1211,13 @@ PY
 start_server() {
     local peer_ip="$1" remote_qp="$2" server_log="$3"
     local server_stats_env=()
+    local server_timeout="$TIMEOUT"
     if [[ -n "$LOOP_SECONDS" ]]; then
         server_stats_env+=(QEC_DECODING_SERVER_STATS=1)
+        # TIMEOUT is the watchdog grace for setup and orderly shutdown.  The
+        # measured replay interval is added separately so BRAM programming and
+        # the finite ILA pass cannot shorten the requested loop duration.
+        server_timeout=$((TIMEOUT + LOOP_SECONDS))
     fi
 
     _log "Starting decoding server (decoder=$DECODER, transport=$TRANSPORT," \
@@ -1231,7 +1247,7 @@ start_server() {
         LD_LIBRARY_PATH="${server_ld_path}:${LD_LIBRARY_PATH:-}" \
         "$SERVER_BIN" \
             --config="$CONFIG_FILE" \
-            --timeout="$TIMEOUT" \
+            --timeout="$server_timeout" \
             > >(tee "$server_log") 2>&1 &
         # The DeviceGraphTransceiver prints the QP/RKey/Buffer handshake during
         # server construction, BEFORE this READY sentinel -- so waiting for
@@ -1250,7 +1266,7 @@ start_server() {
             --num-slots="$NUM_SLOTS" \
             --slot-size="$PAGE_SIZE" \
             --frame-size="$FRAME_SIZE" \
-            --timeout="$TIMEOUT" \
+            --timeout="$server_timeout" \
             > >(tee "$server_log") 2>&1 &
         ready_pattern="Bridge Ready"
     fi
@@ -1353,48 +1369,30 @@ run_playback() {
 
 verify_loop_statistics() {
     local server_log="$1" emulator_log="${2:-}"
-    local stats_line
-    stats_line=$(grep '^QEC_DECODING_SERVER_DECODER_STATS id=0 ' "$server_log" | tail -n 1 || true)
-    if [[ -z "$stats_line" ]]; then
-        _err "Loop run finished without decoder statistics"
-        return 1
-    fi
-
-    local decodes errors verification_corrections loop_decodes
-    decodes=$(sed -n 's/.* decodes=\([0-9][0-9]*\).*/\1/p' <<<"$stats_line")
-    errors=$(sed -n 's/.* errors=\([0-9][0-9]*\).*/\1/p' <<<"$stats_line")
-    if [[ -z "$decodes" || -z "$errors" ]]; then
-        _err "Could not parse decoder statistics: $stats_line"
-        return 1
-    fi
-
     if [[ -z "$PLAYBACK_LOG" ]] || ! grep -q '^  RESULT: PASS$' "$PLAYBACK_LOG"; then
         _err "Finite ILA verification did not report RESULT: PASS"
         return 1
     fi
 
-    verification_corrections=$(sed -n \
-        's/^  get_corrections frames: \([0-9][0-9]*\)$/\1/p' \
-        "$PLAYBACK_LOG" | tail -n 1)
-    if [[ -z "$verification_corrections" ]]; then
-        _err "Could not parse finite ILA correction count"
-        return 1
-    fi
-    if (( decodes < verification_corrections )); then
-        _err "Decoding-server count is below the finite ILA correction count"
-        return 1
-    fi
-    loop_decodes=$((decodes - verification_corrections))
-
-    local loop_frames loop_responses
+    local loop_frames loop_responses loop_measurements response_failures
     loop_frames=$(sed -n 's/^  Playback frames: *\([0-9][0-9]*\)$/\1/p' "$PLAYBACK_LOG" | tail -n 1)
     loop_responses=$(sed -n 's/^  Correction responses: *\([0-9][0-9]*\)$/\1/p' "$PLAYBACK_LOG" | tail -n 1)
-    if [[ -z "$loop_frames" || -z "$loop_responses" ]]; then
+    loop_measurements=$(sed -n 's/^  Completed measurements: *\([0-9][0-9]*\)$/\1/p' "$PLAYBACK_LOG" | tail -n 1)
+    response_failures=$(sed -n 's/^  RPC status failures: *\([0-9][0-9]*\)$/\1/p' "$PLAYBACK_LOG" | tail -n 1)
+    if [[ -z "$loop_frames" || -z "$loop_responses" || -z "$loop_measurements" || -z "$response_failures" ]]; then
         _err "Could not parse loop-only playback statistics"
         return 1
     fi
     if (( loop_responses != loop_frames )); then
         _err "Loop transport failed: frames=$loop_frames responses=$loop_responses"
+        return 1
+    fi
+    if (( loop_measurements < MIN_DECODES )); then
+        _err "Playback acceptance failed: measurements=$loop_measurements required=$MIN_DECODES"
+        return 1
+    fi
+    if (( response_failures != 0 )); then
+        _err "Loop RPC status failures: $response_failures"
         return 1
     fi
 
@@ -1414,9 +1412,40 @@ verify_loop_statistics() {
         fi
     fi
 
-    if (( loop_decodes < MIN_DECODES || errors != 0 )); then
-        _err "Decoding-server acceptance failed: loop_decodes=$loop_decodes errors=$errors required=$MIN_DECODES"
-        return 1
+    local server_result
+    if [[ "$TRANSPORT" == "cpu_roce" ]]; then
+        local stats_line decodes errors verification_corrections loop_decodes
+        stats_line=$(grep '^QEC_DECODING_SERVER_DECODER_STATS id=0 ' "$server_log" | tail -n 1 || true)
+        if [[ -z "$stats_line" ]]; then
+            _err "Loop run finished without decoder statistics"
+            return 1
+        fi
+        decodes=$(sed -n 's/.* decodes=\([0-9][0-9]*\).*/\1/p' <<<"$stats_line")
+        errors=$(sed -n 's/.* errors=\([0-9][0-9]*\).*/\1/p' <<<"$stats_line")
+        verification_corrections=$(sed -n \
+            's/^  get_corrections frames: \([0-9][0-9]*\)$/\1/p' \
+            "$PLAYBACK_LOG" | tail -n 1)
+        if [[ -z "$decodes" || -z "$errors" || -z "$verification_corrections" ]]; then
+            _err "Could not parse CPU decoding-server statistics"
+            return 1
+        fi
+        if (( decodes < verification_corrections )); then
+            _err "Decoding-server count is below the finite ILA correction count"
+            return 1
+        fi
+        loop_decodes=$((decodes - verification_corrections))
+        if (( loop_decodes < MIN_DECODES || errors != 0 )); then
+            _err "Decoding-server acceptance failed: loop_decodes=$loop_decodes errors=$errors required=$MIN_DECODES"
+            return 1
+        fi
+        server_result="PASS ($loop_decodes loop measurements, 0 errors)"
+    else
+        # Device-graph execution bypasses DecodingSession::enqueue_core(), so
+        # its host decode_count is not a completion metric. A complete
+        # loop-only RPC response sequence with zero status failures is the
+        # end-to-end completion signal; the playback tool derives measurements
+        # from that sequence.
+        server_result="PASS (device-graph completion verified by successful RPC responses)"
     fi
 
     _banner "HSB REGRESSION RESULT"
@@ -1424,7 +1453,7 @@ verify_loop_statistics() {
     if [[ -n "$emulator_log" ]]; then
         _info "Loop transport:           PASS ($loop_responses RPC frames, 0 errors, 0 timeouts)"
     fi
-    _info "Decoding server:          PASS ($loop_decodes loop measurements, 0 errors)"
+    _info "Decoding server:          $server_result"
     _info "Required measurements:    $MIN_DECODES"
     _info "RESULT: PASS"
 }
@@ -1433,7 +1462,10 @@ finish_loop_run() {
     local server_log="$1" emulator_log="${2:-}" emulator_pid="${3:-}"
     [[ -n "$LOOP_SECONDS" ]] || return 0
 
-    _log "Waiting for decoding-server statistics"
+    _log "Stopping decoding server after bounded loop playback"
+    if kill -0 "$SERVER_PID" 2>/dev/null; then
+        kill -TERM "$SERVER_PID" 2>/dev/null || true
+    fi
     if ! wait "$SERVER_PID"; then
         _err "Decoding server exited with an error"
         return 1

--- a/libs/qec/unittests/utils/hsb_fpga_decoding_server_test.sh
+++ b/libs/qec/unittests/utils/hsb_fpga_decoding_server_test.sh
@@ -69,6 +69,8 @@ DO_BUILD=false
 DO_SETUP_NETWORK=false
 DO_RUN=true
 VERIFY=true
+LOOP_SECONDS=""
+MIN_DECODES=""
 
 # Directory defaults.  HSB_DIR is used as-is (already on the correct branch);
 # CUDA_QUANTUM_DIR should be checked out at the ref in CUDAQX_DIR/.cudaq_version
@@ -220,6 +222,9 @@ Network options:
 Run options:
   --timeout N            Server timeout in seconds (default: 60)
   --no-verify            Skip correction verification
+  --loop-seconds N       Continuously replay the loaded BRAM windows for N
+                         seconds after one finite ILA verification pass.
+  --min-decodes N        Require at least N server decodes with --loop-seconds
   --num-shots N          Limit number of shots
   --page-size N          Ring buffer slot size in bytes (default: 384)
   --frame-size N         Server TX SGE bytes, cpu_roce only (default: 64;
@@ -270,6 +275,8 @@ while [[ $# -gt 0 ]]; do
         --fpga-ip)          FPGA_IP="$2"; shift ;;
         --mtu)              MTU="$2"; shift ;;
         --timeout)          TIMEOUT="$2"; shift ;;
+        --loop-seconds)     LOOP_SECONDS="$2"; shift ;;
+        --min-decodes)      MIN_DECODES="$2"; shift ;;
         --num-shots)        NUM_SHOTS="$2"; shift ;;
         --page-size)        PAGE_SIZE="$2"; shift ;;
         --frame-size)       FRAME_SIZE="$2"; shift ;;
@@ -284,6 +291,29 @@ while [[ $# -gt 0 ]]; do
     esac
     shift
 done
+
+if [[ -n "$LOOP_SECONDS" ]]; then
+    if ! [[ "$LOOP_SECONDS" =~ ^[1-9][0-9]*$ ]]; then
+        echo "ERROR: --loop-seconds must be a positive integer" >&2
+        exit 1
+    fi
+    if [[ -z "$MIN_DECODES" ]]; then
+        echo "ERROR: --loop-seconds requires --min-decodes" >&2
+        exit 1
+    fi
+    if ! [[ "$MIN_DECODES" =~ ^[1-9][0-9]*$ ]]; then
+        echo "ERROR: --min-decodes must be a positive integer" >&2
+        exit 1
+    fi
+    if ! [[ "$TIMEOUT" =~ ^[1-9][0-9]*$ ]] || (( TIMEOUT <= LOOP_SECONDS )); then
+        echo "ERROR: --timeout must be greater than --loop-seconds" >&2
+        exit 1
+    fi
+    if ! $EMULATE; then
+        echo "ERROR: --loop-seconds is supported only with --emulate; it requires software-emulator loop statistics" >&2
+        exit 1
+    fi
+fi
 
 # Resolve the server-side NIC IP by mode: the emulate loop lives on
 # 10.0.0.0/24, the real FPGA on 192.168.0.0/24.  A bridge IP outside the
@@ -402,6 +432,7 @@ _banner() {
 
 PIDS_TO_KILL=()
 TEMP_FILES=()
+PLAYBACK_LOG=""
 
 cleanup() {
     local pid
@@ -1168,6 +1199,10 @@ PY
 
 start_server() {
     local peer_ip="$1" remote_qp="$2" server_log="$3"
+    local server_stats_env=()
+    if [[ -n "$LOOP_SECONDS" ]]; then
+        server_stats_env+=(QEC_DECODING_SERVER_STATS=1)
+    fi
 
     _log "Starting decoding server (decoder=$DECODER, transport=$TRANSPORT," \
          "remote-qp=$remote_qp)"
@@ -1192,7 +1227,7 @@ start_server() {
         # Eager module loading avoids lazy-load stalls inside the persistent
         # scheduler (same as the old bridge launcher).
         prepare_gpu_roce_config "$peer_ip" "$remote_qp" || return 1
-        CUDA_MODULE_LOADING=EAGER \
+        env CUDA_MODULE_LOADING=EAGER "${server_stats_env[@]}" \
         LD_LIBRARY_PATH="${server_ld_path}:${LD_LIBRARY_PATH:-}" \
         "$SERVER_BIN" \
             --config="$CONFIG_FILE" \
@@ -1203,6 +1238,7 @@ start_server() {
         # READY guarantees the three lines are scrapeable.
         ready_pattern="QEC_DECODING_SERVER_READY device_graph"
     else
+        env "${server_stats_env[@]}" \
         LD_LIBRARY_PATH="${server_ld_path}:${LD_LIBRARY_PATH:-}" \
         "$SERVER_BIN" \
             --config="$CONFIG_FILE" \
@@ -1291,6 +1327,12 @@ run_playback() {
     if $VERIFY; then
         playback_args+=(--verify)
     fi
+    if [[ -n "$LOOP_SECONDS" ]]; then
+        playback_args+=(
+            --loop-seconds "$LOOP_SECONDS"
+            --min-loop-shots "$MIN_DECODES"
+        )
+    fi
     if [[ -n "$NUM_SHOTS" ]]; then
         playback_args+=(--num-shots "$NUM_SHOTS")
     fi
@@ -1298,9 +1340,109 @@ run_playback() {
         playback_args+=(--spacing "$SPACING")
     fi
 
-    local playback_rc=0
-    "$PLAYBACK_BIN" "${playback_args[@]}" || playback_rc=$?
-    return $playback_rc
+    PLAYBACK_LOG=$(mktemp /tmp/decoding_server_playback.XXXXXX.log)
+    TEMP_FILES+=("$PLAYBACK_LOG")
+
+    local playback_rc
+    set +e
+    "$PLAYBACK_BIN" "${playback_args[@]}" 2>&1 | tee "$PLAYBACK_LOG"
+    playback_rc=${PIPESTATUS[0]}
+    set -e
+    return "$playback_rc"
+}
+
+verify_loop_statistics() {
+    local server_log="$1" emulator_log="${2:-}"
+    local stats_line
+    stats_line=$(grep '^QEC_DECODING_SERVER_DECODER_STATS id=0 ' "$server_log" | tail -n 1 || true)
+    if [[ -z "$stats_line" ]]; then
+        _err "Loop run finished without decoder statistics"
+        return 1
+    fi
+
+    local decodes errors verification_corrections loop_decodes
+    decodes=$(sed -n 's/.* decodes=\([0-9][0-9]*\).*/\1/p' <<<"$stats_line")
+    errors=$(sed -n 's/.* errors=\([0-9][0-9]*\).*/\1/p' <<<"$stats_line")
+    if [[ -z "$decodes" || -z "$errors" ]]; then
+        _err "Could not parse decoder statistics: $stats_line"
+        return 1
+    fi
+
+    if [[ -z "$PLAYBACK_LOG" ]] || ! grep -q '^  RESULT: PASS$' "$PLAYBACK_LOG"; then
+        _err "Finite ILA verification did not report RESULT: PASS"
+        return 1
+    fi
+
+    verification_corrections=$(sed -n \
+        's/^  get_corrections frames: \([0-9][0-9]*\)$/\1/p' \
+        "$PLAYBACK_LOG" | tail -n 1)
+    if [[ -z "$verification_corrections" ]]; then
+        _err "Could not parse finite ILA correction count"
+        return 1
+    fi
+    if (( decodes < verification_corrections )); then
+        _err "Decoding-server count is below the finite ILA correction count"
+        return 1
+    fi
+    loop_decodes=$((decodes - verification_corrections))
+
+    local loop_frames loop_responses
+    loop_frames=$(sed -n 's/^  Playback frames: *\([0-9][0-9]*\)$/\1/p' "$PLAYBACK_LOG" | tail -n 1)
+    loop_responses=$(sed -n 's/^  Correction responses: *\([0-9][0-9]*\)$/\1/p' "$PLAYBACK_LOG" | tail -n 1)
+    if [[ -z "$loop_frames" || -z "$loop_responses" ]]; then
+        _err "Could not parse loop-only playback statistics"
+        return 1
+    fi
+    if (( loop_responses != loop_frames )); then
+        _err "Loop transport failed: frames=$loop_frames responses=$loop_responses"
+        return 1
+    fi
+
+    local windows responses send_errors timeouts
+    if [[ -n "$emulator_log" ]]; then
+        windows=$(sed -n 's/^  Windows sent: \([0-9][0-9]*\)$/\1/p' "$emulator_log" | tail -n 1)
+        responses=$(sed -n 's/^  Responses received: \([0-9][0-9]*\)$/\1/p' "$emulator_log" | tail -n 1)
+        send_errors=$(sed -n 's/^  Send errors: \([0-9][0-9]*\)$/\1/p' "$emulator_log" | tail -n 1)
+        timeouts=$(sed -n 's/^  Timeouts: \([0-9][0-9]*\)$/\1/p' "$emulator_log" | tail -n 1)
+        if [[ -z "$windows" || -z "$responses" || -z "$send_errors" || -z "$timeouts" ]]; then
+            _err "Could not parse emulator loop statistics"
+            return 1
+        fi
+        if (( send_errors != 0 || timeouts != 0 || responses != windows )); then
+            _err "Emulator loop transport failed: windows=$windows responses=$responses errors=$send_errors timeouts=$timeouts"
+            return 1
+        fi
+    fi
+
+    if (( loop_decodes < MIN_DECODES || errors != 0 )); then
+        _err "Decoding-server acceptance failed: loop_decodes=$loop_decodes errors=$errors required=$MIN_DECODES"
+        return 1
+    fi
+
+    _banner "HSB REGRESSION RESULT"
+    _info "ILA preflight:            PASS"
+    if [[ -n "$emulator_log" ]]; then
+        _info "Loop transport:           PASS ($loop_responses RPC frames, 0 errors, 0 timeouts)"
+    fi
+    _info "Decoding server:          PASS ($loop_decodes loop measurements, 0 errors)"
+    _info "Required measurements:    $MIN_DECODES"
+    _info "RESULT: PASS"
+}
+
+finish_loop_run() {
+    local server_log="$1" emulator_log="${2:-}" emulator_pid="${3:-}"
+    [[ -n "$LOOP_SECONDS" ]] || return 0
+
+    _log "Waiting for decoding-server statistics"
+    if ! wait "$SERVER_PID"; then
+        _err "Decoding server exited with an error"
+        return 1
+    fi
+    if [[ -n "$emulator_pid" ]] && ! wait "$emulator_pid"; then
+        _err "FPGA emulator exited with an error"
+        return 1
+    fi
+    verify_loop_statistics "$server_log" "$emulator_log"
 }
 
 # ============================================================================
@@ -1343,7 +1485,8 @@ run_emulated() {
     start_server "$EMULATOR_IP" "$emu_qp" "$server_log" || return 1
 
     # ---- 3. Start playback tool ----
-    run_playback "$EMULATOR_IP" --control-port "$CONTROL_PORT"
+    run_playback "$EMULATOR_IP" --control-port "$CONTROL_PORT" || return 1
+    finish_loop_run "$server_log" "$emu_log" "$emu_pid"
 }
 
 # ============================================================================
@@ -1361,7 +1504,8 @@ run_fpga() {
     start_server "$FPGA_IP" "0x2" "$server_log" || return 1
 
     # ---- 2. Start playback tool (BOOTP enumeration; no control port) ----
-    run_playback "$FPGA_IP"
+    run_playback "$FPGA_IP" || return 1
+    finish_loop_run "$server_log"
 }
 
 # ============================================================================

--- a/libs/qec/unittests/utils/hsb_fpga_syndrome_playback.cpp
+++ b/libs/qec/unittests/utils/hsb_fpga_syndrome_playback.cpp
@@ -10,6 +10,7 @@
 
 #include <algorithm>
 #include <chrono>
+#include <csignal>
 #include <cstdint>
 #include <cstring>
 #include <fstream>
@@ -49,9 +50,26 @@ constexpr std::uint32_t PLAYER_ENABLE_OFFSET = 0x0004;
 constexpr std::uint32_t RAM_NUM = 16;
 constexpr std::uint32_t RAM_DEPTH = 512;
 
-constexpr std::uint32_t PLAYER_ENABLE =
+constexpr std::uint32_t PLAYER_ENABLE_SINGLE_PASS =
     0x0000'000D; // enable + single-pass + ptp_bram_ena
+// Matches the HSB GPU-RoCE loopback example's continuous-player setting.
+constexpr std::uint32_t PLAYER_ENABLE_LOOP = 0x0000'0003;
 constexpr std::uint32_t PLAYER_DISABLE = 0x0000'0000;
+// LOOP_STATS register map — must match hsb_fpga_emulator.cpp in the
+// cuda-quantum repository.
+constexpr std::uint32_t LOOP_STATS_MAGIC = 0xE000'0000;
+constexpr std::uint32_t LOOP_STATS_STATE = 0xE000'0004;
+constexpr std::uint32_t LOOP_STATS_WINDOWS_LO = 0xE000'0008;
+constexpr std::uint32_t LOOP_STATS_WINDOWS_HI = 0xE000'000C;
+constexpr std::uint32_t LOOP_STATS_RESPONSES_LO = 0xE000'0010;
+constexpr std::uint32_t LOOP_STATS_RESPONSES_HI = 0xE000'0014;
+constexpr std::uint32_t LOOP_STATS_ERRORS = 0xE000'0018;
+constexpr std::uint32_t LOOP_STATS_TIMEOUTS = 0xE000'001C;
+constexpr std::uint32_t LOOP_STATS_ACK = 0xE000'0020;
+constexpr std::uint32_t LOOP_STATS_MAGIC_VALUE = 0x4853'4245;
+constexpr std::uint32_t LOOP_STATS_COMPLETE = 2;
+constexpr int kLoopStatsMaxRetries = 100;
+constexpr std::chrono::milliseconds kLoopStatsPollInterval{50};
 
 // Sensor TX streaming threshold register. The Host→FPGA path buffers
 // incoming data until this byte threshold is met before streaming to the
@@ -68,6 +86,10 @@ constexpr std::uint32_t RF_SOC_TIMER_SCALE = 322;
 
 constexpr std::uint32_t MOCK_DECODE_FUNCTION_ID =
     cudaq::realtime::fnv1a_hash("mock_decode");
+
+volatile std::sig_atomic_t loop_stop_requested = 0;
+
+extern "C" void request_loop_stop(int) { loop_stop_requested = 1; }
 
 // ============================================================================
 // ILA Capture Block Constants — from spec_sif_tx.json
@@ -382,6 +404,9 @@ struct Options {
       function_name; // RPC function name (overrides default mock_decode)
   std::optional<std::size_t> num_shots;
   bool verify = false;
+  bool loop = false;
+  std::optional<std::uint32_t> loop_seconds;
+  std::optional<std::size_t> min_loop_shots;
 
   // Per-round mode (device-graph scheduler): emit N enqueue_syndromes frames
   // (one per round) followed by 1 get_corrections frame per shot, instead of a
@@ -432,6 +457,13 @@ void print_usage(const char *argv0) {
          "                        frames-per-shot x spacing)\n"
       << "  --verify              Capture and verify correction responses "
          "via ILA\n"
+      << "  --loop                Continuously replay the loaded BRAM windows "
+         "until Ctrl-C; --verify first checks one finite pass\n"
+      << "  --loop-seconds <n>    Replay continuously for n seconds, then "
+         "disable the player cleanly; requires --control-port\n"
+      << "                        and --verify first checks one pass\n"
+      << "  --min-loop-shots <n> Require at least n completed decoding "
+         "measurements in emulator loop mode\n"
       << "  --per-round           Per-round protocol (device-graph scheduler): "
          "send\n"
       << "                        N enqueue_syndromes frames (one per "
@@ -479,6 +511,17 @@ Options parse_args(int argc, char **argv) {
           static_cast<std::uint32_t>(std::stoul(argv[++i], nullptr, 0));
     } else if (arg == "--verify") {
       options.verify = true;
+    } else if (arg == "--loop") {
+      options.loop = true;
+    } else if (arg == "--loop-seconds" && i + 1 < argc) {
+      const auto seconds = std::stoul(argv[++i], nullptr, 0);
+      if (seconds == 0 || seconds > std::numeric_limits<std::uint32_t>::max())
+        throw std::invalid_argument(
+            "--loop-seconds must be a positive integer");
+      options.loop = true;
+      options.loop_seconds = static_cast<std::uint32_t>(seconds);
+    } else if (arg == "--min-loop-shots" && i + 1 < argc) {
+      options.min_loop_shots = std::stoull(argv[++i]);
     } else if (arg == "--per-round") {
       options.per_round = true;
     } else if (arg == "--qp-number" && i + 1 < argc) {
@@ -1026,6 +1069,177 @@ VerifyResult verify_captured_responses(
   return result;
 }
 
+bool verification_passed(const VerifyResult &result,
+                         std::size_t expected_shots) {
+  return result.correction_errors == 0 && result.header_errors == 0 &&
+         result.responses_matched != 0 &&
+         result.unique_shots_verified >= expected_shots;
+}
+
+struct LoopStats {
+  std::uint64_t frames = 0;
+  std::uint64_t responses = 0;
+  std::uint32_t errors = 0;
+  std::uint32_t timeouts = 0;
+};
+
+struct MeasurementRunSummary {
+  std::uint64_t playback_frames = 0;
+  std::uint64_t response_frames = 0;
+  std::uint64_t completed_measurements = 0;
+  bool all_responses_received = false;
+  std::uint32_t transport_errors = 0;
+  std::uint32_t transport_timeouts = 0;
+  std::optional<std::size_t> requested_measurements;
+};
+
+std::uint64_t read_u64(hololink::Hololink &hsb, std::uint32_t lo,
+                       std::uint32_t hi) {
+  return static_cast<std::uint64_t>(hsb.read_uint32(lo)) |
+         (static_cast<std::uint64_t>(hsb.read_uint32(hi)) << 32);
+}
+
+std::optional<LoopStats> read_loop_stats(hololink::Hololink &hsb) {
+  for (int i = 0; i < kLoopStatsMaxRetries; ++i) {
+    if (hsb.read_uint32(LOOP_STATS_MAGIC) == LOOP_STATS_MAGIC_VALUE &&
+        hsb.read_uint32(LOOP_STATS_STATE) == LOOP_STATS_COMPLETE) {
+      const LoopStats stats{
+          read_u64(hsb, LOOP_STATS_WINDOWS_LO, LOOP_STATS_WINDOWS_HI),
+          read_u64(hsb, LOOP_STATS_RESPONSES_LO, LOOP_STATS_RESPONSES_HI),
+          hsb.read_uint32(LOOP_STATS_ERRORS),
+          hsb.read_uint32(LOOP_STATS_TIMEOUTS)};
+      // The software emulator keeps its control-plane session alive until the
+      // client has consumed this final snapshot. This acknowledgement is
+      // outside the playback/RDMA hot path.
+      if (!hsb.write_uint32(LOOP_STATS_ACK, LOOP_STATS_MAGIC_VALUE))
+        throw std::runtime_error("Failed to acknowledge loop statistics");
+      return stats;
+    }
+    std::this_thread::sleep_for(kLoopStatsPollInterval);
+  }
+  return std::nullopt;
+}
+
+MeasurementRunSummary make_measurement_run_summary(
+    const LoopStats &stats, std::size_t frames_per_measurement,
+    std::optional<std::size_t> requested_measurements) {
+  return MeasurementRunSummary{
+      .playback_frames = stats.frames,
+      .response_frames = stats.responses,
+      .completed_measurements = stats.responses / frames_per_measurement,
+      .all_responses_received = stats.responses == stats.frames,
+      .transport_errors = stats.errors,
+      .transport_timeouts = stats.timeouts,
+      .requested_measurements = requested_measurements,
+  };
+}
+
+bool measurement_run_passed(const MeasurementRunSummary &summary) {
+  return summary.all_responses_received && summary.transport_errors == 0 &&
+         summary.transport_timeouts == 0 &&
+         (!summary.requested_measurements ||
+          summary.completed_measurements >= *summary.requested_measurements);
+}
+
+void print_verification_summary(const VerifyResult &result,
+                                std::uint32_t actual_samples,
+                                std::size_t expected_shots, bool per_round,
+                                const std::optional<MeasurementRunSummary>
+                                    &measurement_run = std::nullopt) {
+  const std::size_t corrections_returned =
+      result.rpc_responses - result.enqueue_acks;
+  std::cout << "\n=== Verification Summary ===\n"
+            << "  ILA samples captured:   " << actual_samples << "\n"
+            << "  tvalid=0 (idle):        " << result.tvalid_zero << "\n"
+            << "  ILA RPC response frames: " << result.rpc_responses << "\n";
+  if (per_round)
+    std::cout << "  Enqueue ACKs:           " << result.enqueue_acks << "\n"
+              << "  get_corrections frames: " << corrections_returned << "\n";
+  std::cout << "  Non-RPC frames:         " << result.non_rpc_frames << "\n"
+            << "  Unique shots verified:  " << result.unique_shots_verified
+            << "\n"
+            << "  Corrections matched:    " << result.responses_matched << "\n"
+            << "  Header errors:          " << result.header_errors << "\n"
+            << "  Correction errors:      " << result.correction_errors << "\n"
+            << "  Expected shots:         " << expected_shots << "\n";
+  if (measurement_run) {
+    std::cout << "  Completed measurements: "
+              << measurement_run->completed_measurements << "\n"
+              << "  Playback frames:        "
+              << measurement_run->playback_frames << "\n"
+              << "  Correction responses:   "
+              << measurement_run->response_frames << "\n"
+              << "  Transport errors:       "
+              << measurement_run->transport_errors << "\n"
+              << "  Transport timeouts:     "
+              << measurement_run->transport_timeouts << "\n";
+  }
+  if (!result.latency_samples.empty()) {
+    int64_t lat_min = std::numeric_limits<int64_t>::max();
+    int64_t lat_max = std::numeric_limits<int64_t>::min();
+    int64_t lat_sum = 0;
+    for (const auto &sample : result.latency_samples) {
+      lat_sum += sample.delta_ns;
+      lat_min = std::min(lat_min, sample.delta_ns);
+      lat_max = std::max(lat_max, sample.delta_ns);
+    }
+    const double lat_avg =
+        static_cast<double>(lat_sum) / result.latency_samples.size();
+    for (std::size_t index = 0;
+         index < 5 && index < result.latency_samples.size(); ++index) {
+      const auto &sample = result.latency_samples[index];
+      std::cout << "  rid " << std::setw(3) << sample.request_id << " (shot "
+                << sample.shot << " local " << sample.local << " "
+                << (sample.is_corr ? "get_corrections" : "enqueue")
+                << "): send={sec=" << sample.send_sec
+                << ", nsec=" << sample.send_nsec
+                << "} recv={sec=" << sample.recv_sec
+                << ", nsec=" << sample.recv_nsec
+                << "} delta=" << sample.delta_ns << " ns\n";
+    }
+    std::cout << "\n=== PTP Round-Trip Latency ===\n"
+              << "  Samples:  " << result.latency_samples.size()
+              << " (all captured frames)\n"
+              << "  Min:      " << lat_min << " ns\n"
+              << "  Max:      " << lat_max << " ns\n"
+              << "  Avg:      " << std::fixed << std::setprecision(1) << lat_avg
+              << " ns\n";
+    const std::string csv_path = "ptp_latency.csv";
+    std::ofstream csv(csv_path);
+    if (csv.is_open()) {
+      csv << "request_id,shot,local,kind,send_sec,send_nsec,recv_sec,"
+             "recv_nsec,delta_ns\n";
+      for (const auto &sample : result.latency_samples)
+        csv << sample.request_id << "," << sample.shot << "," << sample.local
+            << "," << (sample.is_corr ? "get_corrections" : "enqueue") << ","
+            << sample.send_sec << "," << sample.send_nsec << ","
+            << sample.recv_sec << "," << sample.recv_nsec << ","
+            << sample.delta_ns << "\n";
+      std::cout << "  CSV written: " << csv_path << " ("
+                << result.latency_samples.size() << " rows)\n";
+    }
+  } else {
+    std::cout << "\n  PTP latency: no valid timestamps found\n";
+  }
+
+  if (!verification_passed(result, expected_shots) ||
+      (measurement_run && !measurement_run_passed(*measurement_run))) {
+    if (result.correction_errors > 0 || result.header_errors > 0)
+      std::cout << "  RESULT: FAIL\n";
+    else if (result.responses_matched == 0)
+      std::cout << "  RESULT: FAIL (no valid responses found)\n";
+    else if (measurement_run && !measurement_run_passed(*measurement_run))
+      std::cout << "  RESULT: FAIL (measurement run did not satisfy the "
+                   "requested acceptance criteria)\n";
+    else
+      std::cout << "  RESULT: FAIL (verified only "
+                << result.unique_shots_verified << " of " << expected_shots
+                << " expected shots)\n";
+    return;
+  }
+  std::cout << "  RESULT: PASS\n";
+}
+
 } // namespace
 
 // ============================================================================
@@ -1034,6 +1248,12 @@ VerifyResult verify_captured_responses(
 
 int main(int argc, char **argv) {
   Options options = parse_args(argc, argv);
+  if ((options.loop_seconds || options.min_loop_shots) &&
+      !options.control_port) {
+    throw std::invalid_argument(
+        "--loop-seconds and --min-loop-shots require --control-port "
+        "(software emulator only)");
+  }
   // --data-dir is required unless both --config and --syndromes are given
   bool has_explicit_files =
       !options.config_file.empty() && !options.syndromes_file.empty();
@@ -1312,7 +1532,7 @@ int main(int argc, char **argv) {
     hsb_channel.configure_roce(*options.buffer_addr, bytes_per_window,
                                rdma_page_size, rdma_num_pages, ROCEV2_UDP_PORT);
 
-    std::cout << "FPGA SIF registers configured for RDMA" << std::endl;
+    std::cout << "FPGA SIF registers configured for RDMA\n";
   }
 
   // ------------------------------------------------------------------
@@ -1331,17 +1551,16 @@ int main(int argc, char **argv) {
   if (!hsb->write_uint32(config_write))
     throw std::runtime_error("Failed to configure player");
 
-  std::cout << "Writing " << num_windows << " windows to playback BRAM..."
-            << std::endl;
+  std::cout << "Writing " << num_windows << " windows to playback BRAM...\n";
   try {
     write_bram(*hsb, windows, bytes_per_window);
-    std::cout << "BRAM write completed successfully" << std::endl;
+    std::cout << "BRAM write completed successfully\n";
   } catch (const std::exception &e) {
     std::cerr << "BRAM write FAILED: " << e.what() << std::endl;
     return 1;
   }
 
-  std::cout << "Verifying playback BRAM contents..." << std::endl;
+  std::cout << "Verifying playback BRAM contents...\n";
   try {
     if (!verify_bram(*hsb, windows, bytes_per_window)) {
       std::cerr << "BRAM readback verification FAILED\n";
@@ -1387,15 +1606,32 @@ int main(int argc, char **argv) {
   // ------------------------------------------------------------------
   // Enable playback
   // ------------------------------------------------------------------
-  if (!hsb->write_uint32(PLAYER_ADDR + PLAYER_ENABLE_OFFSET, PLAYER_ENABLE))
+  // A loop run with --verify starts with exactly one single-pass playback, so
+  // the ILA can verify a finite and unique response sequence before the BRAM
+  // windows are replayed continuously.
+  const bool verify_first_pass = options.loop && options.verify;
+  const std::uint32_t player_enable = (options.loop && !options.verify)
+                                          ? PLAYER_ENABLE_LOOP
+                                          : PLAYER_ENABLE_SINGLE_PASS;
+  if (!hsb->write_uint32(PLAYER_ADDR + PLAYER_ENABLE_OFFSET, player_enable))
     throw std::runtime_error("Failed to enable player");
 
   std::cout << "Playback enabled: " << num_shots << " shots / " << num_windows
             << " frames on hsb " << options.hsb_ip << "\n";
+  if (verify_first_pass) {
+    std::cout << "\n=== Playback Plan ===\n"
+              << "  ILA verification:        " << num_shots
+              << " unique shots / " << num_windows << " frames\n"
+              << "  Continuous replay unit:  same verified " << num_windows
+              << "-frame BRAM load\n"
+              << "  Frames per decode:       " << frames_per_shot << "\n";
+  }
 
   // ------------------------------------------------------------------
   // ILA capture and correction verification
   // ------------------------------------------------------------------
+  std::optional<VerifyResult> verified_result;
+  std::uint32_t verified_sample_count = 0;
   if (options.verify) {
     std::cout << "\n=== ILA Capture & Verification ===\n";
 
@@ -1431,95 +1667,53 @@ int main(int argc, char **argv) {
     auto samples = ila_dump(*hsb, actual_samples);
     std::cout << "Read " << samples.size() << " samples from ILA\n";
 
-    // Verify correction responses against expected values.
-    auto vr = verify_captured_responses(samples, syndromes, num_shots,
-                                        options.per_round, frames_per_shot,
-                                        rdma_num_pages);
-
-    // In per-round mode the response frames split into enqueue ACKs
-    // (result_len==0) and get_corrections frames (result_len>0); only the
-    // latter carry corrections.
-    const std::size_t corrections_returned = vr.rpc_responses - vr.enqueue_acks;
-    std::cout << "\n=== Verification Summary ===\n"
-              << "  ILA samples captured:   " << actual_samples << "\n"
-              << "  tvalid=0 (idle):        " << vr.tvalid_zero << "\n"
-              << "  RPC response frames:    " << vr.rpc_responses << "\n";
-    if (options.per_round)
-      std::cout << "  Enqueue ACKs:           " << vr.enqueue_acks << "\n"
-                << "  get_corrections frames: " << corrections_returned << "\n";
-    std::cout << "  Non-RPC frames:         " << vr.non_rpc_frames << "\n"
-              << "  Unique shots verified:  " << vr.unique_shots_verified
-              << "\n"
-              << "  Corrections matched:    " << vr.responses_matched << "\n"
-              << "  Header errors:          " << vr.header_errors << "\n"
-              << "  Correction errors:      " << vr.correction_errors << "\n"
-              << "  Expected shots:         " << num_shots << "\n";
-    if (!vr.latency_samples.empty()) {
-      int64_t lat_min = std::numeric_limits<int64_t>::max();
-      int64_t lat_max = std::numeric_limits<int64_t>::min();
-      int64_t lat_sum = 0;
-      for (auto &s : vr.latency_samples) {
-        lat_sum += s.delta_ns;
-        if (s.delta_ns < lat_min)
-          lat_min = s.delta_ns;
-        if (s.delta_ns > lat_max)
-          lat_max = s.delta_ns;
-      }
-      double lat_avg = static_cast<double>(lat_sum) / vr.latency_samples.size();
-
-      // Print first 5 samples for diagnostic
-      for (std::size_t k = 0; k < 5 && k < vr.latency_samples.size(); ++k) {
-        auto &s = vr.latency_samples[k];
-        std::cout << "  rid " << std::setw(3) << s.request_id << " (shot "
-                  << s.shot << " local " << s.local << " "
-                  << (s.is_corr ? "get_corrections" : "enqueue") << ")"
-                  << ": send={sec=" << s.send_sec << ", nsec=" << s.send_nsec
-                  << "} recv={sec=" << s.recv_sec << ", nsec=" << s.recv_nsec
-                  << "} delta=" << s.delta_ns << " ns\n";
-      }
-
-      std::cout << "\n=== PTP Round-Trip Latency ===\n"
-                << "  Samples:  " << vr.latency_samples.size()
-                << " (all captured frames)\n"
-                << "  Min:      " << lat_min << " ns\n"
-                << "  Max:      " << lat_max << " ns\n"
-                << "  Avg:      " << std::fixed << std::setprecision(1)
-                << lat_avg << " ns\n";
-
-      // One row per captured frame.  `kind` is enqueue|get_corrections;
-      // `local` is the frame index within its shot (per-round).
-      const std::string csv_path = "ptp_latency.csv";
-      std::ofstream csv(csv_path);
-      if (csv.is_open()) {
-        csv << "request_id,shot,local,kind,send_sec,send_nsec,recv_sec,"
-               "recv_nsec,delta_ns\n";
-        for (auto &s : vr.latency_samples)
-          csv << s.request_id << "," << s.shot << "," << s.local << ","
-              << (s.is_corr ? "get_corrections" : "enqueue") << ","
-              << s.send_sec << "," << s.send_nsec << "," << s.recv_sec << ","
-              << s.recv_nsec << "," << s.delta_ns << "\n";
-        csv.close();
-        std::cout << "  CSV written: " << csv_path << " ("
-                  << vr.latency_samples.size() << " rows)\n";
-      }
-    } else {
-      std::cout << "\n  PTP latency: no valid timestamps found\n";
-    }
-
-    if (vr.correction_errors > 0 || vr.header_errors > 0) {
-      std::cout << "  RESULT: FAIL\n";
+    verified_sample_count = actual_samples;
+    verified_result = verify_captured_responses(
+        samples, syndromes, num_shots, options.per_round, frames_per_shot,
+        rdma_num_pages);
+    if (!verification_passed(*verified_result, num_shots)) {
+      print_verification_summary(*verified_result, verified_sample_count,
+                                 num_shots, options.per_round);
       return 1;
     }
-    if (vr.responses_matched == 0) {
-      std::cout << "  RESULT: FAIL (no valid responses found)\n";
-      return 1;
+    if (!options.loop)
+      print_verification_summary(*verified_result, verified_sample_count,
+                                 num_shots, options.per_round);
+  }
+
+  if (options.loop) {
+    if (verify_first_pass) {
+      if (!hsb->write_uint32(PLAYER_ADDR + PLAYER_ENABLE_OFFSET,
+                             PLAYER_ENABLE_LOOP))
+        throw std::runtime_error("Failed to enable loop player");
     }
-    if (vr.unique_shots_verified < num_shots) {
-      std::cout << "  RESULT: FAIL (verified only " << vr.unique_shots_verified
-                << " of " << num_shots << " expected shots)\n";
-      return 1;
+
+    loop_stop_requested = 0;
+    std::signal(SIGINT, request_loop_stop);
+    const auto loop_start = std::chrono::steady_clock::now();
+    while (!loop_stop_requested) {
+      if (options.loop_seconds &&
+          std::chrono::steady_clock::now() - loop_start >=
+              std::chrono::seconds(*options.loop_seconds))
+        break;
+      std::this_thread::sleep_for(std::chrono::milliseconds(100));
     }
-    std::cout << "  RESULT: PASS\n";
+    if (!hsb->write_uint32(PLAYER_ADDR + PLAYER_ENABLE_OFFSET, PLAYER_DISABLE))
+      throw std::runtime_error("Failed to disable loop player");
+    // The real FPGA exposes no equivalent final-counter register map. Its
+    // manual loop contract ends cleanly when the player is disabled.
+    if (!options.control_port)
+      return 0;
+    const auto loop_stats = read_loop_stats(*hsb);
+    if (!loop_stats)
+      throw std::runtime_error(
+          "emulator did not publish final loop statistics");
+    const auto measurement_run = make_measurement_run_summary(
+        *loop_stats, frames_per_shot, options.min_loop_shots);
+    if (verified_result)
+      print_verification_summary(*verified_result, verified_sample_count,
+                                 num_shots, options.per_round, measurement_run);
+    return measurement_run_passed(measurement_run) ? 0 : 1;
   }
 
   return 0;

--- a/libs/qec/unittests/utils/hsb_fpga_syndrome_playback.cpp
+++ b/libs/qec/unittests/utils/hsb_fpga_syndrome_playback.cpp
@@ -52,8 +52,8 @@ constexpr std::uint32_t RAM_DEPTH = 512;
 
 constexpr std::uint32_t PLAYER_ENABLE_SINGLE_PASS =
     0x0000'000D; // enable + single-pass + ptp_bram_ena
-// Matches the HSB GPU-RoCE loopback example's continuous-player setting.
-constexpr std::uint32_t PLAYER_ENABLE_LOOP = 0x0000'0003;
+// ram_ena | ptp_bram_ena: continuously replay the programmed BRAM payload.
+constexpr std::uint32_t PLAYER_ENABLE_LOOP = 0x0000'0009;
 constexpr std::uint32_t PLAYER_DISABLE = 0x0000'0000;
 // LOOP_STATS register map — must match hsb_fpga_emulator.cpp in the
 // cuda-quantum repository.
@@ -1715,9 +1715,15 @@ int main(int argc, char **argv) {
     if (!hsb->write_uint32(PLAYER_ADDR + PLAYER_ENABLE_OFFSET, PLAYER_DISABLE))
       throw std::runtime_error("Failed to disable loop player");
     // The real FPGA exposes no equivalent final-counter register map. Its
-    // manual loop contract ends cleanly when the player is disabled.
-    if (!options.control_port)
+    // manual loop contract ends cleanly when the player is disabled. Preserve
+    // the finite ILA verification result even though loop statistics are not
+    // available on hardware.
+    if (!options.control_port) {
+      if (verified_result)
+        print_verification_summary(*verified_result, verified_sample_count,
+                                   num_shots, options.per_round);
       return 0;
+    }
     const auto loop_stats = read_loop_stats(*hsb);
     if (!loop_stats)
       throw std::runtime_error(

--- a/libs/qec/unittests/utils/hsb_fpga_syndrome_playback.cpp
+++ b/libs/qec/unittests/utils/hsb_fpga_syndrome_playback.cpp
@@ -66,6 +66,7 @@ constexpr std::uint32_t LOOP_STATS_RESPONSES_HI = 0xE000'0014;
 constexpr std::uint32_t LOOP_STATS_ERRORS = 0xE000'0018;
 constexpr std::uint32_t LOOP_STATS_TIMEOUTS = 0xE000'001C;
 constexpr std::uint32_t LOOP_STATS_ACK = 0xE000'0020;
+constexpr std::uint32_t LOOP_STATS_RESPONSE_FAILURES = 0xE000'0024;
 constexpr std::uint32_t LOOP_STATS_MAGIC_VALUE = 0x4853'4245;
 constexpr std::uint32_t LOOP_STATS_COMPLETE = 2;
 constexpr int kLoopStatsMaxRetries = 100;
@@ -463,7 +464,7 @@ void print_usage(const char *argv0) {
          "disable the player cleanly; requires --control-port\n"
       << "                        and --verify first checks one pass\n"
       << "  --min-loop-shots <n> Require at least n completed decoding "
-         "measurements in emulator loop mode\n"
+         "measurements in emulator loop mode; requires --loop\n"
       << "  --per-round           Per-round protocol (device-graph scheduler): "
          "send\n"
       << "                        N enqueue_syndromes frames (one per "
@@ -521,7 +522,11 @@ Options parse_args(int argc, char **argv) {
       options.loop = true;
       options.loop_seconds = static_cast<std::uint32_t>(seconds);
     } else if (arg == "--min-loop-shots" && i + 1 < argc) {
-      options.min_loop_shots = std::stoull(argv[++i]);
+      const auto min_loop_shots = std::stoull(argv[++i]);
+      if (min_loop_shots == 0)
+        throw std::invalid_argument(
+            "--min-loop-shots must be a positive integer");
+      options.min_loop_shots = min_loop_shots;
     } else if (arg == "--per-round") {
       options.per_round = true;
     } else if (arg == "--qp-number" && i + 1 < argc) {
@@ -1081,6 +1086,7 @@ struct LoopStats {
   std::uint64_t responses = 0;
   std::uint32_t errors = 0;
   std::uint32_t timeouts = 0;
+  std::uint32_t response_failures = 0;
 };
 
 struct MeasurementRunSummary {
@@ -1090,6 +1096,7 @@ struct MeasurementRunSummary {
   bool all_responses_received = false;
   std::uint32_t transport_errors = 0;
   std::uint32_t transport_timeouts = 0;
+  std::uint32_t response_failures = 0;
   std::optional<std::size_t> requested_measurements;
 };
 
@@ -1107,7 +1114,8 @@ std::optional<LoopStats> read_loop_stats(hololink::Hololink &hsb) {
           read_u64(hsb, LOOP_STATS_WINDOWS_LO, LOOP_STATS_WINDOWS_HI),
           read_u64(hsb, LOOP_STATS_RESPONSES_LO, LOOP_STATS_RESPONSES_HI),
           hsb.read_uint32(LOOP_STATS_ERRORS),
-          hsb.read_uint32(LOOP_STATS_TIMEOUTS)};
+          hsb.read_uint32(LOOP_STATS_TIMEOUTS),
+          hsb.read_uint32(LOOP_STATS_RESPONSE_FAILURES)};
       // The software emulator keeps its control-plane session alive until the
       // client has consumed this final snapshot. This acknowledgement is
       // outside the playback/RDMA hot path.
@@ -1130,13 +1138,14 @@ MeasurementRunSummary make_measurement_run_summary(
       .all_responses_received = stats.responses == stats.frames,
       .transport_errors = stats.errors,
       .transport_timeouts = stats.timeouts,
+      .response_failures = stats.response_failures,
       .requested_measurements = requested_measurements,
   };
 }
 
 bool measurement_run_passed(const MeasurementRunSummary &summary) {
   return summary.all_responses_received && summary.transport_errors == 0 &&
-         summary.transport_timeouts == 0 &&
+         summary.transport_timeouts == 0 && summary.response_failures == 0 &&
          (!summary.requested_measurements ||
           summary.completed_measurements >= *summary.requested_measurements);
 }
@@ -1172,7 +1181,9 @@ void print_verification_summary(const VerifyResult &result,
               << "  Transport errors:       "
               << measurement_run->transport_errors << "\n"
               << "  Transport timeouts:     "
-              << measurement_run->transport_timeouts << "\n";
+              << measurement_run->transport_timeouts << "\n"
+              << "  RPC status failures:    "
+              << measurement_run->response_failures << "\n";
   }
   if (!result.latency_samples.empty()) {
     int64_t lat_min = std::numeric_limits<int64_t>::max();
@@ -1248,6 +1259,9 @@ void print_verification_summary(const VerifyResult &result,
 
 int main(int argc, char **argv) {
   Options options = parse_args(argc, argv);
+  if (options.min_loop_shots && !options.loop) {
+    throw std::invalid_argument("--min-loop-shots requires --loop");
+  }
   if ((options.loop_seconds || options.min_loop_shots) &&
       !options.control_port) {
     throw std::invalid_argument(


### PR DESCRIPTION
## Description

Adds bounded HSB playback-loop regression coverage for the software HSB emulator.

The FPGA player has a finite BRAM load, while longer decoder regressions need to exercise the same programmed load repeatedly. This PR:

- Pins CUDA Quantum to the companion software-emulator implementation in NVIDIA/cuda-quantum#5390.
- Adds loop-aware playback handling to the HSB syndrome playback utility.
- Performs one finite ILA verification pass before continuous replay when verification is enabled.
- Uses loop-only emulator counters for playback frames, responses, transport failures, and RPC-status failures.
- Adds bounded-loop acceptance checks to the HSB decoding-server test script, including transport-specific completion handling.

The changes are confined to HSB test utilities and regression harnesses. They do not change the decoding-server or decoder hot paths.

## Runtime / performance impact

N/A for production decoding. The loop path is opt-in test behavior; existing single-pass playback behavior is unchanged. A bounded loop run intentionally takes the configured `--loop-seconds` duration.

## Validation

On GB200, validated the software HSB-emulator CPU-RoCE loop path with the Ising playback fixture. The test requires at least 1,000 completed decoding measurements; playback is time-bounded, so it may complete additional whole
measurements before stopping.

- Required minimum measurements: 1,000
- Completed measurements: 1,290
- Transport errors/timeouts: 0
- RPC-status failures: 0
- Result: PASS

The finite ILA pass verifies correction contents. The bounded replay validates long-run completed-measurement and transport/RPC-status accounting.

Related CUDA-Quantum changes PR: https://github.com/NVIDIA/cuda-quantum/pull/5390

## Self-review checklist

Please confirm each item before requesting review. Check `[x]` or strike
through and explain.

### Before requesting review

- [x] I reviewed my own full diff in GitHub or my editor.
- [x] PR is in Draft if it is not yet ready for review.
- [x] Temporary / debugging changes have been removed.
- [x] Local test logs reviewed; no unexplained warnings or errors.
- [x] CI logs reviewed; no unexplained warnings or errors.
- [x] Full CI has been run.

### Scope and size

- [x] PR is under ~1000 lines, or an exception is justified in the description.
- [ ] Refactoring-only changes are isolated in their own PR(s).
- [x] No existing tests were disabled or modified just to make this PR pass
      (if so, an issue has been raised).

### Tests

- [x] New functionality has new tests.
- [x] Tests fail if the new functionality is broken (including crashes), not
      just when it is missing.
- [ ] Negative tests added where exceptions are expected.
- [ ] Truth data added where simple `EXPECT_*` / `assert` checks are
      insufficient for algorithmic correctness.
- [x] CI runtime impact considered; team notified if significant.

### Documentation

- [ ] Public-facing APIs have Doxygen docs.
- [ ] User-visible behavior changes have public docs, or a follow-up is
      tracked.

### Code style

- [x] Naming follows the existing convention (`snake_case` vs `camelCase`) for
      the area being modified.

### Dependencies

- [x] No new third-party dependencies, **or** the team has been notified and
      OSRB tickets filed.