### PR TITLE
[docs] Improving BP+OSD Decoding With Min-LLR OSD Initialization

### DIFF
--- a/assets/docs/minllr_osd_controls.png
+++ b/assets/docs/minllr_osd_controls.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:726df3b9769f5f72cab0e721e122a26ef7c2457c459f008c84c42d8a52a0271d
+size 331200

--- a/assets/docs/minllr_osd_joint_vs_split.png
+++ b/assets/docs/minllr_osd_joint_vs_split.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b3606dfb700ab46e68d71ff5060841af673da4905af8822c2c6c8cf7752cfddb
+size 234870

--- a/benchmarks/qec/nv_qldpc_minllr_osd/README.md
+++ b/benchmarks/qec/nv_qldpc_minllr_osd/README.md
@@ -29,7 +29,7 @@ CUDA_VISIBLE_DEVICES=0 python3 -u run_sweep.py --label bb72_Zonly \
 python3 plot_sweep.py report_data
 ```
 
-**Arms** (`--arms`, default all four; `bp_method` is the default sum-product,
+**Arms** -- the decoder configurations under test (`--arms`, default all six; `bp_method` is the default sum-product,
 `use_sparsity=True`, `bp_batch_size=2048`, priors from the DEM, decoding to
 observables via `O=L`):
 
@@ -39,6 +39,11 @@ observables via `O=L`):
 | `BP10-minLLR+OSD-CS10` | 10 | 3 | 10 | `min_llr` |
 | `BP60+OSD-0` | 60 | 1 (OSD-0) | -- | `final_llr` |
 | `BP10-minLLR+OSD-0` | 10 | 1 | -- | `min_llr` |
+| `BP10+OSD-CS10` (control) | 10 | 3 | 10 | `final_llr` |
+| `BP60-minLLR+OSD-CS10` (control) | 60 | 3 | 10 | `min_llr` |
+
+The two controls change only one factor each relative to the first two arms, so the
+effect of `osd_init_method` can be separated from that of `max_iterations`.
 
 **Stopping rule.** Syndromes are drawn in `--batch` chunks (default 10,000) from
 one `stim` sampler (`--seed`). An arm stops once it has `--stop-fails` (default
@@ -53,11 +58,13 @@ Running the same label again with a different `--seed` appends an independent
 sample; `plot_sweep.py` pools all records for the same (label, arm, p). The shipped
 `report_data` does this twice: the `[[72,12,6]]` DEMs were re-run with
 `--seed 24680 --stop-fails 1000` (cheap, tightens every point), and the
-`[[144,12,12]]` joint-XYZ `BP10-minLLR+OSD-CS10` point at `p = 0.002` was extended
-with `--seed 67890` and `--seed 13579`, `--max-shots 1000000` each.
+`[[144,12,12]]` joint-XYZ `BP10-minLLR+OSD-CS10` and `BP60-minLLR+OSD-CS10` points at
+`p = 0.002` were extended with `--seed 67890` and `--seed 13579`, `--max-shots 1000000`
+each.
 `plot_sweep.py` prints the table (fails/shots, LER, Wilson 95% interval, ratio to
 the `min_llr` CS10 arm) and writes `report_data/figures/minllr_osd_joint_vs_split.png` (the
 main figure of the guide: joint XYZ vs split X/Z DEM of the same memory-Z circuit,
-OSD-CS10 arms, one column per code), `minllr_osd_ler.png` (one panel per DEM, OSD-CS10
-arms) and `minllr_osd_0_ler.png` (the OSD-0 arms); the latter two are kept here for
-reference and are not shown on the docs page.
+OSD-CS10 arms, one column per code), `minllr_osd_controls.png` (the matched-iteration
+controls, one panel per DEM), `minllr_osd_ler.png` (one panel per DEM, OSD-CS10 arms) and
+`minllr_osd_0_ler.png` (the OSD-0 arms); the latter two are kept here for reference and
+are not shown on the docs page.

--- a/benchmarks/qec/nv_qldpc_minllr_osd/README.md
+++ b/benchmarks/qec/nv_qldpc_minllr_osd/README.md
@@ -1,0 +1,63 @@
+Reproduces the data and figures in the min-LLR OSD user guide
+(`docs/sphinx/performance/nv_qldpc_minllr_osd_user_guide.rst`): logical error
+rate versus physical error rate for BP+OSD with the default final-LLR OSD column
+ordering versus `osd_init_method="min_llr"`, on bivariate-bicycle codes.
+
+**Circuits.** Two families are used:
+
+- `assets/benchmarks/bb{72,144}_memory_Z.stim` -- "split X/Z" circuits: only
+  the detectors of the basis being decoded are kept, from Relay-BP (<https://github.com/trmue/relay>,
+  Apache-2.0). Every noise argument in these files is the literal `(0.002)`;
+  `run_sweep.py` rescales to other `p` by substituting that literal.
+- Relay-BP's own `tests/testdata/bicycle_bivariate/*.stim` -- "joint XYZ"
+  `memory_Z` circuits with both X and Z check detectors, one file per error rate. Clone the Relay-BP repo and pass the per-rate glob (with
+  `{p}` in place of the rate) as `--circuit`.
+
+**Requirements:** a GPU; `cudaq-qec` with the `nv-qldpc-decoder` plugin
+(`osd_init_method` needs CUDA-Q QEC >= 0.8), `stim`, `numpy`, `matplotlib`.
+
+**Usage** (one process per DEM; all arms decode the same sampled syndromes):
+```
+export PYTHONPATH=<cuda-qx build>/python:/usr/local/cudaq
+R=<relay checkout>/tests/testdata/bicycle_bivariate
+CUDA_VISIBLE_DEVICES=0 python3 -u run_sweep.py --label bb72_fullZ \
+  --circuit "$R/circuit=bicycle_bivariate_72_12_6_memory_Z,*error_rate={p},*" \
+  --rates 0.001,0.0015,0.002,0.003,0.004,0.005 --max-shots 200000 --out report_data
+CUDA_VISIBLE_DEVICES=0 python3 -u run_sweep.py --label bb72_Zonly \
+  --circuit ../../../assets/benchmarks/bb72_memory_Z.stim \
+  --rates 0.001,0.0015,0.002,0.003,0.004,0.005 --max-shots 200000 --out report_data
+python3 plot_sweep.py report_data
+```
+
+**Arms** (`--arms`, default all four; `bp_method` is the default sum-product,
+`use_sparsity=True`, `bp_batch_size=2048`, priors from the DEM, decoding to
+observables via `O=L`):
+
+| Arm | `max_iterations` | `osd_method` | `osd_order` | `osd_init_method` |
+|---|---|---|---|---|
+| `BP60+OSD-CS10` | 60 | 3 (combination sweep) | 10 | `final_llr` |
+| `BP10-minLLR+OSD-CS10` | 10 | 3 | 10 | `min_llr` |
+| `BP60+OSD-0` | 60 | 1 (OSD-0) | -- | `final_llr` |
+| `BP10-minLLR+OSD-0` | 10 | 1 | -- | `min_llr` |
+
+**Stopping rule.** Syndromes are drawn in `--batch` chunks (default 10,000) from
+one `stim` sampler (`--seed`). An arm stops once it has `--stop-fails` (default
+100) logical failures or `--max-shots` shots. Because the baseline arms fail far
+more often they stop early; only the `min_llr` arms run to the shot cap at low
+`p`. Points with zero failures are plotted as their 95% Wilson upper bound.
+
+**Outputs** in `--out`: `<label>.jsonl` (one record per arm and rate: shots,
+fails, LER, BP-converged count, decode seconds, DEM sizes) and
+`<label>_p<p>_<arm>_seed<seed>.npz` (per-shot `fail` and `bp_converged` flags).
+Running the same label again with a different `--seed` appends an independent
+sample; `plot_sweep.py` pools all records for the same (label, arm, p). The shipped
+`report_data` does this twice: the `[[72,12,6]]` DEMs were re-run with
+`--seed 24680 --stop-fails 1000` (cheap, tightens every point), and the
+`[[144,12,12]]` joint-XYZ `BP10-minLLR+OSD-CS10` point at `p = 0.002` was extended
+with `--seed 67890` and `--seed 13579`, `--max-shots 1000000` each.
+`plot_sweep.py` prints the table (fails/shots, LER, Wilson 95% interval, ratio to
+the `min_llr` CS10 arm) and writes `report_data/figures/minllr_osd_joint_vs_split.png` (the
+main figure of the guide: joint XYZ vs split X/Z DEM of the same memory-Z circuit,
+OSD-CS10 arms, one column per code), `minllr_osd_ler.png` (one panel per DEM, OSD-CS10
+arms) and `minllr_osd_0_ler.png` (the OSD-0 arms); the latter two are kept here for
+reference and are not shown on the docs page.

--- a/benchmarks/qec/nv_qldpc_minllr_osd/plot_sweep.py
+++ b/benchmarks/qec/nv_qldpc_minllr_osd/plot_sweep.py
@@ -1,0 +1,181 @@
+# ============================================================================ #
+# Copyright (c) 2026 NVIDIA Corporation & Affiliates.                          #
+# All rights reserved.                                                         #
+#                                                                              #
+# This source code and the accompanying materials are made available under     #
+# the terms of the Apache License 2.0 which accompanies this distribution.     #
+# ============================================================================ #
+
+# Plots LER vs physical error rate from the JSON lines written by run_sweep.py
+# and prints the per-point table (fails/shots, LER, Wilson 95% interval, ratio
+# to the min_llr arm). See README.md.
+import glob, json, math, os, sys
+from collections import defaultdict
+import numpy as np
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+
+ROOT = sys.argv[1] if len(sys.argv) > 1 else "report_data"
+FIG = os.path.join(ROOT, "figures")
+os.makedirs(FIG, exist_ok=True)
+
+# Categorical palette slots 1-4, fixed order.
+STYLE = {
+    "BP60+OSD-CS10": dict(color="#eb6834", ls="-", lw=2.0, alpha=1.0, marker="o"),
+    "BP10-minLLR+OSD-CS10": dict(color="#2a78d6", ls="-", lw=2.4, alpha=1.0, marker="o"),
+    "BP60+OSD-0": dict(color="#eda100", ls="-", lw=2.0, alpha=1.0, marker="o"),
+    "BP10-minLLR+OSD-0": dict(color="#1baf7a", ls="-", lw=2.4, alpha=1.0, marker="o"),
+}
+FIGURES = {
+    "minllr_osd_cs10_ler": ["BP60+OSD-CS10", "BP10-minLLR+OSD-CS10"],
+    "minllr_osd_0_ler": ["BP60+OSD-0", "BP10-minLLR+OSD-0"],
+}
+# Only these labels are plotted (in this order); other labels in the data
+# directory are still tabulated.
+TITLES = {
+    "bb72_fullZ": "[[72,12,6]] joint XYZ",
+    "bb144_fullZ": "[[144,12,12]] joint XYZ",
+    "bb72_Zonly": "[[72,12,6]] split X/Z",
+    "bb144_Zonly": "[[144,12,12]] split X/Z",
+}
+
+
+def wilson(k, n, z=1.96):
+    if n == 0:
+        return (0.0, 1.0)
+    ph = k / n
+    den = 1 + z * z / n
+    c = (ph + z * z / (2 * n)) / den
+    h = z * math.sqrt(ph * (1 - ph) / n + z * z / (4 * n * n)) / den
+    return (max(c - h, 0.0), min(c + h, 1.0))
+
+
+rows = []
+for f in sorted(glob.glob(os.path.join(ROOT, "*.jsonl"))):
+    rows += [json.loads(l) for l in open(f) if l.strip()]
+# label -> arm -> list of (p, fails, shots); records for the same (label, arm,
+# p) -- e.g. extension runs with different seeds -- are pooled.
+acc = defaultdict(lambda: [0, 0])
+for r in rows:
+    acc[(r["label"], r["arm"], r["p"])][0] += r["fails"]
+    acc[(r["label"], r["arm"], r["p"])][1] += r["shots"]
+data = defaultdict(dict)
+for (label, arm, p), (k, n) in acc.items():
+    data[label].setdefault(arm, []).append((p, k, n))
+labels = [l for l in TITLES if l in data]
+extra = sorted(set(data) - set(TITLES))
+
+# ---- table -----------------------------------------------------------------
+ref = "BP10-minLLR+OSD-CS10"
+for label in labels + extra:
+    print(f"\n== {label}")
+    print(f"{'p':>7} {'arm':24} {'fails/shots':>14} {'LER':>9} {'Wilson 95%':>22} {'x vs min_llr CS10':>18}")
+    refd = {p: (k, n) for p, k, n in data[label].get(ref, [])}
+    for arm in list(STYLE) + sorted(set(data[label]) - set(STYLE)):
+        for p, k, n in sorted(data[label].get(arm, [])):
+            lo, hi = wilson(k, n)
+            ratio = ""
+            if p in refd and arm != ref:
+                rk, rn = refd[p]
+                ratio = f"{(k / n) / (rk / rn):.1f}x" if rk else f">{(k / n) / (1 / rn):.0f}x"
+            print(f"{p:>7} {arm:24} {f'{k}/{n}':>14} {k / n:>9.2e} "
+                  f"{f'[{lo:.1e}, {hi:.1e}]':>22} {ratio:>18}")
+
+# ---- figures -----------------------------------------------------------------
+ROWS = [("OSD-CS10", ["BP60+OSD-CS10", "BP10-minLLR+OSD-CS10"]),
+        ("OSD-0", ["BP60+OSD-0", "BP10-minLLR+OSD-0"])]
+plt.rcParams.update({"font.size": 12, "axes.labelsize": 14,
+                     "axes.labelweight": "bold", "axes.titlesize": 12,
+                     "axes.titleweight": "bold", "legend.fontsize": 10,
+                     "legend.handlelength": 4.0})
+
+
+ZERO_FAIL_POINTS = []
+
+
+def draw(ax, label, arm, name, ls=None, alpha=None):
+    """One LER-vs-p curve with a Wilson band; zero-failure points become open
+    down-triangles at the 95% upper bound."""
+    pts = sorted(data[label].get(arm, []))
+    if not pts:
+        return []
+    st = STYLE[arm]
+    ls = st["ls"] if ls is None else ls
+    alpha = st["alpha"] if alpha is None else alpha
+    ps = np.array([p for p, _, _ in pts])
+    ler = np.array([k / n_ for _, k, n_ in pts])
+    ci = np.array([wilson(k, n_) for _, k, n_ in pts])
+    pos = ler > 0
+    ax.plot(ps[pos], ler[pos], color=st["color"], ls=ls, lw=st["lw"],
+            alpha=alpha, marker=st["marker"], ms=6, label=name)
+    ax.fill_between(ps[pos], ci[pos, 0], ci[pos, 1], color=st["color"],
+                    alpha=0.12 * alpha, lw=0)
+    if (~pos).any():
+        ax.plot(ps[~pos], ci[~pos, 1], color=st["color"], ls="none",
+                marker="v", ms=8, alpha=alpha, mfc="none")
+        ZERO_FAIL_POINTS.append((label, arm))
+    return list(ps)
+
+
+def finish(ax, title, allp):
+    ax.set_xscale("log")
+    ax.set_yscale("log")
+    allp = sorted(set(allp))
+    ax.set_xticks(allp)
+    ax.set_xticklabels([f"{p:g}" for p in allp], rotation=45, ha="right")
+    ax.xaxis.set_minor_locator(matplotlib.ticker.NullLocator())
+    ax.set_title(title)
+    ax.grid(True, which="both", color="#e6e5e1", lw=0.6)
+    ax.set_axisbelow(True)
+    for sp in ("top", "right"):
+        ax.spines[sp].set_visible(False)
+    ax.legend(loc="lower right", frameon=False)
+
+
+def save(fig, axes, name):
+    for axrow in axes:
+        axrow[0].set_ylabel("logical error rate per shot")
+    for ax in axes[-1]:
+        ax.set_xlabel("physical error rate p")
+    if ZERO_FAIL_POINTS:
+        fig.text(0.995, 0.005, "open triangles: 95% Wilson upper bound at zero observed failures",
+                 ha="right", va="bottom", fontsize=9, color="#52514e")
+    fig.tight_layout(rect=(0, 0.04, 1, 1))
+    out = os.path.join(FIG, name)
+    fig.savefig(out, dpi=160)
+    print("wrote", out)
+
+
+# Figure 1: one panel per DEM, OSD-CS10 arms (used on the docs page).
+# Figure 1b: the same with the OSD-0 arms (collected, kept in report_data only).
+ncol = len(labels)
+for (row_name, arms), fname in zip(ROWS, ("minllr_osd_ler.png", "minllr_osd_0_ler.png")):
+    fig, axes = plt.subplots(1, ncol, figsize=(4.2 * ncol, 4.6), sharey=True, squeeze=False)
+    for ax, label in zip(axes[0], labels):
+        allp = []
+        for arm in arms:
+            allp += draw(ax, label, arm, arm)
+        finish(ax, f"{TITLES.get(label, label)} -- {row_name}", allp)
+    save(fig, axes, fname)
+
+# Figure 2: correlated (joint XYZ) vs uncorrelated (split X/Z) decoding of the
+# same memory-Z circuit, per code, OSD-CS10 only; one column per code.
+CODES = [("[[72,12,6]]", "bb72_fullZ", "bb72_Zonly"),
+         ("[[144,12,12]]", "bb144_fullZ", "bb144_Zonly")]
+CODES = [c for c in CODES if c[1] in data or c[2] in data]
+if CODES:
+    fig, axes = plt.subplots(1, len(CODES), figsize=(5.2 * len(CODES), 5.0),
+                             sharey=True, squeeze=False)
+    for (row_name, arms), axrow in zip(ROWS[:1], axes):
+        for ax, (code, joint, split) in zip(axrow, CODES):
+            allp = []
+            # legend order = top-to-bottom order of the curves at low p:
+            # baseline joint, baseline split, min-LLR split, min-LLR joint
+            base, minllr = arms
+            allp += draw(ax, joint, base, f"{base}, joint XYZ")
+            allp += draw(ax, split, base, f"{base}, split X/Z", ls="--", alpha=0.5)
+            allp += draw(ax, split, minllr, f"{minllr}, split X/Z", ls="--", alpha=0.5)
+            allp += draw(ax, joint, minllr, f"{minllr}, joint XYZ")
+            finish(ax, f"{code} -- {row_name}", allp)
+    save(fig, axes, "minllr_osd_joint_vs_split.png")

--- a/benchmarks/qec/nv_qldpc_minllr_osd/plot_sweep.py
+++ b/benchmarks/qec/nv_qldpc_minllr_osd/plot_sweep.py
@@ -13,6 +13,7 @@ import glob, json, math, os, sys
 from collections import defaultdict
 import numpy as np
 import matplotlib
+
 matplotlib.use("Agg")
 import matplotlib.pyplot as plt
 
@@ -22,10 +23,14 @@ os.makedirs(FIG, exist_ok=True)
 
 # Categorical palette slots 1-4, fixed order.
 STYLE = {
-    "BP60+OSD-CS10": dict(color="#eb6834", ls="-", lw=2.0, alpha=1.0, marker="o"),
-    "BP10-minLLR+OSD-CS10": dict(color="#2a78d6", ls="-", lw=2.4, alpha=1.0, marker="o"),
-    "BP60+OSD-0": dict(color="#eda100", ls="-", lw=2.0, alpha=1.0, marker="o"),
-    "BP10-minLLR+OSD-0": dict(color="#1baf7a", ls="-", lw=2.4, alpha=1.0, marker="o"),
+    "BP60+OSD-CS10":
+        dict(color="#eb6834", ls="-", lw=2.0, alpha=1.0, marker="o"),
+    "BP10-minLLR+OSD-CS10":
+        dict(color="#2a78d6", ls="-", lw=2.4, alpha=1.0, marker="o"),
+    "BP60+OSD-0":
+        dict(color="#eda100", ls="-", lw=2.0, alpha=1.0, marker="o"),
+    "BP10-minLLR+OSD-0":
+        dict(color="#1baf7a", ls="-", lw=2.4, alpha=1.0, marker="o"),
 }
 FIGURES = {
     "minllr_osd_cs10_ler": ["BP60+OSD-CS10", "BP10-minLLR+OSD-CS10"],
@@ -70,7 +75,9 @@ extra = sorted(set(data) - set(TITLES))
 ref = "BP10-minLLR+OSD-CS10"
 for label in labels + extra:
     print(f"\n== {label}")
-    print(f"{'p':>7} {'arm':24} {'fails/shots':>14} {'LER':>9} {'Wilson 95%':>22} {'x vs min_llr CS10':>18}")
+    print(
+        f"{'p':>7} {'arm':24} {'fails/shots':>14} {'LER':>9} {'Wilson 95%':>22} {'x vs min_llr CS10':>18}"
+    )
     refd = {p: (k, n) for p, k, n in data[label].get(ref, [])}
     for arm in list(STYLE) + sorted(set(data[label]) - set(STYLE)):
         for p, k, n in sorted(data[label].get(arm, [])):
@@ -85,11 +92,15 @@ for label in labels + extra:
 # ---- figures -----------------------------------------------------------------
 ROWS = [("OSD-CS10", ["BP60+OSD-CS10", "BP10-minLLR+OSD-CS10"]),
         ("OSD-0", ["BP60+OSD-0", "BP10-minLLR+OSD-0"])]
-plt.rcParams.update({"font.size": 12, "axes.labelsize": 14,
-                     "axes.labelweight": "bold", "axes.titlesize": 12,
-                     "axes.titleweight": "bold", "legend.fontsize": 10,
-                     "legend.handlelength": 4.0})
-
+plt.rcParams.update({
+    "font.size": 12,
+    "axes.labelsize": 14,
+    "axes.labelweight": "bold",
+    "axes.titlesize": 12,
+    "axes.titleweight": "bold",
+    "legend.fontsize": 10,
+    "legend.handlelength": 4.0
+})
 
 ZERO_FAIL_POINTS = []
 
@@ -107,13 +118,30 @@ def draw(ax, label, arm, name, ls=None, alpha=None):
     ler = np.array([k / n_ for _, k, n_ in pts])
     ci = np.array([wilson(k, n_) for _, k, n_ in pts])
     pos = ler > 0
-    ax.plot(ps[pos], ler[pos], color=st["color"], ls=ls, lw=st["lw"],
-            alpha=alpha, marker=st["marker"], ms=6, label=name)
-    ax.fill_between(ps[pos], ci[pos, 0], ci[pos, 1], color=st["color"],
-                    alpha=0.12 * alpha, lw=0)
+    ax.plot(ps[pos],
+            ler[pos],
+            color=st["color"],
+            ls=ls,
+            lw=st["lw"],
+            alpha=alpha,
+            marker=st["marker"],
+            ms=6,
+            label=name)
+    ax.fill_between(ps[pos],
+                    ci[pos, 0],
+                    ci[pos, 1],
+                    color=st["color"],
+                    alpha=0.12 * alpha,
+                    lw=0)
     if (~pos).any():
-        ax.plot(ps[~pos], ci[~pos, 1], color=st["color"], ls="none",
-                marker="v", ms=8, alpha=alpha, mfc="none")
+        ax.plot(ps[~pos],
+                ci[~pos, 1],
+                color=st["color"],
+                ls="none",
+                marker="v",
+                ms=8,
+                alpha=alpha,
+                mfc="none")
         ZERO_FAIL_POINTS.append((label, arm))
     return list(ps)
 
@@ -139,8 +167,14 @@ def save(fig, axes, name):
     for ax in axes[-1]:
         ax.set_xlabel("physical error rate p")
     if ZERO_FAIL_POINTS:
-        fig.text(0.995, 0.005, "open triangles: 95% Wilson upper bound at zero observed failures",
-                 ha="right", va="bottom", fontsize=9, color="#52514e")
+        fig.text(
+            0.995,
+            0.005,
+            "open triangles: 95% Wilson upper bound at zero observed failures",
+            ha="right",
+            va="bottom",
+            fontsize=9,
+            color="#52514e")
     fig.tight_layout(rect=(0, 0.04, 1, 1))
     out = os.path.join(FIG, name)
     fig.savefig(out, dpi=160)
@@ -150,8 +184,13 @@ def save(fig, axes, name):
 # Figure 1: one panel per DEM, OSD-CS10 arms (used on the docs page).
 # Figure 1b: the same with the OSD-0 arms (collected, kept in report_data only).
 ncol = len(labels)
-for (row_name, arms), fname in zip(ROWS, ("minllr_osd_ler.png", "minllr_osd_0_ler.png")):
-    fig, axes = plt.subplots(1, ncol, figsize=(4.2 * ncol, 4.6), sharey=True, squeeze=False)
+for (row_name,
+     arms), fname in zip(ROWS, ("minllr_osd_ler.png", "minllr_osd_0_ler.png")):
+    fig, axes = plt.subplots(1,
+                             ncol,
+                             figsize=(4.2 * ncol, 4.6),
+                             sharey=True,
+                             squeeze=False)
     for ax, label in zip(axes[0], labels):
         allp = []
         for arm in arms:
@@ -165,8 +204,11 @@ CODES = [("[[72,12,6]]", "bb72_fullZ", "bb72_Zonly"),
          ("[[144,12,12]]", "bb144_fullZ", "bb144_Zonly")]
 CODES = [c for c in CODES if c[1] in data or c[2] in data]
 if CODES:
-    fig, axes = plt.subplots(1, len(CODES), figsize=(5.2 * len(CODES), 5.0),
-                             sharey=True, squeeze=False)
+    fig, axes = plt.subplots(1,
+                             len(CODES),
+                             figsize=(5.2 * len(CODES), 5.0),
+                             sharey=True,
+                             squeeze=False)
     for (row_name, arms), axrow in zip(ROWS[:1], axes):
         for ax, (code, joint, split) in zip(axrow, CODES):
             allp = []
@@ -174,8 +216,18 @@ if CODES:
             # baseline joint, baseline split, min-LLR split, min-LLR joint
             base, minllr = arms
             allp += draw(ax, joint, base, f"{base}, joint XYZ")
-            allp += draw(ax, split, base, f"{base}, split X/Z", ls="--", alpha=0.5)
-            allp += draw(ax, split, minllr, f"{minllr}, split X/Z", ls="--", alpha=0.5)
+            allp += draw(ax,
+                         split,
+                         base,
+                         f"{base}, split X/Z",
+                         ls="--",
+                         alpha=0.5)
+            allp += draw(ax,
+                         split,
+                         minllr,
+                         f"{minllr}, split X/Z",
+                         ls="--",
+                         alpha=0.5)
             allp += draw(ax, joint, minllr, f"{minllr}, joint XYZ")
             finish(ax, f"{code} -- {row_name}", allp)
     save(fig, axes, "minllr_osd_joint_vs_split.png")

--- a/benchmarks/qec/nv_qldpc_minllr_osd/plot_sweep.py
+++ b/benchmarks/qec/nv_qldpc_minllr_osd/plot_sweep.py
@@ -31,6 +31,12 @@ STYLE = {
         dict(color="#eda100", ls="-", lw=2.0, alpha=1.0, marker="o"),
     "BP10-minLLR+OSD-0":
         dict(color="#1baf7a", ls="-", lw=2.4, alpha=1.0, marker="o"),
+    # matched-iteration controls (dashed, in the hue of the arm sharing their
+    # OSD ordering); plotted only in the controls figure
+    "BP10+OSD-CS10":
+        dict(color="#eb6834", ls="--", lw=1.8, alpha=0.6, marker="s"),
+    "BP60-minLLR+OSD-CS10":
+        dict(color="#2a78d6", ls="--", lw=1.8, alpha=0.6, marker="s"),
 }
 FIGURES = {
     "minllr_osd_cs10_ler": ["BP60+OSD-CS10", "BP10-minLLR+OSD-CS10"],
@@ -197,6 +203,26 @@ for (row_name,
             allp += draw(ax, label, arm, arm)
         finish(ax, f"{TITLES.get(label, label)} -- {row_name}", allp)
     save(fig, axes, fname)
+
+# Figure 1c: matched-iteration controls, one panel per DEM, OSD-CS10 only.
+# Legend order = curve order at low p: BP60 / BP10 default ordering, then
+# BP10 / BP60 min-LLR.
+CTRL = [
+    "BP60+OSD-CS10", "BP10+OSD-CS10", "BP10-minLLR+OSD-CS10",
+    "BP60-minLLR+OSD-CS10"
+]
+if any(a in data[l] for l in labels for a in CTRL[1::2]):
+    fig, axes = plt.subplots(1,
+                             ncol,
+                             figsize=(4.4 * ncol, 4.8),
+                             sharey=True,
+                             squeeze=False)
+    for ax, label in zip(axes[0], labels):
+        allp = []
+        for arm in CTRL:
+            allp += draw(ax, label, arm, arm)
+        finish(ax, f"{TITLES.get(label, label)} -- OSD-CS10", allp)
+    save(fig, axes, "minllr_osd_controls.png")
 
 # Figure 2: correlated (joint XYZ) vs uncorrelated (split X/Z) decoding of the
 # same memory-Z circuit, per code, OSD-CS10 only; one column per code.

--- a/benchmarks/qec/nv_qldpc_minllr_osd/run_sweep.py
+++ b/benchmarks/qec/nv_qldpc_minllr_osd/run_sweep.py
@@ -24,6 +24,11 @@ ARMS = {
     "BP10-minLLR+OSD-CS10": (10, 3, 10, "min_llr"),
     "BP60+OSD-0": (60, 1, 0, "final_llr"),
     "BP10-minLLR+OSD-0": (10, 1, 0, "min_llr"),
+    # matched-iteration controls: each changes only one factor relative to the
+    # two arms above, so the effect of osd_init_method can be separated from
+    # the effect of max_iterations.
+    "BP10+OSD-CS10": (10, 3, 10, "final_llr"),  # BP10, default ordering
+    "BP60-minLLR+OSD-CS10": (60, 3, 10, "min_llr"),  # BP60, min-LLR ordering
 }
 
 

--- a/benchmarks/qec/nv_qldpc_minllr_osd/run_sweep.py
+++ b/benchmarks/qec/nv_qldpc_minllr_osd/run_sweep.py
@@ -1,0 +1,140 @@
+# ============================================================================ #
+# Copyright (c) 2026 NVIDIA Corporation & Affiliates.                          #
+# All rights reserved.                                                         #
+#                                                                              #
+# This source code and the accompanying materials are made available under     #
+# the terms of the Apache License 2.0 which accompanies this distribution.     #
+# ============================================================================ #
+
+# LER-vs-physical-error-rate sweep: BP+OSD with the default final-LLR OSD
+# ordering versus BP + osd_init_method="min_llr". See README.md for usage.
+#
+# Every arm decodes the same sampled syndromes (paired comparison). An arm
+# stops after it has accumulated STOP_FAILS logical failures or MAX_SHOTS
+# shots, whichever comes first; results are appended as JSON lines and as
+# per-shot flag arrays so the plots can recompute Wilson intervals. Re-running
+# with a different --seed appends an independent sample that plot_sweep.py
+# pools with the earlier one (used to extend low-LER points).
+import argparse, glob, json, os, sys, time
+import numpy as np, stim, cudaq_qec as qec
+
+ARMS = {
+    # name: (max_iterations, osd_method, osd_order, osd_init_method)
+    "BP60+OSD-CS10": (60, 3, 10, "final_llr"),
+    "BP10-minLLR+OSD-CS10": (10, 3, 10, "min_llr"),
+    "BP60+OSD-0": (60, 1, 0, "final_llr"),
+    "BP10-minLLR+OSD-0": (10, 1, 0, "min_llr"),
+}
+
+
+def load_circuit(spec, p):
+    """spec is either a path to a stim file whose noise arguments are all the
+    literal (0.002) (the assets/benchmarks Z-only circuits) -- rescaled to p by
+    substitution -- or a glob with {p} for a per-rate circuit family."""
+    if "{p}" in spec:
+        fs = glob.glob(spec.format(p=p))
+        if len(fs) != 1:
+            raise SystemExit(f"expected one circuit for {spec} p={p}, got {fs}")
+        return stim.Circuit.from_file(fs[0])
+    txt = open(spec).read()
+    if "(0.002)" not in txt:
+        raise SystemExit(f"{spec}: expected literal (0.002) noise arguments")
+    return stim.Circuit(txt.replace("(0.002)", f"({p})"))
+
+
+def dem_mats(c):
+    dem = c.detector_error_model()
+    H = np.zeros((dem.num_detectors, dem.num_errors), np.uint8)
+    L = np.zeros((dem.num_observables, dem.num_errors), np.uint8)
+    er = np.zeros(dem.num_errors)
+    e = 0
+    for ins in dem.flattened():
+        if ins.type == "error":
+            er[e] = ins.args_copy()[0]
+            for t in ins.targets_copy():
+                if t.is_relative_detector_id():
+                    H[t.val, e] = 1
+                elif t.is_logical_observable_id():
+                    L[t.val, e] = 1
+            e += 1
+    return H, L, er
+
+
+def make_decoder(H, L, er, arm):
+    max_iter, osd_method, osd_order, init = ARMS[arm]
+    return qec.get_decoder("nv-qldpc-decoder", H, error_rate_vec=er,
+                           use_sparsity=True, use_osd=True,
+                           osd_method=osd_method, osd_order=osd_order,
+                           osd_init_method=init, max_iterations=max_iter,
+                           bp_batch_size=2048, O=L)
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--label", required=True, help="DEM label used in output")
+    ap.add_argument("--circuit", required=True,
+                    help="stim file with literal (0.002) noise, or glob with {p}")
+    ap.add_argument("--rates", required=True, help="comma-separated p values")
+    ap.add_argument("--arms", default=",".join(ARMS), help="comma-separated")
+    ap.add_argument("--batch", type=int, default=10000)
+    ap.add_argument("--max-shots", type=int, required=True)
+    ap.add_argument("--stop-fails", type=int, default=100)
+    ap.add_argument("--seed", type=int, default=12345)
+    ap.add_argument("--out", required=True, help="output directory")
+    a = ap.parse_args()
+    os.makedirs(a.out, exist_ok=True)
+    arms = a.arms.split(",")
+    for arm in arms:
+        if arm not in ARMS:
+            raise SystemExit(f"unknown arm {arm}; choose from {list(ARMS)}")
+    jsonl = os.path.join(a.out, f"{a.label}.jsonl")
+
+    for p in a.rates.split(","):
+        c = load_circuit(a.circuit, p)
+        H, L, er = dem_mats(c)
+        sampler = c.compile_detector_sampler(seed=a.seed)
+        n_batches = -(-a.max_shots // a.batch)
+        dets, obss = [], []
+        decoders = {arm: make_decoder(H, L, er, arm) for arm in arms}
+        flags = {arm: [] for arm in arms}
+        conv = {arm: [] for arm in arms}
+        secs = {arm: 0.0 for arm in arms}
+        active = set(arms)
+        for b in range(n_batches):
+            if not active:
+                break
+            det, obs = sampler.sample(a.batch, separate_observables=True)
+            det = det.astype(np.uint8)
+            obs = obs.astype(np.uint8)
+            for arm in list(active):
+                t = time.time()
+                res = decoders[arm].decode_batch(det)
+                secs[arm] += time.time() - t
+                pred = np.array([r.result for r in res], np.uint8)
+                flags[arm].append(np.any(pred != obs, axis=1))
+                conv[arm].append(np.array([r.converged for r in res], bool))
+                fails = int(sum(f.sum() for f in flags[arm]))
+                shots = sum(len(f) for f in flags[arm])
+                print(f"{a.label} p={p} {arm}: {fails}/{shots} fails, "
+                      f"{secs[arm]:.0f}s", flush=True)
+                if fails >= a.stop_fails:
+                    active.discard(arm)
+        for arm in arms:
+            f = np.concatenate(flags[arm])
+            cv = np.concatenate(conv[arm])
+            rec = dict(label=a.label, p=float(p), arm=arm, shots=int(len(f)),
+                       fails=int(f.sum()), ler=float(f.mean()),
+                       bp_converged=int(cv.sum()), decode_sec=round(secs[arm], 1),
+                       num_detectors=int(H.shape[0]), num_errors=int(H.shape[1]),
+                       num_observables=int(L.shape[0]), seed=a.seed,
+                       max_shots=a.max_shots, stop_fails=a.stop_fails)
+            with open(jsonl, "a") as fh:
+                fh.write(json.dumps(rec) + "\n")
+            np.savez_compressed(
+                os.path.join(a.out, f"{a.label}_p{p}_{arm}_seed{a.seed}.npz"),
+                fail=f, bp_converged=cv)
+        del decoders
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/qec/nv_qldpc_minllr_osd/run_sweep.py
+++ b/benchmarks/qec/nv_qldpc_minllr_osd/run_sweep.py
@@ -62,18 +62,26 @@ def dem_mats(c):
 
 def make_decoder(H, L, er, arm):
     max_iter, osd_method, osd_order, init = ARMS[arm]
-    return qec.get_decoder("nv-qldpc-decoder", H, error_rate_vec=er,
-                           use_sparsity=True, use_osd=True,
-                           osd_method=osd_method, osd_order=osd_order,
-                           osd_init_method=init, max_iterations=max_iter,
-                           bp_batch_size=2048, O=L)
+    return qec.get_decoder("nv-qldpc-decoder",
+                           H,
+                           error_rate_vec=er,
+                           use_sparsity=True,
+                           use_osd=True,
+                           osd_method=osd_method,
+                           osd_order=osd_order,
+                           osd_init_method=init,
+                           max_iterations=max_iter,
+                           bp_batch_size=2048,
+                           O=L)
 
 
 def main():
     ap = argparse.ArgumentParser()
     ap.add_argument("--label", required=True, help="DEM label used in output")
-    ap.add_argument("--circuit", required=True,
-                    help="stim file with literal (0.002) noise, or glob with {p}")
+    ap.add_argument(
+        "--circuit",
+        required=True,
+        help="stim file with literal (0.002) noise, or glob with {p}")
     ap.add_argument("--rates", required=True, help="comma-separated p values")
     ap.add_argument("--arms", default=",".join(ARMS), help="comma-separated")
     ap.add_argument("--batch", type=int, default=10000)
@@ -115,24 +123,35 @@ def main():
                 conv[arm].append(np.array([r.converged for r in res], bool))
                 fails = int(sum(f.sum() for f in flags[arm]))
                 shots = sum(len(f) for f in flags[arm])
-                print(f"{a.label} p={p} {arm}: {fails}/{shots} fails, "
-                      f"{secs[arm]:.0f}s", flush=True)
+                print(
+                    f"{a.label} p={p} {arm}: {fails}/{shots} fails, "
+                    f"{secs[arm]:.0f}s",
+                    flush=True)
                 if fails >= a.stop_fails:
                     active.discard(arm)
         for arm in arms:
             f = np.concatenate(flags[arm])
             cv = np.concatenate(conv[arm])
-            rec = dict(label=a.label, p=float(p), arm=arm, shots=int(len(f)),
-                       fails=int(f.sum()), ler=float(f.mean()),
-                       bp_converged=int(cv.sum()), decode_sec=round(secs[arm], 1),
-                       num_detectors=int(H.shape[0]), num_errors=int(H.shape[1]),
-                       num_observables=int(L.shape[0]), seed=a.seed,
-                       max_shots=a.max_shots, stop_fails=a.stop_fails)
+            rec = dict(label=a.label,
+                       p=float(p),
+                       arm=arm,
+                       shots=int(len(f)),
+                       fails=int(f.sum()),
+                       ler=float(f.mean()),
+                       bp_converged=int(cv.sum()),
+                       decode_sec=round(secs[arm], 1),
+                       num_detectors=int(H.shape[0]),
+                       num_errors=int(H.shape[1]),
+                       num_observables=int(L.shape[0]),
+                       seed=a.seed,
+                       max_shots=a.max_shots,
+                       stop_fails=a.stop_fails)
             with open(jsonl, "a") as fh:
                 fh.write(json.dumps(rec) + "\n")
-            np.savez_compressed(
-                os.path.join(a.out, f"{a.label}_p{p}_{arm}_seed{a.seed}.npz"),
-                fail=f, bp_converged=cv)
+            np.savez_compressed(os.path.join(
+                a.out, f"{a.label}_p{p}_{arm}_seed{a.seed}.npz"),
+                                fail=f,
+                                bp_converged=cv)
         del decoders
 
 

--- a/docs/sphinx/performance/index.rst
+++ b/docs/sphinx/performance/index.rst
@@ -4,19 +4,18 @@ Performance Studies
 In-depth performance studies of CUDA-Q QEC decoders on NVIDIA GPUs -- measuring
 decode latency, logical error rate, and the trade-offs behind decoder tuning knobs.
 
-The first study shows how **gamma ensembling** narrows the Relay BP decode-latency
-tail, improving the logical error rate under hard decode deadlines by up to **~89x**
-on bivariate-bicycle codes (measured on a single GB200 with CUDA-Q QEC 0.7.0).
-
-The second study shows how **relay solution recording** replaces a per-``stop_nconv``
-sweep of full decode runs with a single recording run plus offline post-processing,
-reproducing every RelayBP-N result exactly from one GPU pass.
-
-The third study shows how **min-LLR OSD initialization** (``osd_init_method="min_llr"``)
-lets a 10-iteration BP+OSD decoder beat a 60-iteration one by up to **~100x** in logical
-error rate on joint-XYZ circuit-level DEMs of bivariate-bicycle codes, and makes
-correlated (joint XYZ) BP+OSD decoding more accurate than uncorrelated (split X/Z)
-decoding.
+* :ref:`Gamma ensembles <ensemble_gamma_user_guide>` -- how ensembling Relay BP gamma
+  trajectories narrows the decode-latency tail, improving the logical error rate under
+  hard decode deadlines by up to **~89x** on bivariate-bicycle codes (measured on a
+  single GB200 with CUDA-Q QEC 0.7.0).
+* :ref:`Relay solution recording <relay_solutions_user_guide>` -- how recording every
+  Relay BP convergence replaces a per-``stop_nconv`` sweep of full decode runs with one
+  recording run plus offline post-processing, reproducing every RelayBP-N result exactly.
+* :ref:`Min-LLR OSD initialization <minllr_osd_user_guide>` -- how
+  ``osd_init_method="min_llr"`` lets a 10-iteration BP+OSD decoder beat a 60-iteration
+  one by up to **~100x** in logical error rate on joint-XYZ circuit-level DEMs of
+  bivariate-bicycle codes, and makes correlated (joint XYZ) BP+OSD decoding more accurate
+  than uncorrelated (split X/Z) decoding.
 
 .. toctree::
    :maxdepth: 1

--- a/docs/sphinx/performance/index.rst
+++ b/docs/sphinx/performance/index.rst
@@ -12,8 +12,15 @@ The second study shows how **relay solution recording** replaces a per-``stop_nc
 sweep of full decode runs with a single recording run plus offline post-processing,
 reproducing every RelayBP-N result exactly from one GPU pass.
 
+The third study shows how **min-LLR OSD initialization** (``osd_init_method="min_llr"``)
+lets a 10-iteration BP+OSD decoder beat a 60-iteration one by up to **~100x** in logical
+error rate on joint-XYZ circuit-level DEMs of bivariate-bicycle codes, and makes
+correlated (joint XYZ) BP+OSD decoding more accurate than uncorrelated (split X/Z)
+decoding.
+
 .. toctree::
    :maxdepth: 1
 
    Improving Relay BP Decoding With Gamma Ensembles <nv_qldpc_gamma_ensemble_user_guide>
    Sweeping Relay BP Stopping Criteria From a Single Run <nv_qldpc_relay_solutions_user_guide>
+   Improving BP+OSD Decoding With Min-LLR OSD Initialization <nv_qldpc_minllr_osd_user_guide>

--- a/docs/sphinx/performance/nv_qldpc_minllr_osd_user_guide.rst
+++ b/docs/sphinx/performance/nv_qldpc_minllr_osd_user_guide.rst
@@ -64,10 +64,10 @@ detectors of the basis being measured ("split X/Z", or *uncorrelated* decoding):
 Y error on a data qubit is a single, correctly-weighted mechanism in the joint DEM but
 is modeled as two independent X and Z errors in the split DEMs. In practice, however,
 BP+OSD has been observed to decode the *uncorrelated* problem more accurately. The
-Tesseract paper [Aghababaie Beni, Higgott, Shutty, `arXiv:2503.10988
-<https://arxiv.org/abs/2503.10988>`_] notes that the uncorrelated variant receives
-"much less information about the error model," yet is "significantly more accurate
-than correlated BPOSD." The paper attributes this behavior to trapping sets:
+Tesseract paper by Beni, Higgott and Shutty
+(`arXiv:2503.10988 <https://arxiv.org/abs/2503.10988>`_) notes that the uncorrelated
+variant receives "much less information about the error model," yet is "significantly
+more accurate than correlated BPOSD". The paper attributes this behavior to trapping sets:
 "Y-type errors can cause trapping sets in BP-based decoders when both bases of
 detectors are annotated." Overlapping X and Z stabilizers introduce short cycles
 through Y errors on their shared qubits, and the joint DEM contains more low-weight
@@ -84,8 +84,9 @@ Experiment
 ++++++++++
 
 The circuits are the bivariate-bicycle memory-Z experiments published with the
-Relay-BP decoder (`github.com/trmue/relay <https://github.com/trmue/relay>`_, in
-``tests/testdata/bicycle_bivariate/``, Apache-2.0): 6 and 12 rounds of syndrome
+Relay-BP decoder (`tests/testdata/bicycle_bivariate
+<https://github.com/trmue/relay/tree/main/tests/testdata/bicycle_bivariate>`_ in the
+`trmue/relay <https://github.com/trmue/relay>`_ repository, Apache-2.0): 6 and 12 rounds of syndrome
 extraction for ``[[72,12,6]]`` and ``[[144,12,12]]`` respectively, under uniform
 circuit-level depolarizing noise with one file per physical error rate. Two kinds of
 circuit-level DEM are built from them:
@@ -97,9 +98,12 @@ circuit-level DEM are built from them:
   detectors of the basis being decoded remain (the ``assets/benchmarks`` files in this
   repository; 2.2k and 8.8k mechanisms respectively).
 
-All arms decode the same sampled syndromes. An arm is stopped once it has observed
-100 logical failures or reached the shot cap; points with zero observed failures are
-shown as their 95% Wilson upper bound.
+Each decoder configuration under test is an *arm* of the experiment (the term comes
+from the benchmark script, whose ``--arms`` option selects them; the two compared here
+are BP60+OSD-CS10 and BP10-minLLR+OSD-CS10, and the matched-iteration controls below
+add two more). All arms decode the same sampled syndromes, so comparisons between arms
+are paired. An arm is stopped once it has observed 100 logical failures or reached the
+shot cap; points with zero observed failures are shown as their 95% Wilson upper bound.
 
 .. list-table:: Decoder and experiment parameters
    :header-rows: 1
@@ -180,9 +184,28 @@ Ten iterations are sufficient for the configuration evaluated here. Compared wit
 60-iteration baseline, this uses six times fewer BP iterations while achieving a lower
 logical error rate.
 
+Controls: Ordering Versus Iteration Count
+++++++++++++++++++++++++++++++++++++++++++
+
+The two arms above differ in both ``max_iterations`` and ``osd_init_method``. To
+attribute the improvement, two matched-iteration controls were run on the same
+syndromes: BP10+OSD-CS10 (10 iterations, default ordering) and BP60-minLLR+OSD-CS10
+(60 iterations, min-LLR ordering). Dashed curves are the controls, drawn in the hue of
+the arm that shares their OSD ordering.
+
+.. image:: ../../../assets/docs/minllr_osd_controls.png
+   :align: center
+   :alt: LER versus physical error rate per DEM, with matched-iteration controls
+
+The results show that min-LLR ordering accounts for nearly all of the accuracy
+improvement. Increasing BP from 10 to 60 iterations without changing the
+ordering has little effect. With min-LLR ordering, the additional iterations
+provide a smaller, code-dependent benefit. Ten iterations therefore offer a
+strong cost-accuracy tradeoff, retaining most of the gain with about one sixth
+of the BP work.
+
 See Also
 ++++++++
 
 * :ref:`Quantum Low-Density Parity-Check Decoder <qldpc_decoder>` -- the nv-qldpc-decoder overview
-* :ref:`Improving Relay BP Decoding With Gamma Ensembles <ensemble_gamma_user_guide>`
 * :ref:`C++ <nv_qldpc_decoder_api_cpp>` and :ref:`Python <nv_qldpc_decoder_api_python>` API reference

--- a/docs/sphinx/performance/nv_qldpc_minllr_osd_user_guide.rst
+++ b/docs/sphinx/performance/nv_qldpc_minllr_osd_user_guide.rst
@@ -1,0 +1,202 @@
+.. The data and figures on this page are reproducible with the scripts in
+   benchmarks/qec/nv_qldpc_minllr_osd/ (see the README there for the circuits,
+   parameter table, stopping rule and expected runtime).
+   Tested at:
+     cudaqx  04719bc3dd98540b34976da33f8959061d4f9445
+     stim    v1.16.0
+
+.. _minllr_osd_user_guide:
+
+Improving BP+OSD Decoding With Min-LLR OSD Initialization
+==========================================================
+
+Belief propagation followed by ordered-statistics decoding (BP+OSD) is the standard
+post-processor for quantum LDPC codes: when BP fails to converge, OSD sorts the
+columns of the parity-check matrix by how likely BP believes each error is, solves
+the syndrome on the most likely columns, and optionally searches low-weight
+alternatives (OSD-CS). The quality of the OSD solution therefore depends on the
+quality of that column ordering.
+
+By default the ordering is taken from the marginal log-likelihood ratios (LLRs)
+after the *last* BP iteration. On circuit-level detector error models, BP that has
+not converged is frequently oscillating: a column that BP was confident about at
+iteration 6 may look unremarkable at iteration 60. The NV-qLDPC decoder's
+``osd_init_method="min_llr"`` option instead orders columns by the *minimum*
+marginal LLR each column reached over all BP iterations, so a column that was
+confident of an error at *any* point in the trajectory sorts first. The running
+minimum is tracked inside the BP kernel, so it costs no extra memory traffic and
+needs no LLR history buffer.
+
+.. code-block:: python
+
+    import cudaq_qec as qec
+
+    # From a circuit-level DEM of the code:
+    #   H            detector-error matrix (detectors x error mechanisms)
+    #   L            observables-flips matrix (observables x error mechanisms)
+    #   error_rates  prior probability of each error mechanism
+    decoder = qec.get_decoder(
+        "nv-qldpc-decoder", H, error_rate_vec=error_rates,
+        O=L,                                  # decode straight to observables
+        use_sparsity=True, use_osd=True,
+        osd_method=3, osd_order=10,           # OSD combination sweep, lambda = 10
+        max_iterations=10,                    # only 10 BP iterations ...
+        osd_init_method="min_llr",            # ... ordered by the running-min LLR
+        bp_batch_size=2048)
+
+    # With O given, each result is the predicted observable flips (k bits),
+    # not a correction vector; compare it directly to the measured observables.
+    results = decoder.decode_batch(syndromes)
+    predicted = [r.result for r in results]
+
+Note the iteration count: ten BP iterations, not the 50-100 that BP+OSD configurations
+usually run. With the min-LLR ordering the BP stage only has to *visit* the right
+columns at some point, not settle on them, and a short trajectory does that. Below we
+compare this configuration (BP10-minLLR+OSD-CS10) against the conventional BP60+OSD-CS10
+on bivariate-bicycle (BB) codes as a function of the physical error rate.
+
+Why the ordering matters so much: correlated decoding and Y errors
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+A circuit-level DEM that annotates both the X- and Z-type detectors ("joint XYZ", or
+*correlated* decoding) carries strictly more information than one that keeps only the
+detectors of the basis being measured ("split X/Z", or *uncorrelated* decoding): a
+Y error on a data qubit is a single, correctly-weighted mechanism in the joint DEM but
+is modeled as two independent X and Z errors in the split DEMs. In practice, however,
+BP+OSD has been observed to decode the *uncorrelated* problem more accurately. The
+Tesseract paper [Aghababaie Beni, Higgott, Shutty, `arXiv:2503.10988
+<https://arxiv.org/abs/2503.10988>`_] benchmarks against uncorrelated BP+OSD for
+exactly this reason, noting that "the uncorrelated variant of BPOSD receives much less
+information about the error model" yet is "significantly more accurate than correlated
+BPOSD", and explains the effect: "Y-type errors can cause trapping sets in BP-based
+decoders when both bases of detectors are annotated" -- every overlapping pair of X and
+Z stabilizers produces a 4-cycle through the Y errors on their shared qubits, and the
+joint DEM also has more low-weight degenerate configurations (an X and a Z error on the
+same qubit are indistinguishable from, and comparable in probability to, a Y error).
+"Both degeneracy and short cycles in the Tanner graph are known to be problematic for
+BP-based decoders."
+
+Trapping sets and degeneracy are precisely the situations in which BP oscillates rather
+than converges, and in which the *final* marginals are a poor summary of what BP
+learned. Ordering OSD by the running-minimum LLR recovers the columns that BP was
+confident about at some point in the trajectory, before the oscillation set in. The
+experiment below shows that with ``min_llr`` the correlated (joint XYZ) BP+OSD decoder
+not only stops losing to the uncorrelated one but beats it, so that -- to our knowledge
+for the first time with BP+OSD -- decoding the fully correlated error model is strictly
+better than decoding the split model.
+
+Experiment
+++++++++++
+
+The circuits are the bivariate-bicycle memory-Z experiments published with the
+Relay-BP decoder (`github.com/trmue/relay <https://github.com/trmue/relay>`_, in
+``tests/testdata/bicycle_bivariate/``, Apache-2.0): 6 and 12 rounds of syndrome
+extraction for ``[[72,12,6]]`` and ``[[144,12,12]]`` respectively, under uniform
+circuit-level depolarizing noise with one file per physical error rate. Two kinds of
+circuit-level DEM are built from them:
+
+* **joint XYZ** -- the circuits as published, which annotate both the X- and Z-check
+  detectors; the DEM has all circuit-level error mechanisms (about 16k for
+  ``[[72,12,6]]``, 68k for ``[[144,12,12]]``).
+* **split X/Z** -- the same circuits with the X-check detectors removed, so only the
+  detectors of the basis being decoded remain (the ``assets/benchmarks`` files in this
+  repository; 2.2k and 8.8k mechanisms respectively).
+
+All arms decode the same sampled syndromes. An arm is stopped once it has observed
+100 logical failures or reached the shot cap; points with zero observed failures are
+shown as their 95% Wilson upper bound.
+
+.. list-table:: Decoder and experiment parameters
+   :header-rows: 1
+   :widths: 32 68
+
+   * - Parameter
+     - Value
+   * - GPU
+     - NVIDIA GB200
+   * - Codes
+     - ``[[72,12,6]]`` (6 rounds), ``[[144,12,12]]`` (12 rounds)
+   * - Noise model
+     - uniform circuit-level, ``p`` swept from 0.001 to 0.005 (``[[72,12,6]]``) and 0.002 to 0.006 (``[[144,12,12]]``)
+   * - Shot cap
+     - 200,000 (``[[72,12,6]]`` and split X/Z), 100,000 (``[[144,12,12]]`` joint XYZ);
+       the ``[[72,12,6]]`` DEMs were sampled a second time with an independent seed and
+       a 1000-failure stopping rule, and the ``[[144,12,12]]`` joint-XYZ min-LLR point at
+       ``p = 0.002`` was extended with two further independent 1,000,000-shot samples
+   * - Stopping rule
+     - 100 logical failures per arm (pooled over the independent samples above)
+   * - ``bp_method``
+     - 0 (sum-product, default)
+   * - ``max_iterations``
+     - 60 (baseline) / 10 (min-LLR arms)
+   * - ``use_osd``
+     - True
+   * - ``osd_method`` / ``osd_order``
+     - 3 (combination sweep) / 10
+   * - ``osd_init_method``
+     - ``"final_llr"`` (default) / ``"min_llr"``
+   * - ``use_sparsity``
+     - True
+   * - ``bp_batch_size``
+     - 2048
+   * - Priors
+     - ``error_rate_vec`` from the DEM; observables decoded via ``O=L``
+
+Results
++++++++
+
+For each code, the same memory-Z circuit and the same sampled syndromes are decoded
+two ways: dashed, faded curves use the split X/Z DEM (uncorrelated decoding), solid
+curves the joint XYZ DEM (correlated decoding). Orange is the conventional
+BP60+OSD-CS10, blue is BP10-minLLR+OSD-CS10. Shaded bands are 95% Wilson intervals;
+each point is stopped at 100 or more logical failures.
+
+.. image:: ../../../assets/docs/minllr_osd_joint_vs_split.png
+   :align: center
+   :alt: LER versus physical error rate, joint XYZ vs split X/Z DEM, default vs min-LLR OSD ordering
+
+Three observations:
+
+1. **With the default ordering, correlated decoding loses** (solid orange above dashed
+   orange). This reproduces the Tesseract paper's observation: the correlated decoder is
+   *worse* than the uncorrelated one by 6x-7x for ``[[72,12,6]]`` at ``p`` <= 0.002 and by
+   14x-19x for ``[[144,12,12]]`` at ``p`` = 0.002-0.003, despite having strictly more
+   information about the noise.
+
+2. **The min-LLR ordering removes the penalty and inverts it** (solid blue below dashed
+   blue). On the joint XYZ DEMs the change from BP60+OSD-CS10 to BP10-minLLR+OSD-CS10
+   lowers the logical error rate by 3.6x at ``p = 0.005``, 11x at 0.003, 25x at 0.002 and
+   36x at 0.001 (2.0e-3 vs 5.5e-5) for ``[[72,12,6]]``, and by 2.4x at ``p = 0.006``, 5x at
+   0.005, 15x at 0.004, 46x at 0.003 (4.5e-2 vs 9.7e-4) and 117x at ``p = 0.002`` (3.5e-3 vs
+   3.0e-5, the latter from 63 failures in 2.1 million shots) for ``[[144,12,12]]``. The gap
+   widens as ``p`` falls because the min-LLR curves keep the steep low-``p`` slope of about
+   5 while the default-ordering curves flatten toward saturation. The correlated min-LLR
+   decoder now beats the uncorrelated one on both codes: by 2.5x-3.6x for ``[[72,12,6]]`` at
+   ``p`` <= 0.002 (5.5e-5 vs 2.0e-4 at ``p = 0.001``) and 1.2x-1.6x at higher rates, and by
+   2.0x at ``p = 0.002`` (3.0e-5 vs 6.0e-5) and 1.3x at ``p = 0.003`` for ``[[144,12,12]]``,
+   with ``p`` >= 0.004 within noise. To our knowledge this is the first BP+OSD
+   configuration for which decoding the full correlated circuit-level model is at least
+   as accurate as decoding the split model at every rate measured, and better wherever
+   the two are resolvable.
+
+3. **On the split X/Z DEMs the ordering matters much less** (dashed blue only modestly
+   below dashed orange): 1.2x-1.6x for ``[[72,12,6]]`` and 1.1x-3.1x for ``[[144,12,12]]``,
+   largest at the lowest rate. Those DEMs have no Y-induced 4-cycles, so BP oscillates
+   less and the final marginals are already a reasonable ordering. The min-LLR gain is
+   concentrated exactly where the trapping sets are.
+
+On the iteration count: BP converges on only about 1% of joint-XYZ syndromes within 10
+iterations at these rates (and on well under half even at 60 for ``p`` >= 0.002), so on
+those DEMs the decoder
+is effectively "OSD with a good ordering", and ten iterations are enough to produce
+that ordering. We have not swept the iteration count systematically here; anecdotally,
+comparable results have been seen with as few as five iterations, which suggests the
+useful signal sits in the earliest part of the BP trajectory. The savings are real: six
+times fewer BP iterations than the baseline, at a lower logical error rate.
+
+See Also
+++++++++
+
+* :ref:`Quantum Low-Density Parity-Check Decoder <qldpc_decoder>` -- the nv-qldpc-decoder overview
+* :ref:`Improving Relay BP Decoding With Gamma Ensembles <ensemble_gamma_user_guide>`
+* :ref:`C++ <nv_qldpc_decoder_api_cpp>` and :ref:`Python <nv_qldpc_decoder_api_python>` API reference

--- a/docs/sphinx/performance/nv_qldpc_minllr_osd_user_guide.rst
+++ b/docs/sphinx/performance/nv_qldpc_minllr_osd_user_guide.rst
@@ -7,11 +7,11 @@
 
 .. _minllr_osd_user_guide:
 
-Improving BP+OSD Decoding With Min-LLR OSD Initialization
-==========================================================
+Using Min-LLR OSD Initialization with BP+OSD
+============================================
 
-Belief propagation followed by ordered-statistics decoding (BP+OSD) is the standard
-post-processor for quantum LDPC codes: when BP fails to converge, OSD sorts the
+Belief propagation followed by ordered-statistics decoding (BP+OSD) is commonly used
+to decode quantum LDPC codes. When BP fails to converge, OSD sorts the
 columns of the parity-check matrix by how likely BP believes each error is, solves
 the syndrome on the most likely columns, and optionally searches low-weight
 alternatives (OSD-CS). The quality of the OSD solution therefore depends on the
@@ -24,8 +24,8 @@ iteration 6 may look unremarkable at iteration 60. The NV-qLDPC decoder's
 ``osd_init_method="min_llr"`` option instead orders columns by the *minimum*
 marginal LLR each column reached over all BP iterations, so a column that was
 confident of an error at *any* point in the trajectory sorts first. The running
-minimum is tracked inside the BP kernel, so it costs no extra memory traffic and
-needs no LLR history buffer.
+minimum is tracked inside the BP kernel and does not require storing the full LLR
+history.
 
 .. code-block:: python
 
@@ -50,40 +50,35 @@ needs no LLR history buffer.
     predicted = [r.result for r in results]
 
 Note the iteration count: ten BP iterations, not the 50-100 that BP+OSD configurations
-usually run. With the min-LLR ordering the BP stage only has to *visit* the right
-columns at some point, not settle on them, and a short trajectory does that. Below we
-compare this configuration (BP10-minLLR+OSD-CS10) against the conventional BP60+OSD-CS10
-on bivariate-bicycle (BB) codes as a function of the physical error rate.
+usually run. Min-LLR ordering can use information encountered before BP converges,
+which permits a shorter BP trajectory. Below we compare this configuration
+(BP10-minLLR+OSD-CS10) against the conventional BP60+OSD-CS10 on bivariate-bicycle
+(BB) codes as a function of the physical error rate.
 
-Why the ordering matters so much: correlated decoding and Y errors
-+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+Column Ordering Importance and Sensitivity
+++++++++++++++++++++++++++++++++++++++++++
 
 A circuit-level DEM that annotates both the X- and Z-type detectors ("joint XYZ", or
-*correlated* decoding) carries strictly more information than one that keeps only the
+*correlated* decoding) retains more information than one that keeps only the
 detectors of the basis being measured ("split X/Z", or *uncorrelated* decoding): a
 Y error on a data qubit is a single, correctly-weighted mechanism in the joint DEM but
 is modeled as two independent X and Z errors in the split DEMs. In practice, however,
 BP+OSD has been observed to decode the *uncorrelated* problem more accurately. The
 Tesseract paper [Aghababaie Beni, Higgott, Shutty, `arXiv:2503.10988
-<https://arxiv.org/abs/2503.10988>`_] benchmarks against uncorrelated BP+OSD for
-exactly this reason, noting that "the uncorrelated variant of BPOSD receives much less
-information about the error model" yet is "significantly more accurate than correlated
-BPOSD", and explains the effect: "Y-type errors can cause trapping sets in BP-based
-decoders when both bases of detectors are annotated" -- every overlapping pair of X and
-Z stabilizers produces a 4-cycle through the Y errors on their shared qubits, and the
-joint DEM also has more low-weight degenerate configurations (an X and a Z error on the
-same qubit are indistinguishable from, and comparable in probability to, a Y error).
-"Both degeneracy and short cycles in the Tanner graph are known to be problematic for
-BP-based decoders."
+<https://arxiv.org/abs/2503.10988>`_] notes that the uncorrelated variant receives
+"much less information about the error model," yet is "significantly more accurate
+than correlated BPOSD." The paper attributes this behavior to trapping sets:
+"Y-type errors can cause trapping sets in BP-based decoders when both bases of
+detectors are annotated." Overlapping X and Z stabilizers introduce short cycles
+through Y errors on their shared qubits, and the joint DEM contains more low-weight
+degenerate configurations. As the authors note, "both degeneracy and short cycles in
+the Tanner graph are known to be problematic for BP-based decoders." These effects can
+prevent BP from converging and make its final marginals a poor basis for OSD ordering.
 
-Trapping sets and degeneracy are precisely the situations in which BP oscillates rather
-than converges, and in which the *final* marginals are a poor summary of what BP
-learned. Ordering OSD by the running-minimum LLR recovers the columns that BP was
-confident about at some point in the trajectory, before the oscillation set in. The
-experiment below shows that with ``min_llr`` the correlated (joint XYZ) BP+OSD decoder
-not only stops losing to the uncorrelated one but beats it, so that -- to our knowledge
-for the first time with BP+OSD -- decoding the fully correlated error model is strictly
-better than decoding the split model.
+Running-minimum LLR ordering preserves information from earlier BP iterations instead
+of relying only on the final marginals. In the experiment below, this change makes the
+correlated decoder at least as accurate as the split decoder across the measured
+physical error rates.
 
 Experiment
 ++++++++++
@@ -163,36 +158,27 @@ Three observations:
    14x-19x for ``[[144,12,12]]`` at ``p`` = 0.002-0.003, despite having strictly more
    information about the noise.
 
-2. **The min-LLR ordering removes the penalty and inverts it** (solid blue below dashed
-   blue). On the joint XYZ DEMs the change from BP60+OSD-CS10 to BP10-minLLR+OSD-CS10
-   lowers the logical error rate by 3.6x at ``p = 0.005``, 11x at 0.003, 25x at 0.002 and
-   36x at 0.001 (2.0e-3 vs 5.5e-5) for ``[[72,12,6]]``, and by 2.4x at ``p = 0.006``, 5x at
-   0.005, 15x at 0.004, 46x at 0.003 (4.5e-2 vs 9.7e-4) and 117x at ``p = 0.002`` (3.5e-3 vs
-   3.0e-5, the latter from 63 failures in 2.1 million shots) for ``[[144,12,12]]``. The gap
-   widens as ``p`` falls because the min-LLR curves keep the steep low-``p`` slope of about
-   5 while the default-ordering curves flatten toward saturation. The correlated min-LLR
-   decoder now beats the uncorrelated one on both codes: by 2.5x-3.6x for ``[[72,12,6]]`` at
-   ``p`` <= 0.002 (5.5e-5 vs 2.0e-4 at ``p = 0.001``) and 1.2x-1.6x at higher rates, and by
-   2.0x at ``p = 0.002`` (3.0e-5 vs 6.0e-5) and 1.3x at ``p = 0.003`` for ``[[144,12,12]]``,
-   with ``p`` >= 0.004 within noise. To our knowledge this is the first BP+OSD
-   configuration for which decoding the full correlated circuit-level model is at least
-   as accurate as decoding the split model at every rate measured, and better wherever
-   the two are resolvable.
+2. **The min-LLR ordering removes this penalty and makes correlated decoding
+   advantageous** (solid blue below dashed blue). On the joint XYZ DEMs, min-LLR ordering
+   reduces the logical error rate increasingly as ``p`` falls, reaching improvements of
+   36x for ``[[72,12,6]]`` and 117x for ``[[144,12,12]]`` at the lowest measured rates.
+   Unlike the default-ordering curves, the min-LLR curves retain a steep low-``p`` slope
+   rather than flattening toward saturation. With min-LLR ordering, correlated decoding
+   is at least as accurate as split decoding at every measured rate and is clearly better
+   where the confidence intervals separate.
 
 3. **On the split X/Z DEMs the ordering matters much less** (dashed blue only modestly
    below dashed orange): 1.2x-1.6x for ``[[72,12,6]]`` and 1.1x-3.1x for ``[[144,12,12]]``,
    largest at the lowest rate. Those DEMs have no Y-induced 4-cycles, so BP oscillates
-   less and the final marginals are already a reasonable ordering. The min-LLR gain is
-   concentrated exactly where the trapping sets are.
+   less and the final marginals are already a reasonable ordering. This is consistent
+   with min-LLR ordering being most useful when short cycles impede BP convergence.
 
 On the iteration count: BP converges on only about 1% of joint-XYZ syndromes within 10
 iterations at these rates (and on well under half even at 60 for ``p`` >= 0.002), so on
-those DEMs the decoder
-is effectively "OSD with a good ordering", and ten iterations are enough to produce
-that ordering. We have not swept the iteration count systematically here; anecdotally,
-comparable results have been seen with as few as five iterations, which suggests the
-useful signal sits in the earliest part of the BP trajectory. The savings are real: six
-times fewer BP iterations than the baseline, at a lower logical error rate.
+those DEMs the decoder relies primarily on OSD, with BP providing the column ordering.
+Ten iterations are sufficient for the configuration evaluated here. Compared with the
+60-iteration baseline, this uses six times fewer BP iterations while achieving a lower
+logical error rate.
 
 See Also
 ++++++++


### PR DESCRIPTION
Add a docs page demonstrating usage and potential benefits for the new `osd_init_method="min_llr"` option for the nv-qldpc-decoder.