### PR TITLE
[docs] Add NV-Fusion latency study docs and decoder benchmark

### DIFF
--- a/assets/docs/nv_fusion_block_schedule.png
+++ b/assets/docs/nv_fusion_block_schedule.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:44f4a9049918f95f23a47d3d38cf554e9536f065f134e44ea8d417f02edbbf12
+size 109391

--- a/assets/docs/nv_fusion_streaming_instance_latency.png
+++ b/assets/docs/nv_fusion_streaming_instance_latency.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:94411245f2585604f5a03a5b0083ad1eb7342d88467d9f51a781359f40fa72b0
+size 106297

--- a/assets/docs/nv_fusion_streaming_tail_latency.png
+++ b/assets/docs/nv_fusion_streaming_tail_latency.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:44e55de6d11addd133ec9ea91825a4b854035ebba69d5d70bb7bf306233b6814
-size 246414
+oid sha256:8eb026f276a1ec9078dcd07ef2cc02216d487202cf09ba3d657a5848fc5e190a
+size 244036

--- a/assets/docs/nv_fusion_streaming_tail_latency.png
+++ b/assets/docs/nv_fusion_streaming_tail_latency.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:44e55de6d11addd133ec9ea91825a4b854035ebba69d5d70bb7bf306233b6814
+size 246414

--- a/benchmarks/qec/CMakeLists.txt
+++ b/benchmarks/qec/CMakeLists.txt
@@ -1,0 +1,9 @@
+# ============================================================================ #
+# Copyright (c) 2026 NVIDIA Corporation & Affiliates.                          #
+# All rights reserved.                                                         #
+#                                                                              #
+# This source code and the accompanying materials are made available under     #
+# the terms of the Apache License 2.0 which accompanies this distribution.     #
+# ============================================================================ #
+
+add_subdirectory(decoder_latency)

--- a/benchmarks/qec/decoder_latency/CMakeLists.txt
+++ b/benchmarks/qec/decoder_latency/CMakeLists.txt
@@ -1,0 +1,34 @@
+# ============================================================================ #
+# Copyright (c) 2026 NVIDIA Corporation & Affiliates.                          #
+# All rights reserved.                                                         #
+#                                                                              #
+# This source code and the accompanying materials are made available under     #
+# the terms of the Apache License 2.0 which accompanies this distribution.     #
+# ============================================================================ #
+
+find_package(Threads REQUIRED)
+
+# General decoder benchmark: compares any registered plugin by name.
+# EXCLUDE_FROM_ALL keeps it out of normal builds while leaving the target
+# available independently of whether the unit-test suite is enabled.
+add_executable(benchmark-qec-decoder EXCLUDE_FROM_ALL
+    benchmark-qec-decoder.cpp
+    benchmark_instance_pool.cpp)
+target_include_directories(benchmark-qec-decoder PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR})
+target_link_libraries(benchmark-qec-decoder PRIVATE
+    cudaq-qec-decoders
+    libstim
+    Threads::Threads)
+set_target_properties(benchmark-qec-decoder PROPERTIES
+    RUNTIME_OUTPUT_DIRECTORY
+    "${CMAKE_BINARY_DIR}/benchmarks/qec/decoder_latency"
+    BUILD_RPATH
+    "${CMAKE_BINARY_DIR}/lib;${CMAKE_BINARY_DIR}/lib/decoder-plugins")
+
+# Plugins are discovered through BUILD_RPATH. Build the directly supported
+# comparison plugins before the benchmark.
+add_dependencies(benchmark-qec-decoder cudaq-qec-pymatching)
+if(TARGET cudaq-qec-nv-fusion-decoder)
+    add_dependencies(benchmark-qec-decoder cudaq-qec-nv-fusion-decoder)
+endif()

--- a/benchmarks/qec/decoder_latency/README.md
+++ b/benchmarks/qec/decoder_latency/README.md
@@ -1,0 +1,243 @@
+# QEC decoder latency benchmark
+
+`benchmark-qec-decoder` measures latency, throughput, and logical error rate
+for registered CUDA-QX QEC decoders. It generates Stim rotated-surface-code
+Z-memory circuits and can sweep code distance, round count, physical noise,
+decoder parameters, and concurrent decoder instances.
+
+The benchmark supports two execution modes:
+
+- `batch`: times one `decode()` call per shot.
+- `stream`: enqueues detector rounds individually and reports both total
+  decoder work and the latency from the final round through observable
+  correction readout.
+
+## Build
+
+Configure CUDA-QX from the repository root. The benchmark does not require the
+unit-test suite:
+
+```bash
+cmake -G Ninja -S . -B build \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DCUDAQ_INSTALL_DIR=/usr/local/cudaq \
+  -DCUDAQ_DIR=/usr/local/cudaq/lib/cmake/cudaq \
+  -DCUDAQX_ENABLE_LIBS=qec \
+  -DCUDAQX_INCLUDE_TESTS=OFF \
+  -DCUDAQX_BINDINGS_PYTHON=OFF
+
+cmake --build build --target benchmark-qec-decoder -j$(nproc)
+```
+
+The executable is written to:
+
+```text
+build/benchmarks/qec/decoder_latency/benchmark-qec-decoder
+```
+
+NV-Fusion is enabled by default and requires access to its private dependency.
+Pass `-DCUDAQ_QEC_BUILD_FUSION_DECODER=OFF` when it is not needed.
+
+## Example
+
+Run from the build directory:
+
+```bash
+./benchmarks/qec/decoder_latency/benchmark-qec-decoder \
+  --decoders pymatching,nv-fusion-decoder \
+  --distances 5,7,13 \
+  --rounds 100,1000,10000 \
+  --mode stream \
+  --round_interval_us 1 \
+  --shots 1000 \
+  --csv
+```
+
+Use `--help` for all sweep, decoder-parameter, output, and CPU-affinity
+options. Repeated `--param KEY=VALUE` arguments are converted according to the
+selected decoder's registered parameter schema.
+
+## Workload and sweep behavior
+
+The benchmark generates a Stim `rotated_memory_z` circuit for every requested
+distance, round count, and noise value. The noise value is applied to
+after-Clifford depolarization, reset flips, measurement flips, and inter-round
+data depolarization. Stim uses a fixed random seed so decoders at the same
+sweep point receive the same sampled shots.
+
+The sweep is the Cartesian product of:
+
+- `--decoders NAME[,NAME,...]` (default: `pymatching`)
+- `--distance N` or `--distances N[,N,...]` (default: 5)
+- `--rounds N[,N,...]` (default: the distance)
+- `--noise P` or `--noises P[,P,...]` (default: 0.001)
+- `--decoder_instances N[,N,...]` (default: 1)
+
+Option names accept either hyphens or underscores.
+
+Distances must be odd and at least 3. Each circuit shot contains one more
+detector round than the requested stabilizer-round count because final data
+readout contributes a detector round.
+
+`--warmup N` controls untimed shots (default: 20), and `--shots N` controls
+timed shots **per decoder instance** (default: 500). Increasing the instance
+count therefore increases the total samples and work; it does not divide a
+fixed shot pool.
+
+## Decoder options
+
+Use a repeatable `--param KEY=VALUE` to pass decoder-specific settings:
+
+```bash
+--param num_threads=8 --param block_leaf_size=50
+```
+
+Values are converted using the selected decoder's registered schema. Boolean,
+integer, floating-point, and string parameters are supported. A key absent
+from a decoder's schema is skipped for that decoder, allowing one command to
+compare decoders with different option sets.
+
+The benchmark supplies `O` and `error_rate_vec` to every decoder by default.
+It also supplies temporal detector-round information to NV-Fusion.
+`--no_O` withholds `O` during construction and configures it afterward,
+matching the real-time server's non-TensorRT construction path.
+
+`--block_leaf_size N` is a convenience option for decoders whose schema
+supports that parameter. Omitting it lets the decoder select its own schedule.
+
+When `--param num_threads=0` is used with multiple instances, the benchmark
+replaces zero with a per-instance share of the available CPUs. It reserves
+CPUs for the instance thread so the decoder's worker pool does not contend
+with the thread driving its fork-join work. Explicit nonzero thread counts are
+forwarded unchanged.
+
+## What is timed
+
+Select `--mode batch`, `--mode stream`, or `--mode both` (the default).
+
+In batch mode:
+
+- The stopwatch wraps only `decode()`.
+- Observable comparison and logical-error bookkeeping are outside the timed
+  region.
+- Reported p50, p90, and p99 values are per-shot decode latencies.
+
+In streaming mode:
+
+- The syndrome is enqueued one detector round at a time.
+- Each `enqueue_syndrome()` call is timed separately.
+- Per-shot decoder work is the sum of those calls plus correction readout.
+- Streaming tail latency covers the final round's enqueue and
+  `get_obs_corrections()`. This is the response time after the final syndrome
+  round arrives.
+- Pacing waits are excluded from decoder-work and tail-latency samples.
+
+`--round_interval_us T` paces detector rounds with a busy-wait. Pacing models a
+real-time arrival rate, but it also occupies the instance's CPU between rounds.
+Without this option, rounds are enqueued as quickly as possible.
+
+The `rounds/s` value uses a separate wall-clock interval around each
+instance's complete timed shot loop. It includes pacing, decoder reset, and
+bookkeeping, while excluding decoder construction, warmup, and thread
+creation. Rates are computed per instance and then summed. Consequently, a
+paced run is capped near `1e6 / T` rounds/s per instance and measures whether
+the decoders keep up, not their unconstrained peak throughput.
+
+## Concurrent instances and CPU placement
+
+Each value passed to `--decoder_instances` creates that many independent
+decoder objects and drives them concurrently. A start gate ensures no
+instance begins its timed region before all instances have completed decoder
+construction and warmup. Latency samples are pooled across instances, while
+throughput is the sum of their independently measured rates.
+
+Each decoder is constructed and driven by the same instance thread. This
+preserves decoder implementations that bind their construction thread to a
+CUDA device.
+
+Instances are unpinned by default. `--pin_instances` divides the CPUs in the
+process's current affinity mask into non-overlapping, equal-sized blocks for
+each row. Any remainder is left idle. The instance pins itself before decoder
+construction, so worker threads created by the decoder inherit its CPU block.
+
+Manual placement is also available:
+
+- `--instance_core_base N`: first CPU assigned to instance zero.
+- `--instance_core_width W`: consecutive CPUs available to each instance.
+- `--instance_core_stride S`: distance between instance starting CPUs;
+  defaults to the width.
+
+Do not combine automatic and manual placement. Ensure the width can
+accommodate the decoder's internal worker count, and inspect the host's CPU,
+core, SMT, and NUMA topology before assuming adjacent CPU IDs are independent
+physical cores.
+
+## Output
+
+The human-readable report includes decoder, distance, rounds, instances,
+shots, noise, latency percentiles, detector rounds per second, and logical
+error rate. Streaming output has a separate table for final-round tail
+latency. Tables are printed after the requested point list finishes, so a long
+sweep can remain quiet until completion.
+
+`--csv` additionally emits rows prefixed with `csv,` for machine parsing. The
+CSV columns are:
+
+```text
+mode,id,decoder,d,rounds,det_rounds,instances,shots,total_shots,noise,
+p50,p90,p99,tail_p50,tail_p99,rounds_s,ler
+```
+
+Percentile resolution is limited by the sample count. With 1,000 timed shots
+per instance, p99 is approximately the tenth-slowest sample; use more shots
+or repeated runs for stable extreme-tail claims.
+
+## Supported decoders
+
+The benchmark accepts any name resolved by the C++ decoder registry, but a
+registered decoder is not necessarily compatible with the benchmark's current
+surface-code matrix input and flat parameter interface.
+
+The following decoders are supported directly:
+
+- `pymatching`: the default CPU comparison decoder.
+- `nv-fusion-decoder`: supports batch and native real-time streaming
+  measurements. The CMake option `CUDAQ_QEC_BUILD_FUSION_DECODER` must be
+  enabled.
+
+The CMake target explicitly builds these decoder plugins when they are
+available. Additional registered plugins must be built separately or added as
+target dependencies before the benchmark can discover them.
+
+## Decoders requiring additional work
+
+The following registered decoders are not currently supported as turnkey
+benchmark selections:
+
+- `chromobius`: requires a color-code detector error model. Supporting it
+  requires a color-code workload and a benchmark construction path that passes
+  a serialized DEM instead of the generated surface-code parity-check matrix.
+- `trt_decoder`: requires an ONNX model or TensorRT engine whose input and
+  output dimensions match the workload. It also needs an explicit CMake target
+  dependency and a documented model-specific benchmark configuration.
+- `sliding_window`: requires an inner decoder and nested
+  `inner_decoder_params`. The current `--param KEY=VALUE` interface cannot
+  construct that discriminated nested parameter map; add structured
+  configuration-file or nested-parameter support.
+- `single_error_lut` and `multi_error_lut`: registry construction is possible,
+  but lookup-table growth makes the generated sweep impractical beyond very
+  small codes. Supporting meaningful comparisons requires constrained
+  distance/round validation and decoder-appropriate defaults.
+- `single_error_lut_example`: this is an example plugin rather than a
+  production performance target. It would need an explicit build dependency
+  and the same small-workload restrictions as the LUT decoders.
+
+When adding another decoder, verify all of the following:
+
+1. Its plugin target is built before `benchmark-qec-decoder`.
+2. It accepts the generated `H`, `O`, and error-rate vector, or the benchmark
+   provides the decoder's required DEM/model input.
+3. Required parameters can be represented by the CLI.
+4. Its result represents the same observables used for logical-error checks.
+5. Streaming mode either has a meaningful real-time implementation or is
+   clearly documented as using the base-class batch-at-boundary behavior.

--- a/benchmarks/qec/decoder_latency/benchmark-qec-decoder.cpp
+++ b/benchmarks/qec/decoder_latency/benchmark-qec-decoder.cpp
@@ -1,0 +1,1270 @@
+/*******************************************************************************
+ * Copyright (c) 2026 NVIDIA Corporation & Affiliates.                         *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+// General-purpose latency and throughput benchmark for any registered
+// CUDA-QX QEC decoder plugin.  Generates rotated surface-code memory circuits
+// and sweeps over distances, round counts, and noise rates, running both the
+// batch decode() and streaming enqueue_syndrome() paths for each named decoder.
+// Results are printed in a single flat table that includes every sweep
+// dimension and a per-decoder integer ID.
+//
+// A sweep point can also be run on several concurrent decoder instances
+// (--decoder_instances): each instance is an independent decoder driven by its
+// own thread, which is how a real deployment decodes several logical qubits at
+// once.  Latency percentiles are pooled over all instances of a point, so they
+// describe the machine while every instance is loaded; rounds/s sums the rate
+// each instance held over its own window.  --shots counts timed shots *per
+// instance*, so --decoder_instances 1 reproduces the single-decoder numbers
+// exactly and higher counts add work rather than dividing it.
+//
+// Run with --help for the available knobs.
+//
+// Examples, where <decoder> is any name the plugin registry resolves:
+//   benchmark-qec-decoder --decoders <decoder>,<decoder>
+//   benchmark-qec-decoder \
+//     --decoders <decoder>,<decoder> \
+//     --distances 3,5,7,9 --rounds 5,10 --noises 0.001,0.005 \
+//     --param num_threads=4
+//   benchmark-qec-decoder --decoders <decoder> --decoder_instances 1,2,4,8
+//   benchmark-qec-decoder --decoders <decoder> \
+//     --decoder_instances 1,2,4,8 --pin_instances
+//   benchmark-qec-decoder --decoders <decoder> --param num_threads=4 \
+//     --decoder_instances 4 --instance_core_base 8 --instance_core_width 4
+//
+// Values for --param are auto-typed: "true"/"false" -> bool,
+// digits -> uint64, decimal -> double, otherwise -> string.
+
+#include "benchmark_instance_pool.h"
+#include "stim.h"
+#include "cudaq/qec/decoder.h"
+#include "cudaq/qec/decoder_config_schema.h"
+#include "cudaq/qec/pcm_utils.h"
+#include "cudaq/qec/sparse_binary_matrix.h"
+#include <algorithm>
+#include <chrono>
+#include <cmath>
+#include <cstdint>
+#include <cstring>
+#include <iomanip>
+#include <iostream>
+#include <memory>
+#include <random>
+#include <set>
+#include <string>
+#include <thread>
+#include <vector>
+
+namespace {
+
+using clock_type = std::chrono::steady_clock;
+using index_type = cudaq::qec::sparse_binary_matrix::index_type;
+using cudaq::qec::benchmark::allowed_cpus;
+using cudaq::qec::benchmark::concat_instance_samples;
+using cudaq::qec::benchmark::core_layout;
+using cudaq::qec::benchmark::divide_cpus;
+using cudaq::qec::benchmark::effective_stride;
+using cudaq::qec::benchmark::first_instance_error;
+using cudaq::qec::benchmark::instance_pool_result;
+using cudaq::qec::benchmark::instance_result;
+using cudaq::qec::benchmark::instance_sample_kind;
+using cudaq::qec::benchmark::instance_shot_offset;
+using cudaq::qec::benchmark::instance_work;
+using cudaq::qec::benchmark::resolve_instance_cpus;
+using cudaq::qec::benchmark::run_instances;
+using cudaq::qec::benchmark::sum_instance_results;
+using cudaq::qec::benchmark::worker_threads_per_instance;
+
+// ── Options
+// ───────────────────────────────────────────────────────────────────
+
+struct options {
+  std::vector<std::size_t> distances = {5};
+  // Empty rounds_list means "use distance" for each configuration.
+  std::vector<std::size_t> rounds_list;
+  std::vector<double> noises;
+  // Timed shots per decoder instance, so the instance count scales total work
+  // rather than splitting a fixed pool.
+  std::size_t shots = 500;
+  std::size_t warmup = 20;
+  std::vector<std::string> decoders;
+  // Concurrent decoder instances per sweep point. Empty means one instance.
+  std::vector<std::size_t> instances_list;
+  // CPU placement for the instances. A negative base disables pinning,
+  // matching the core_pinning convention in realtime/pipeline.h.
+  core_layout cores;
+  // Divide the available CPUs among each row's instances instead of taking a
+  // hand-written base/width/stride.
+  bool auto_pin = false;
+  // 0 = unset: the key is withheld so the decoder picks its own schedule.
+  // Otherwise forwarded as uint64 to decoders whose schema lists
+  // block_leaf_size.
+  std::size_t block_leaf_size = 0;
+  std::chrono::nanoseconds round_interval{0};
+  bool run_batch = true;
+  bool run_stream = true;
+  bool emit_csv = false;
+  // False reproduces the realtime server, which passes O only to trt_decoder.
+  bool pass_O = true;
+  std::vector<std::pair<std::string, std::string>> extra_params;
+};
+
+// CPU placement for a row running @p instances instances.
+//
+// Automatic placement depends on the instance count, so it cannot be resolved
+// once at startup: a --decoder_instances 1,2,4 sweep divides the machine three
+// different ways.
+core_layout layout_for(const options &opts, std::size_t instances) {
+  if (!opts.auto_pin)
+    return opts.cores;
+  return divide_cpus(instances, allowed_cpus());
+}
+
+void print_usage(const char *argv0) {
+  std::cout
+      << "Usage: " << argv0 << " [options]\n"
+      << "  --decoders NAME[,...]      plugins to compare (default: "
+         "pymatching)\n"
+      << "  --distance N               single distance (default 5)\n"
+      << "  --distances N[,N,...]      distances to sweep\n"
+      << "  --rounds N[,N,...]         round counts to sweep "
+         "(default=distance)\n"
+      << "  --noise P                  single noise value (default 0.001)\n"
+      << "  --noises P[,P,...]         noise values to sweep\n"
+      << "  --shots N                  timed shots per instance (default "
+         "500)\n"
+      << "  --warmup N                 untimed warmup shots (default 20)\n"
+      << "  --decoder_instances N[,...]\n"
+      << "                             concurrent whole decoders per point,\n"
+      << "                             one thread each (default 1)\n"
+      << "  --pin_instances            pin instances, dividing the available\n"
+      << "                             CPUs evenly among each row's\n"
+      << "                             instances (default: unpinned)\n"
+      << "  --instance_core_base N     place instances by hand: instance i on\n"
+      << "                             CPU N+i*stride\n"
+      << "  --instance_core_width W    CPUs per instance (default 1). Its\n"
+      << "                             decoder's own threads inherit the\n"
+      << "                             mask, so match a threaded decoder\n"
+      << "  --instance_core_stride S   CPUs between instances (default: same\n"
+      << "                             as width). Use 2 to skip SMT siblings\n"
+      << "  --block_leaf_size N        brickwall leaf height; omit to let the\n"
+      << "                             decoder choose its own schedule\n"
+      << "  --round_interval_us T      pace streaming rounds by T "
+         "microseconds\n"
+      << "  --mode M                   batch, stream, or both (default both)\n"
+      << "  --param KEY=VALUE          extra param forwarded to all decoders\n"
+      << "                             (repeatable; auto-typed)\n"
+      << "  --csv                      emit machine-readable CSV rows\n"
+      << "  --no_O                     withhold the O param, as the realtime\n"
+      << "                             server does for every non-trt decoder\n"
+      << "  --help                     show this message\n";
+}
+
+// ── Argument parsing
+// ──────────────────────────────────────────────────────────
+
+std::vector<std::string> split_csv_str(const std::string &text) {
+  std::vector<std::string> out;
+  std::size_t pos = 0;
+  while (pos <= text.size()) {
+    const auto comma = text.find(',', pos);
+    const auto piece = text.substr(pos, comma - pos);
+    if (!piece.empty())
+      out.push_back(piece);
+    if (comma == std::string::npos)
+      break;
+    pos = comma + 1;
+  }
+  return out;
+}
+
+std::vector<std::size_t> parse_size_list(const std::string &text) {
+  std::vector<std::size_t> out;
+  for (const auto &s : split_csv_str(text))
+    out.push_back(static_cast<std::size_t>(std::stoull(s)));
+  return out;
+}
+
+std::vector<double> parse_double_list(const std::string &text) {
+  std::vector<double> out;
+  for (const auto &s : split_csv_str(text))
+    out.push_back(std::stod(s));
+  return out;
+}
+
+bool parse_args(int argc, char **argv, options &opts, int &exit_code) {
+  // No value of this CLI starts with "--", so a token that does is the next
+  // option rather than this one's value. Catching that here turns
+  // "--shots --csv" into an error instead of a std::stoull throw, and stops a
+  // misspelled valueless flag from swallowing the option after it.
+  auto need_value = [&](int i) -> bool {
+    if (i + 1 < argc && std::string(argv[i + 1]).rfind("--", 0) != 0)
+      return true;
+    std::cerr << "error: " << argv[i]
+              << " requires a value (run --help to list the options)\n";
+    exit_code = 1;
+    return false;
+  };
+
+  for (int i = 1; i < argc; ++i) {
+    // Accept either spelling of an option name: every flag here is written
+    // with underscores, but the binary itself is hyphenated, which makes
+    // --pin-instances an easy slip for --pin_instances.
+    std::string arg = argv[i];
+    if (arg.rfind("--", 0) == 0)
+      std::replace(arg.begin() + 2, arg.end(), '-', '_');
+
+    if (arg == "--help" || arg == "-h") {
+      print_usage(argv[0]);
+      exit_code = 0;
+      return false;
+    }
+    if (arg == "--csv") {
+      opts.emit_csv = true;
+      continue;
+    }
+    if (arg == "--no_O") {
+      opts.pass_O = false;
+      continue;
+    }
+    if (arg == "--pin_instances") {
+      opts.auto_pin = true;
+      continue;
+    }
+    if (!need_value(i))
+      return false;
+    const char *const typed = argv[i];
+    const std::string val = argv[++i];
+
+    if (arg == "--decoders")
+      opts.decoders = split_csv_str(val);
+    else if (arg == "--distance") {
+      opts.distances.clear();
+      opts.distances.push_back(std::stoull(val));
+    } else if (arg == "--distances")
+      opts.distances = parse_size_list(val);
+    else if (arg == "--rounds")
+      opts.rounds_list = parse_size_list(val);
+    else if (arg == "--noise") {
+      opts.noises.clear();
+      opts.noises.push_back(std::stod(val));
+    } else if (arg == "--noises")
+      opts.noises = parse_double_list(val);
+    else if (arg == "--shots")
+      opts.shots = std::stoull(val);
+    else if (arg == "--warmup")
+      opts.warmup = std::stoull(val);
+    else if (arg == "--decoder_instances")
+      opts.instances_list = parse_size_list(val);
+    else if (arg == "--instance_core_base")
+      opts.cores.base = std::stoi(val);
+    else if (arg == "--instance_core_width")
+      opts.cores.width = std::stoull(val);
+    else if (arg == "--instance_core_stride")
+      opts.cores.stride = std::stoull(val);
+    else if (arg == "--block_leaf_size")
+      opts.block_leaf_size = std::stoull(val);
+    else if (arg == "--round_interval_us")
+      opts.round_interval = std::chrono::nanoseconds(
+          static_cast<int64_t>(std::llround(std::stod(val) * 1e3)));
+    else if (arg == "--mode") {
+      opts.run_batch = val == "batch" || val == "both";
+      opts.run_stream = val == "stream" || val == "both";
+      if (!opts.run_batch && !opts.run_stream) {
+        std::cerr << "error: --mode must be batch, stream, or both\n";
+        exit_code = 1;
+        return false;
+      }
+    } else if (arg == "--param") {
+      const auto eq = val.find('=');
+      if (eq == std::string::npos) {
+        std::cerr << "error: --param requires KEY=VALUE format\n";
+        exit_code = 1;
+        return false;
+      }
+      opts.extra_params.push_back({val.substr(0, eq), val.substr(eq + 1)});
+    } else {
+      std::cerr << "error: unknown option " << typed << "\n";
+      print_usage(argv[0]);
+      exit_code = 1;
+      return false;
+    }
+  } // end - for(i)
+
+  if (opts.decoders.empty())
+    opts.decoders.push_back("pymatching");
+  if (opts.noises.empty())
+    opts.noises.push_back(0.001);
+
+  if (opts.distances.empty()) {
+    std::cerr << "error: --distances needs at least one value\n";
+    exit_code = 1;
+    return false;
+  }
+  for (auto d : opts.distances) {
+    if (d < 3 || d % 2 == 0) {
+      std::cerr << "error: all distances must be odd and >= 3\n";
+      exit_code = 1;
+      return false;
+    }
+  }
+  if (opts.decoders.empty()) {
+    std::cerr << "error: --decoders needs at least one name\n";
+    exit_code = 1;
+    return false;
+  }
+  if (opts.shots == 0) {
+    std::cerr << "error: --shots must be positive\n";
+    exit_code = 1;
+    return false;
+  }
+  if (opts.instances_list.empty())
+    opts.instances_list.push_back(1);
+  for (auto n : opts.instances_list) {
+    if (n == 0) {
+      std::cerr << "error: --decoder_instances values must be positive\n";
+      exit_code = 1;
+      return false;
+    }
+  }
+  // --pin_instances computes the placement, so a hand-written one alongside it
+  // would be silently ignored.
+  if (opts.auto_pin &&
+      (opts.cores.base >= 0 || opts.cores.width > 1 || opts.cores.stride > 0)) {
+    std::cerr << "error: --pin_instances places instances automatically; drop "
+                 "it to use --instance_core_base/_width/_stride\n";
+    exit_code = 1;
+    return false;
+  }
+  // Width and stride only mean something next to a base; accepting them alone
+  // would silently discard the placement the user asked for.
+  if (opts.cores.base < 0 && (opts.cores.width > 1 || opts.cores.stride > 0)) {
+    std::cerr << "error: --instance_core_width and --instance_core_stride "
+                 "need --instance_core_base\n";
+    exit_code = 1;
+    return false;
+  }
+  // Reject an unhonorable pin now: the widest instance count decides how many
+  // CPUs the run needs, and finding out mid-sweep would throw away every point
+  // measured so far.
+  try {
+    for (const std::size_t n : opts.instances_list)
+      (void)resolve_instance_cpus(n - 1, layout_for(opts, n),
+                                  std::thread::hardware_concurrency());
+  } catch (const std::exception &e) {
+    std::cerr << "error: " << e.what() << "\n";
+    exit_code = 1;
+    return false;
+  }
+  if (opts.noises.empty()) {
+    std::cerr << "error: --noises needs at least one value\n";
+    exit_code = 1;
+    return false;
+  }
+  for (auto n : opts.noises) {
+    if (n <= 0.0 || n >= 1.0) {
+      std::cerr << "error: noise values must be in (0, 1)\n";
+      exit_code = 1;
+      return false;
+    }
+  }
+  return true;
+} // end - parse_args()
+
+// ── Circuit / DEM helpers
+// ─────────────────────────────────────────────────────
+
+struct benchmark_data {
+  stim::Circuit circuit;
+  stim::DetectorErrorModel dem;
+  std::vector<std::vector<cudaq::qec::float_t>> soft_syndromes;
+  std::vector<std::vector<uint8_t>> hard_syndromes;
+  std::vector<uint64_t> observable_masks;
+};
+
+benchmark_data generate_data(const options &opts, std::size_t distance,
+                             std::size_t rounds, double noise) {
+  stim::CircuitGenParameters gen(rounds, distance, "rotated_memory_z");
+  gen.after_clifford_depolarization = noise;
+  gen.after_reset_flip_probability = noise;
+  gen.before_measure_flip_probability = noise;
+  gen.before_round_data_depolarization = noise;
+
+  benchmark_data data;
+  data.circuit = stim::generate_surface_code_circuit(gen).circuit;
+
+  const std::size_t total = opts.warmup + opts.shots;
+  std::mt19937_64 rng(0);
+  auto sampled = stim::sample_batch_detection_events<stim::MAX_BITWORD_WIDTH>(
+      data.circuit, total, rng);
+  const auto &dets = sampled.first;
+  const auto &obs = sampled.second;
+
+  const std::size_t nd = data.circuit.count_detectors();
+  const std::size_t no = data.circuit.count_observables();
+  data.soft_syndromes.resize(total);
+  data.hard_syndromes.resize(total);
+  data.observable_masks.assign(total, 0);
+  for (std::size_t s = 0; s < total; ++s) {
+    data.soft_syndromes[s].assign(nd, 0.0);
+    data.hard_syndromes[s].assign(nd, 0);
+    for (std::size_t d = 0; d < nd; ++d)
+      if (dets[d][s]) {
+        data.soft_syndromes[s][d] = 1.0;
+        data.hard_syndromes[s][d] = 1;
+      }
+    for (std::size_t o = 0; o < no && o < 64; ++o)
+      if (obs[o][s])
+        data.observable_masks[s] ^= uint64_t{1} << o;
+  }
+
+  data.dem = stim::ErrorAnalyzer::circuit_to_detector_error_model(
+      data.circuit, /*decompose_errors=*/true, /*fold_loops=*/true,
+      /*allow_gauge_detectors=*/false,
+      /*approximate_disjoint_errors_threshold=*/0,
+      /*ignore_decomposition_failures=*/false,
+      /*block_decomposition_from_introducing_remnant_edges=*/false);
+  return data;
+} // end - generate_data()
+
+struct dem_matrices {
+  cudaq::qec::sparse_binary_matrix H;
+  cudaqx::tensor<uint8_t> O;
+  std::vector<double> priors;
+};
+
+// Extract H, O, and priors from the decomposed DEM without depending on
+// PyMatching internals.  Stim's decompose_errors=true splits hyperedges
+// into graphlike components separated by ^ (is_separator()) targets; each
+// component becomes one column of H with 1 or 2 non-zero rows.
+dem_matrices make_matrices(const stim::DetectorErrorModel &dem) {
+  struct edge {
+    double p = 0.0;
+    std::vector<std::size_t> detectors;
+    std::vector<std::size_t> observables;
+  };
+
+  std::vector<edge> edges;
+  const stim::DetectorErrorModel flat = dem.flattened();
+  for (const stim::DemInstruction &ins : flat.instructions) {
+    if (ins.type != stim::DemInstructionType::DEM_ERROR)
+      continue;
+    const double p = ins.arg_data[0];
+    edge cur;
+    cur.p = p;
+    for (const stim::DemTarget &t : ins.target_data) {
+      if (t.is_separator()) {
+        edges.push_back(cur);
+        cur = edge{};
+        cur.p = p;
+      } else if (t.is_relative_detector_id()) {
+        cur.detectors.push_back(static_cast<std::size_t>(t.val()));
+      } else if (t.is_observable_id()) {
+        cur.observables.push_back(static_cast<std::size_t>(t.val()));
+      }
+    }
+    edges.push_back(cur);
+  }
+
+  const std::size_t nd = dem.count_detectors();
+  const std::size_t no = dem.count_observables();
+  const std::size_t ne = edges.size();
+
+  dem_matrices m;
+  m.priors.assign(ne, 0.0);
+  m.O = cudaqx::tensor<uint8_t>({no, ne});
+  std::vector<std::vector<index_type>> H_nested(ne);
+  for (std::size_t col = 0; col < ne; ++col) {
+    m.priors[col] = edges[col].p;
+    for (auto det : edges[col].detectors)
+      H_nested[col].push_back(static_cast<index_type>(det));
+    for (auto o : edges[col].observables)
+      m.O.at({o, col}) = 1;
+  }
+  m.H = cudaq::qec::sparse_binary_matrix::from_nested_csc(
+      static_cast<index_type>(nd), static_cast<index_type>(ne), H_nested);
+  return m;
+} // end - make_matrices()
+
+std::vector<int32_t> detector_round_map(const stim::Circuit &circuit) {
+  std::set<uint64_t> all;
+  for (uint64_t d = 0; d < circuit.count_detectors(); ++d)
+    all.insert(d);
+  std::vector<int32_t> dr(circuit.count_detectors(), 0);
+  for (const auto &e : circuit.get_detector_coordinates(all)) {
+    if (!e.second.empty())
+      dr[e.first] = static_cast<int32_t>(std::llround(e.second.back()));
+  }
+  return dr;
+}
+
+std::vector<std::size_t> detectors_per_round(const std::vector<int32_t> &dr) {
+  const auto max_r = *std::max_element(dr.begin(), dr.end());
+  std::vector<std::size_t> widths(static_cast<std::size_t>(max_r) + 1, 0);
+  for (auto r : dr)
+    ++widths[static_cast<std::size_t>(r)];
+  return widths;
+}
+
+void set_identity_d_sparse(cudaq::qec::decoder &dec, std::size_t nd) {
+  std::vector<std::vector<uint32_t>> d_sparse(nd);
+  for (std::size_t i = 0; i < nd; ++i)
+    d_sparse[i].push_back(static_cast<uint32_t>(i));
+  dec.set_D_sparse(d_sparse);
+}
+
+// ── Parameter helpers
+// ─────────────────────────────────────────────────────────
+
+void insert_typed(cudaqx::heterogeneous_map &m, const std::string &key,
+                  const std::string &val) {
+  if (val == "true") {
+    m.insert(key, true);
+    return;
+  }
+  if (val == "false") {
+    m.insert(key, false);
+    return;
+  }
+  try {
+    std::size_t pos = 0;
+    const uint64_t u = std::stoull(val, &pos);
+    if (pos == val.size()) {
+      m.insert(key, u);
+      return;
+    }
+  } catch (...) {
+  }
+  try {
+    std::size_t pos = 0;
+    const double d = std::stod(val, &pos);
+    if (pos == val.size()) {
+      m.insert(key, d);
+      return;
+    }
+  } catch (...) {
+  }
+  m.insert(key, val);
+}
+
+// True for a --param value that means numeric zero, the sentinel decoders use
+// for "size this yourself".
+bool spells_zero(const std::string &val) {
+  return !val.empty() && val.find_first_not_of('0') == std::string::npos;
+}
+
+// Whether the user asked a decoder to size its thread pool from the machine.
+bool wants_machine_sized_threads(const options &opts) {
+  for (const auto &kv : opts.extra_params)
+    if (kv.first == "num_threads" && spells_zero(kv.second))
+      return true;
+  return false;
+}
+
+// Thread count to substitute for a num_threads=0 request on a row running
+// @p instances instances, or 0 to leave the request untouched.
+std::size_t auto_thread_share(const options &opts, std::size_t instances) {
+  const core_layout layout = layout_for(opts, instances);
+
+  // A single unpinned instance genuinely does have the machine to itself, so
+  // defer to the decoder's own sentinel handling and keep its numbers intact.
+  if (instances <= 1 && layout.base < 0)
+    return 0;
+  // Short of the instance's whole share: the substituted pool has to leave the
+  // instance thread a CPU, the way a decoder's own sentinel path does.
+  return worker_threads_per_instance(instances, layout,
+                                     std::thread::hardware_concurrency());
+}
+
+// Build a params map tailored to one decoder, in tiers:
+//
+//   Universal  -- O and error_rate_vec are included by default.  They are not
+//                 in every decoder's schema (e.g. pymatching's schema omits O)
+//                 but every decoder that uses them reads them from params, and
+//                 omitting O causes pymatching to fall back to edge mode which
+//                 rejects the parallel edges that DEM decomposition produces.
+//                 --no_O withholds O to mirror the realtime server, which
+//                 hands it to trt_decoder alone: pymatching then decodes into
+//                 error space and the base class projects to observables.
+//
+//   detector_round -- vector<int32_t> has no corresponding param_kind so it
+//                 cannot appear in any schema.  nv-fusion-decoder reads it
+//                 directly, while decoders with strict schema validation
+//                 reject unknown keys. Passed only to nv-fusion-decoder by
+//                 name; add other decoder names here if a future decoder also
+//                 needs temporal round information.
+//
+//   num_threads -- a request of 0 ("size yourself from the machine") is
+//                 rewritten to the caller's auto_threads, since a decoder
+//                 resolves that sentinel with no idea how many other
+//                 instances are running. 0 for auto_threads leaves it alone.
+//
+//   Schema-gated -- decoder-specific knobs and user --param values are
+//                 included only when the decoder's registered schema
+//                 explicitly lists them.  This silently skips a knob for every
+//                 decoder that does not declare it, without warnings or
+//                 validation failures.
+cudaqx::heterogeneous_map build_decoder_params(
+    const std::string &name, const dem_matrices &matrices,
+    const std::vector<int32_t> &dr, std::size_t block_leaf,
+    const std::vector<std::pair<std::string, std::string>> &extra, bool pass_O,
+    std::size_t auto_threads) {
+  const auto *schema = cudaq::qec::decoding::config::find_decoder_schema(name);
+
+  auto in_schema = [&](const std::string &key) -> bool {
+    if (!schema)
+      return true; // no schema: accept all keys
+    for (const auto &ps : schema->params)
+      if (ps.key == key)
+        return true;
+    return false;
+  };
+
+  cudaqx::heterogeneous_map p;
+
+  // ── Universal ──────────────────────────────────────────────────────────────
+  if (pass_O)
+    p.insert("O", matrices.O);
+  p.insert("error_rate_vec", matrices.priors);
+
+  // ── detector_round (name-gated) ────────────────────────────────────────────
+  if (name == "nv-fusion-decoder")
+    p.insert("detector_round", dr);
+
+  // ── Schema-gated ──────────────────────────────────────────────────────────
+  // Zero means no leaf height was requested: omit the key entirely so the
+  // decoder applies its own automatic schedule.
+  if (block_leaf != 0 && in_schema("block_leaf_size"))
+    p.insert("block_leaf_size", static_cast<std::size_t>(block_leaf));
+
+  // User --param values: use the schema's param_kind to pick the correct
+  // storage type.  This matters because on Linux x86-64 uint64_t
+  // (unsigned long long) and std::size_t (unsigned long) are distinct types
+  // in std::any, so a uint64 schema key stored as uint64_t would fail the
+  // any_cast<std::size_t> inside the decoder and silently fall back to its
+  // default value.  Decoders with no schema fall back to insert_typed.
+  for (const auto &kv : extra) {
+    const std::string &key = kv.first;
+    // num_threads=0 asks the decoder to size itself from the machine, which it
+    // does without knowing another instance exists: every instance of a row
+    // would build a whole-machine pool.  Substituting this row's share keeps
+    // the total near one thread per CPU.  Any explicit count is passed through
+    // untouched, which is also the way to opt out.
+    const std::string val =
+        (auto_threads > 0 && key == "num_threads" && spells_zero(kv.second))
+            ? std::to_string(auto_threads)
+            : kv.second;
+    if (!in_schema(key))
+      continue;
+
+    bool inserted = false;
+    if (schema) {
+      for (const auto &ps : schema->params) {
+        if (ps.key != key)
+          continue;
+        namespace cfg = cudaq::qec::decoding::config;
+        switch (ps.kind) {
+        case cfg::param_kind::boolean:
+          p.insert(key, val == "true");
+          break;
+        case cfg::param_kind::int32:
+          p.insert(key, static_cast<int>(std::stoi(val)));
+          break;
+        case cfg::param_kind::uint64:
+          p.insert(key, static_cast<std::size_t>(std::stoull(val)));
+          break;
+        case cfg::param_kind::f64:
+          p.insert(key, std::stod(val));
+          break;
+        case cfg::param_kind::string:
+          p.insert(key, val);
+          break;
+        default:
+          insert_typed(p, key, val);
+          break;
+        }
+        inserted = true;
+        break;
+      }
+    }
+    if (!inserted)
+      insert_typed(p, key, val);
+  }
+
+  return p;
+} // end - build_decoder_params()
+
+// ── Timing
+// ────────────────────────────────────────────────────────────────────
+
+struct latency_stats {
+  double p50 = 0.0;
+  double p90 = 0.0;
+  double p99 = 0.0;
+  double mean = 0.0;
+  double min = 0.0;
+  double max = 0.0;
+};
+
+double percentile(const std::vector<double> &sorted, double p) {
+  if (sorted.empty())
+    return 0.0;
+  const double pos = (p / 100.0) * static_cast<double>(sorted.size() - 1);
+  const auto lo = static_cast<std::size_t>(pos);
+  const auto hi = std::min(lo + 1, sorted.size() - 1);
+  return sorted[lo] * (1.0 - (pos - static_cast<double>(lo))) +
+         sorted[hi] * (pos - static_cast<double>(lo));
+}
+
+latency_stats summarize(std::vector<double> v) {
+  latency_stats s;
+  if (v.empty())
+    return s;
+  std::sort(v.begin(), v.end());
+  double sum = 0.0;
+  for (auto x : v)
+    sum += x;
+  s.mean = sum / static_cast<double>(v.size());
+  s.p50 = percentile(v, 50.0);
+  s.p90 = percentile(v, 90.0);
+  s.p99 = percentile(v, 99.0);
+  s.min = v.front();
+  s.max = v.back();
+  return s;
+}
+
+double elapsed_us(clock_type::time_point a, clock_type::time_point b) {
+  return std::chrono::duration<double, std::micro>(b - a).count();
+}
+
+// One point of the sweep: everything that identifies a row of the report.
+struct sweep_point {
+  int decoder_id = 0;
+  std::string name;
+  std::size_t distance = 0;
+  std::size_t rounds = 0;
+  double noise = 0.0;
+  std::size_t instances = 1;
+};
+
+// Which decode path a point is measured on.
+enum class bench_mode {
+  batch,  ///< decode() on a whole syndrome at once
+  stream, ///< enqueue_syndrome() round by round
+};
+
+struct measurement {
+  int decoder_id = 0;
+  std::string name;
+  std::size_t distance = 0;
+  std::size_t rounds = 0;
+  double noise = 0.0;
+  std::size_t instances = 1;
+  // Timed shots per instance; total_shots is the sum over instances and is
+  // what the logical error rate divides by.
+  std::size_t shots = 0;
+  std::size_t total_shots = 0;
+  // Detector rounds in one shot, which is the number of rounds the streaming
+  // path enqueues and the batch path decodes at once.  Stim emits one final
+  // round from the data readout, so this is `rounds` + 1 rather than `rounds`.
+  std::size_t rounds_per_shot = 0;
+  latency_stats latency;
+  latency_stats tail;
+  // Detector rounds per second: the rate each instance of the point held over
+  // its own timed window, summed.
+  double throughput = 0.0;
+  std::size_t logical_errors = 0;
+};
+
+uint64_t mask_from_result(const cudaq::qec::decoder_result &r) {
+  uint64_t mask = 0;
+  for (std::size_t i = 0; i < r.result.size() && i < 64; ++i)
+    if (cudaq::qec::convert_soft_to_hard(r.result[i]))
+      mask ^= uint64_t{1} << i;
+  return mask;
+}
+
+uint64_t mask_from_corrections(const uint8_t *corr, std::size_t n) {
+  uint64_t mask = 0;
+  for (std::size_t i = 0; i < n && i < 64; ++i)
+    if (corr[i])
+      mask ^= uint64_t{1} << i;
+  return mask;
+}
+
+// Shot an instance decodes on its i-th timed iteration.  Instances enter the
+// shared pool at different points and wrap, so concurrent instances are never
+// decoding the same syndrome in lockstep while still covering the same shots.
+std::size_t timed_shot(const options &opts, std::size_t offset, std::size_t i) {
+  return opts.warmup + (offset + i) % opts.shots;
+}
+
+void warmup_batch(cudaq::qec::decoder &dec, const benchmark_data &data,
+                  const options &opts) {
+  for (std::size_t s = 0; s < opts.warmup; ++s)
+    (void)dec.decode(data.soft_syndromes[s]);
+}
+
+// Timed batch loop for one instance.  Only the decode() call is inside the
+// stopwatch; the observable comparison that follows is bookkeeping.
+void run_batch_instance(cudaq::qec::decoder &dec, const benchmark_data &data,
+                        const options &opts, std::size_t offset,
+                        instance_result &out) {
+  out.shots = opts.shots;
+  out.shot_us.reserve(opts.shots);
+  for (std::size_t i = 0; i < opts.shots; ++i) {
+    const std::size_t shot = timed_shot(opts, offset, i);
+    const auto t0 = clock_type::now();
+    auto decoded = dec.decode(data.soft_syndromes[shot]);
+    out.shot_us.push_back(elapsed_us(t0, clock_type::now()));
+    if (mask_from_result(decoded) != data.observable_masks[shot])
+      ++out.logical_errors;
+  }
+} // end - run_batch_instance()
+
+void spin_until(clock_type::time_point t) {
+  while (clock_type::now() < t) {
+  }
+}
+
+// One streaming shot: enqueue every round, then read the corrections out.
+// Reports in-decoder work (sum of the enqueue calls, excluding any pacing
+// spin) and the tail (final round plus corrections readout) separately, and
+// returns the predicted observable mask.
+uint64_t stream_shot(cudaq::qec::decoder &dec, const benchmark_data &data,
+                     const options &opts,
+                     const std::vector<std::size_t> &round_widths,
+                     std::size_t shot, std::size_t num_obs, double *shot_us,
+                     double *tail_us) {
+  const std::vector<uint8_t> &syn = data.hard_syndromes[shot];
+  double work = 0.0;
+  std::size_t offset = 0;
+
+  dec.reset_decoder();
+  const auto shot_start = clock_type::now();
+  for (std::size_t r = 0; r + 1 < round_widths.size(); ++r) {
+    if (opts.round_interval.count() > 0)
+      spin_until(shot_start + static_cast<int64_t>(r) * opts.round_interval);
+    const auto rs = clock_type::now();
+    dec.enqueue_syndrome(syn.data() + offset, round_widths[r]);
+    work += elapsed_us(rs, clock_type::now());
+    offset += round_widths[r];
+  }
+  if (opts.round_interval.count() > 0)
+    spin_until(shot_start + static_cast<int64_t>(round_widths.size() - 1) *
+                                opts.round_interval);
+  const auto tail_start = clock_type::now();
+  dec.enqueue_syndrome(syn.data() + offset, round_widths.back());
+  const uint8_t *corr = dec.get_obs_corrections();
+  const double tail = elapsed_us(tail_start, clock_type::now());
+
+  if (shot_us)
+    *shot_us = work + tail;
+  if (tail_us)
+    *tail_us = tail;
+  return mask_from_corrections(corr, num_obs);
+} // end - stream_shot()
+
+void warmup_stream(cudaq::qec::decoder &dec, const benchmark_data &data,
+                   const options &opts,
+                   const std::vector<std::size_t> &round_widths) {
+  const std::size_t num_obs = dec.get_num_observables();
+  for (std::size_t s = 0; s < opts.warmup; ++s)
+    (void)stream_shot(dec, data, opts, round_widths, s, num_obs, nullptr,
+                      nullptr);
+}
+
+// Timed streaming loop for one instance.
+void run_stream_instance(cudaq::qec::decoder &dec, const benchmark_data &data,
+                         const options &opts,
+                         const std::vector<std::size_t> &round_widths,
+                         std::size_t offset, instance_result &out) {
+  const std::size_t num_obs = dec.get_num_observables();
+  double shot_us = 0.0;
+  double tail_us = 0.0;
+
+  out.shots = opts.shots;
+  out.shot_us.reserve(opts.shots);
+  out.tail_us.reserve(opts.shots);
+  for (std::size_t i = 0; i < opts.shots; ++i) {
+    const std::size_t shot = timed_shot(opts, offset, i);
+    const uint64_t predicted = stream_shot(dec, data, opts, round_widths, shot,
+                                           num_obs, &shot_us, &tail_us);
+    out.shot_us.push_back(shot_us);
+    out.tail_us.push_back(tail_us);
+    if (predicted != data.observable_masks[shot])
+      ++out.logical_errors;
+  }
+} // end - run_stream_instance()
+
+// Fold every instance of a point into the single row the report prints.  The
+// percentiles come from the pooled samples on purpose: a percentile taken from
+// one instance says nothing about the instances contending with it.
+measurement pool_measurement(const instance_pool_result &pool,
+                             const options &opts, const sweep_point &point,
+                             std::size_t rounds_per_shot) {
+  measurement result;
+  const auto totals = sum_instance_results(pool.instances);
+  auto shot_us =
+      concat_instance_samples(pool.instances, instance_sample_kind::shot);
+  auto tail_us =
+      concat_instance_samples(pool.instances, instance_sample_kind::tail);
+
+  result.decoder_id = point.decoder_id;
+  result.name = point.name;
+  result.distance = point.distance;
+  result.rounds = point.rounds;
+  result.noise = point.noise;
+  result.instances = point.instances;
+  result.shots = opts.shots;
+  result.total_shots = totals.shots;
+  result.rounds_per_shot = rounds_per_shot;
+  result.logical_errors = totals.logical_errors;
+  result.latency = summarize(std::move(shot_us));
+  // Batch mode records no tail samples; mirror the decode latency so a row
+  // can be printed against either column.
+  result.tail =
+      tail_us.empty() ? result.latency : summarize(std::move(tail_us));
+  // Rounds retired per second, each instance rated over its own timed window
+  // and the rates then summed.  Rating them separately is what keeps an
+  // instance that finishes early from being charged for the time it spent
+  // waiting on the slowest one, which a single shared window would fold into
+  // the denominator of every instance.  A window holds everything the shot
+  // loop does, pacing spins included, so under --round_interval_us this
+  // reports the paced round rate the decoders sustained rather than the rate
+  // they are capable of.
+  result.throughput = 0.0;
+  for (const auto &instance : pool.instances) {
+    if (instance.wall_us <= 0.0)
+      continue;
+    result.throughput += static_cast<double>(instance.shots * rounds_per_shot) *
+                         1e6 / instance.wall_us;
+  }
+  return result;
+} // end - pool_measurement()
+
+// Run one sweep point across its decoder instances and return the pooled row.
+//
+// Every instance builds its own decoder inside its own thread rather than
+// being handed one: decoder construction persistently pins the constructing
+// thread to the decoder's CUDA device, and the library's rule is that the
+// thread that builds a decoder is the thread that drives it.
+measurement run_point(const options &opts, const benchmark_data &data,
+                      const dem_matrices &matrices,
+                      const cudaqx::heterogeneous_map &dec_params,
+                      const std::vector<std::size_t> &round_widths,
+                      bench_mode mode, const sweep_point &point) {
+  std::vector<std::unique_ptr<cudaq::qec::decoder>> decoders(point.instances);
+  instance_work work;
+
+  work.setup = [&](std::size_t instance) {
+    auto dec = cudaq::qec::decoder::get(point.name, matrices.H, dec_params);
+    // Stamp the sweep's id on the decoder so any [DecoderStats] line it logs
+    // carries the same ID the table rows report.  Every instance of a point
+    // shares that id, matching the one pooled row the point produces.
+    dec->set_decoder_id(static_cast<uint32_t>(point.decoder_id));
+    // A decoder that never saw O in its params has no observables of its own,
+    // so supply them the way create_realtime_decoder() does.
+    if (!opts.pass_O)
+      dec->set_O_sparse(cudaq::qec::pcm_to_sparse_vec(matrices.O));
+    if (mode == bench_mode::stream) {
+      set_identity_d_sparse(*dec, data.circuit.count_detectors());
+      warmup_stream(*dec, data, opts, round_widths);
+    } else {
+      warmup_batch(*dec, data, opts);
+    }
+    decoders[instance] = std::move(dec);
+  }; // end - work.setup
+
+  work.run = [&](std::size_t instance, instance_result &out) {
+    const std::size_t offset =
+        instance_shot_offset(instance, point.instances, opts.shots);
+    if (mode == bench_mode::stream)
+      run_stream_instance(*decoders[instance], data, opts, round_widths, offset,
+                          out);
+    else
+      run_batch_instance(*decoders[instance], data, opts, offset, out);
+  };
+
+  const instance_pool_result pool =
+      run_instances(point.instances, layout_for(opts, point.instances), work);
+  const std::string failure = first_instance_error(pool.instances);
+  if (!failure.empty())
+    throw std::runtime_error(failure);
+  return pool_measurement(pool, opts, point, round_widths.size());
+} // end - run_point()
+
+// ── Output
+// ────────────────────────────────────────────────────────────────────
+
+// Column widths for the flat results table.
+constexpr int col_w_id = 4;
+constexpr int col_w_decoder = 26;
+constexpr int col_w_d = 4;
+constexpr int col_w_rounds = 8;
+constexpr int col_w_instances = 11;
+constexpr int col_w_shots = 11; // timed shots per instance
+constexpr int col_w_noise = 11;
+// 11 so the widest latency heading ("decode p50", 10 characters) still leaves
+// a separating space; anything narrower runs it into the noise column.
+constexpr int col_w_lat = 11;
+// 13 because a round rate is the shot rate times the rounds in a shot, so the
+// integer here runs several digits longer than a shots/s figure would.
+constexpr int col_w_tput = 13; // rounds/s summed over instances
+constexpr int col_w_ler = 12;
+// Divider width. The decoder name is printed with a two-space gutter, hence
+// the + 2; deriving the total keeps it correct as columns come and go.
+constexpr int table_width =
+    col_w_id + col_w_decoder + 2 + col_w_d + col_w_rounds + col_w_instances +
+    col_w_shots + col_w_noise + 3 * col_w_lat + col_w_tput + col_w_ler;
+
+// The logical error rate divides by the shots of every instance, so a row must
+// carry the total alongside the per-instance count.
+double logical_error_rate(const measurement &row) {
+  if (row.total_shots == 0)
+    return 0.0;
+  return static_cast<double>(row.logical_errors) /
+         static_cast<double>(row.total_shots);
+}
+
+// CPU placement in one phrase, for the configuration header.
+std::string describe_pinning(const core_layout &cores) {
+  const std::size_t width = cores.width > 0 ? cores.width : 1;
+  const std::size_t stride = effective_stride(cores);
+  std::string text;
+
+  if (cores.base < 0)
+    return "none";
+  text = "CPU " + std::to_string(cores.base) + "+";
+  if (stride != 1)
+    text += std::to_string(stride) + "*";
+  text += "instance";
+  if (width > 1)
+    text += ", " + std::to_string(width) + " CPUs each";
+  return text;
+}
+
+// Automatic placement differs per row, so report each instance count's blocks
+// rather than a single layout the run never actually uses.
+std::string describe_auto_pinning(const options &opts) {
+  const auto cpus = allowed_cpus();
+  std::string text = "auto over ";
+
+  if (cpus.empty())
+    return "auto (no CPU list available)";
+  text += std::to_string(cpus.size()) + " CPUs (" +
+          std::to_string(cpus.front()) + "-" + std::to_string(cpus.back()) +
+          "):";
+  for (const std::size_t n : opts.instances_list) {
+    const core_layout layout = layout_for(opts, n);
+    text += "  " + std::to_string(n) + " inst: ";
+    text += layout.base < 0 ? std::string("unpinned")
+                            : std::to_string(layout.width) + " CPUs each";
+  }
+  return text;
+}
+
+void print_table_header(const std::string &title, const std::string &lat_col) {
+  std::cout << "\n" << title << "\n";
+  // The round rate divides by a count no column carries, and one no reader
+  // would guess from the rounds column, so spell the convention out.
+  std::cout << "rounds/s: detector rounds retired per second, summed over "
+               "instances; a shot carries rounds+1 of them\n";
+  std::cout << std::right << std::setw(col_w_id) << "id" << std::left
+            << std::setw(col_w_decoder + 2) << "  decoder" << std::right
+            << std::setw(col_w_d) << "d" << std::setw(col_w_rounds) << "rounds"
+            << std::setw(col_w_instances) << "instances"
+            << std::setw(col_w_shots) << "shots/inst" << std::setw(col_w_noise)
+            << "noise" << std::setw(col_w_lat) << (lat_col + " p50")
+            << std::setw(col_w_lat) << "p90" << std::setw(col_w_lat) << "p99"
+            << std::setw(col_w_tput) << "rounds/s" << std::setw(col_w_ler)
+            << "LER"
+            << "\n";
+  std::cout << std::string(table_width, '-') << "\n";
+}
+
+void print_table_row(const measurement &row, bool use_tail) {
+  const auto &lat = use_tail ? row.tail : row.latency;
+  std::cout << std::right << std::fixed << std::setw(col_w_id) << row.decoder_id
+            << "  " << std::left << std::setw(col_w_decoder) << row.name
+            << std::right << std::setw(col_w_d) << row.distance
+            << std::setw(col_w_rounds) << row.rounds
+            << std::setw(col_w_instances) << row.instances
+            << std::setw(col_w_shots) << row.shots << std::setw(col_w_noise)
+            << std::scientific << std::setprecision(2) << row.noise
+            << std::fixed << std::setprecision(2) << std::setw(col_w_lat)
+            << lat.p50 << std::setw(col_w_lat) << lat.p90
+            << std::setw(col_w_lat) << lat.p99 << std::setprecision(0)
+            << std::setw(col_w_tput) << row.throughput << std::setprecision(4)
+            << std::setw(col_w_ler) << logical_error_rate(row) << "\n";
+}
+
+void print_csv_row(const std::string &mode, const measurement &row) {
+  std::cout << "csv," << mode << "," << row.decoder_id << "," << row.name << ","
+            << row.distance << "," << row.rounds << "," << row.rounds_per_shot
+            << "," << row.instances << "," << row.shots << ","
+            << row.total_shots << "," << std::scientific << std::setprecision(2)
+            << row.noise << "," << std::fixed << std::setprecision(3)
+            << row.latency.p50 << "," << row.latency.p90 << ","
+            << row.latency.p99 << "," << row.tail.p50 << "," << row.tail.p99
+            << "," << std::setprecision(1) << row.throughput << ","
+            << std::setprecision(4) << logical_error_rate(row) << "\n";
+}
+
+} // namespace
+
+int main(int argc, char **argv) {
+  options opts;
+  int exit_code = 0;
+  if (!parse_args(argc, argv, opts, exit_code))
+    return exit_code;
+
+  // Print configuration summary.
+  std::cout << std::defaultfloat << "benchmark-qec-decoder"
+            << "  shots=" << opts.shots << " (warmup " << opts.warmup << ")"
+            << "  hardware_concurrency=" << std::thread::hardware_concurrency()
+            << "\n"
+            << "decoders:  ";
+  for (std::size_t i = 0; i < opts.decoders.size(); ++i)
+    std::cout << (i ? ", " : "") << "[" << i << "] " << opts.decoders[i];
+  std::cout << "\n"
+            << "round pacing="
+            << (opts.round_interval.count() > 0
+                    ? std::to_string(
+                          static_cast<double>(opts.round_interval.count()) /
+                          1e3) +
+                          " us per round"
+                    : std::string("none"))
+            << "  O param=" << (opts.pass_O ? "passed" : "withheld") << "\n"
+            << "instances: ";
+  for (std::size_t i = 0; i < opts.instances_list.size(); ++i)
+    std::cout << (i ? ", " : "") << opts.instances_list[i];
+  std::cout << "  pinning="
+            << (opts.auto_pin ? describe_auto_pinning(opts)
+                              : describe_pinning(opts.cores))
+            << "\n";
+
+  // Rewriting a value the user typed is only acceptable if the run says so.
+  if (wants_machine_sized_threads(opts)) {
+    std::cout << "num_threads=0 ->";
+    for (const std::size_t n : opts.instances_list) {
+      const std::size_t share = auto_thread_share(opts, n);
+      std::cout << "  " << n << " inst: "
+                << (share == 0 ? std::string("decoder default")
+                               : std::to_string(share) + " threads");
+    }
+    std::cout << "\n";
+  }
+
+  // Oversubscription turns decode latency into scheduler noise, which is easy
+  // to mistake for a decoder regression, so say so up front.
+  const unsigned num_cpus = std::thread::hardware_concurrency();
+  const std::size_t widest =
+      *std::max_element(opts.instances_list.begin(), opts.instances_list.end());
+  if (num_cpus > 0 && widest > num_cpus)
+    std::cerr << "warning: " << widest << " decoder instances on " << num_cpus
+              << " CPUs oversubscribes the machine; latencies will include "
+                 "scheduling delay\n";
+  // A stride under the width is legitimate for contention studies, but it is
+  // also an easy typo, and it quietly undoes the isolation pinning is for.
+  if (opts.cores.base >= 0 && effective_stride(opts.cores) < opts.cores.width)
+    std::cerr << "warning: stride " << effective_stride(opts.cores)
+              << " is narrower than width " << opts.cores.width
+              << ", so instances share CPUs\n";
+
+  // Accumulate all rows first so each mode's table is printed contiguously.
+  std::vector<measurement> batch_rows, stream_rows;
+
+  // Outer sweep: distances × rounds × noises.
+  for (const std::size_t distance : opts.distances) {
+    // Effective rounds list: use the distance itself when none specified.
+    std::vector<std::size_t> effective_rounds;
+    if (opts.rounds_list.empty())
+      effective_rounds.push_back(distance);
+    else
+      effective_rounds = opts.rounds_list;
+
+    for (const std::size_t rounds : effective_rounds) {
+      // 0 = unset: let the decoder choose rather than imposing a schedule.
+      const std::size_t block_leaf = opts.block_leaf_size;
+
+      for (const double noise : opts.noises) {
+        auto data = generate_data(opts, distance, rounds, noise);
+        auto matrices = make_matrices(data.dem);
+        const auto dr = detector_round_map(data.circuit);
+        const auto round_widths = detectors_per_round(dr);
+
+        for (int id = 0; id < static_cast<int>(opts.decoders.size()); ++id) {
+          const auto &name = opts.decoders[static_cast<std::size_t>(id)];
+          try {
+            // Instance count innermost: consecutive rows then form the
+            // scaling curve for one decoder at one configuration.
+            for (const std::size_t instances : opts.instances_list) {
+              // Rebuilt per row because a machine-sized thread request
+              // resolves against this row's instance count.
+              const cudaqx::heterogeneous_map dec_params = build_decoder_params(
+                  name, matrices, dr, block_leaf, opts.extra_params,
+                  opts.pass_O, auto_thread_share(opts, instances));
+              sweep_point point;
+              point.decoder_id = id;
+              point.name = name;
+              point.distance = distance;
+              point.rounds = rounds;
+              point.noise = noise;
+              point.instances = instances;
+
+              if (opts.run_batch)
+                batch_rows.push_back(run_point(opts, data, matrices, dec_params,
+                                               round_widths, bench_mode::batch,
+                                               point));
+              if (opts.run_stream)
+                stream_rows.push_back(run_point(opts, data, matrices,
+                                                dec_params, round_widths,
+                                                bench_mode::stream, point));
+            } // end - for(instances)
+          } catch (const std::exception &e) {
+            std::cerr << "error: decoder [" << id << "] " << name
+                      << " (d=" << distance << " r=" << rounds << " p=" << noise
+                      << "): " << e.what() << "\n";
+            return 1;
+          }
+        } // end - for(id)
+      } // end - for(noise)
+    } // end - for(rounds)
+  } // end - for(distance)
+
+  // Print batch table (all configs, then all stream configs). Latencies are
+  // pooled over the instances of a row and rounds/s is summed over them.
+  if (!batch_rows.empty()) {
+    print_table_header("batch decode() -- latencies in microseconds, pooled "
+                       "over instances",
+                       "decode");
+    for (const auto &row : batch_rows)
+      print_table_row(row, /*use_tail=*/false);
+  }
+  if (!stream_rows.empty()) {
+    print_table_header("streaming: last round + corrections -- latencies in "
+                       "microseconds, pooled over instances",
+                       "tail");
+    for (const auto &row : stream_rows)
+      print_table_row(row, /*use_tail=*/true);
+  }
+
+  // CSV output (interleaved batch then stream to keep mode grouping).
+  if (opts.emit_csv) {
+    std::cout << "csv,mode,id,decoder,d,rounds,det_rounds,instances,shots,"
+                 "total_shots,noise,"
+                 "p50,p90,p99,tail_p50,tail_p99,rounds_s,ler\n";
+    for (const auto &row : batch_rows)
+      print_csv_row("batch", row);
+    for (const auto &row : stream_rows)
+      print_csv_row("stream", row);
+  }
+
+  std::cout << std::defaultfloat;
+  return 0;
+}

--- a/benchmarks/qec/decoder_latency/benchmark_instance_pool.cpp
+++ b/benchmarks/qec/decoder_latency/benchmark_instance_pool.cpp
@@ -1,0 +1,329 @@
+/*******************************************************************************
+ * Copyright (c) 2026 NVIDIA Corporation & Affiliates.                         *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+// Implementation of the benchmark instance harness: thread fan-out, CPU
+// pinning, the setup/run start gate, and the pooling helpers that fold
+// per-instance samples into machine-wide numbers.  See
+// benchmark_instance_pool.h for the contract.
+
+#include "benchmark_instance_pool.h"
+
+#include <algorithm>
+#include <barrier>
+#include <chrono>
+#include <cstring>
+#include <stdexcept>
+#include <thread>
+
+#if defined(__linux__)
+#include <pthread.h>
+#include <sched.h>
+#endif
+
+namespace cudaq::qec::benchmark {
+
+namespace {
+
+using clock_type = std::chrono::steady_clock;
+
+double elapsed_us(clock_type::time_point a, clock_type::time_point b) {
+  return std::chrono::duration<double, std::micro>(b - a).count();
+}
+
+// "CPU 5" or "CPUs 4-7", for messages a user has to act on.
+std::string describe_block(int first, std::size_t count) {
+  if (count == 1)
+    return "CPU " + std::to_string(first);
+  return "CPUs " + std::to_string(first) + "-" +
+         std::to_string(first + static_cast<int>(count) - 1);
+}
+
+} // namespace
+
+// Pinning runs on the instance's own thread rather than on the spawning thread
+// so that everything the instance touches afterwards -- decoder construction
+// included -- allocates with the final CPU (and therefore the final NUMA node)
+// already in effect.  It also means threads the decoder spawns inherit this
+// mask, which is why a block can be wider than a single CPU.
+std::string pin_current_thread(const cpu_block &block) {
+  if (block.first < 0 || block.count == 0)
+    return {};
+
+  const std::string where = describe_block(block.first, block.count);
+
+#if defined(__linux__)
+  cpu_set_t set;
+  int status = 0;
+
+  CPU_ZERO(&set);
+  for (std::size_t i = 0; i < block.count; ++i)
+    CPU_SET(block.first + static_cast<int>(i), &set);
+  status = pthread_setaffinity_np(pthread_self(), sizeof(set), &set);
+  if (status != 0)
+    return "failed to pin decoder instance thread to " + where + ": " +
+           std::strerror(status);
+  return {};
+#else
+  return "instance CPU pinning is only implemented on Linux (requested " +
+         where + ")";
+#endif
+} // end - pin_current_thread()
+
+std::size_t effective_stride(const core_layout &layout) {
+  // Stride 0 means "pack instances back to back", i.e. advance by one whole
+  // block. A zero width still advances by 1 so no two instances share a
+  // first CPU.
+  if (layout.stride > 0)
+    return layout.stride;
+  return layout.width > 0 ? layout.width : 1;
+}
+
+std::vector<int> allowed_cpus() {
+  std::vector<int> cpus;
+
+#if defined(__linux__)
+  cpu_set_t set;
+
+  CPU_ZERO(&set);
+  if (sched_getaffinity(0, sizeof(set), &set) != 0)
+    return cpus;
+  for (int cpu = 0; cpu < CPU_SETSIZE; ++cpu)
+    if (CPU_ISSET(cpu, &set))
+      cpus.push_back(cpu);
+#endif
+  return cpus;
+} // end - allowed_cpus()
+
+core_layout divide_cpus(std::size_t num_instances,
+                        const std::vector<int> &cpus) {
+  core_layout layout;
+
+  // Nothing to divide, or too few CPUs to give each instance its own: leave
+  // pinning off rather than hand out overlapping blocks, which would be worse
+  // than letting the scheduler place the threads.
+  if (num_instances == 0 || cpus.size() < num_instances)
+    return layout;
+
+  // base + i * stride can only name a contiguous run, so a fragmented cpuset
+  // (0-3,8-11 under a cgroup, say) has to be refused: tiling from the bottom
+  // would put an instance on a CPU this process may not be allowed to use.
+  if (static_cast<std::size_t>(cpus.back() - cpus.front()) + 1 != cpus.size())
+    throw std::runtime_error(
+        "cannot place decoder instances automatically: the " +
+        std::to_string(cpus.size()) + " available CPUs (" +
+        std::to_string(cpus.front()) + "-" + std::to_string(cpus.back()) +
+        ") are not contiguous; place them by hand with instance_core_base, "
+        "instance_core_width and instance_core_stride");
+
+  layout.base = cpus.front();
+  // Floor: a remainder stays idle rather than making one instance wider or
+  // running the last block past the end of the range.
+  layout.width = cpus.size() / num_instances;
+  return layout;
+} // end - divide_cpus()
+
+std::size_t cpus_per_instance(std::size_t num_instances,
+                              const core_layout &layout, unsigned num_cpus) {
+  // Pinned: the block is all this instance may touch, whatever the machine
+  // looks like, so it is the whole answer.
+  if (layout.base >= 0)
+    return layout.width > 0 ? layout.width : 1;
+  // Unknown CPU count (hardware_concurrency() may return 0): stay at 1 rather
+  // than invent a share.
+  if (num_cpus == 0)
+    return 1;
+  if (num_instances == 0)
+    num_instances = 1;
+  // Floor, not round: dividing 24 CPUs among 5 instances has to give 4, since
+  // 5 would put 25 threads on the machine.
+  return std::max<std::size_t>(1, num_cpus / num_instances);
+} // end - cpus_per_instance()
+
+std::size_t worker_threads_per_instance(std::size_t num_instances,
+                                        const core_layout &layout,
+                                        unsigned num_cpus) {
+  const std::size_t cpus = cpus_per_instance(num_instances, layout, num_cpus);
+
+  // Ceiling on the reserve, matching the four hardware threads a decoder holds
+  // back when it sizes a pool from the whole machine: past a few CPUs of slack
+  // the barrier has enough room to absorb a preemption, and holding back more
+  // only idles the block.
+  constexpr std::size_t kMaxReservedCpus = 4;
+  // CPUs per reserved CPU, so the reserve scales with the block instead of
+  // eating it: a 6-CPU block gives up 1, and 24 CPUs reach the ceiling.
+  constexpr std::size_t kCpusPerReservedCpu = 6;
+  const std::size_t reserved = std::max<std::size_t>(
+      1, std::min(kMaxReservedCpus, cpus / kCpusPerReservedCpu));
+
+  // A block with nothing to spare still has to run: 0 would be read as the
+  // machine-sizing sentinel this substitution exists to replace.
+  return cpus > reserved ? cpus - reserved : 1;
+} // end - worker_threads_per_instance()
+
+cpu_block resolve_instance_cpus(std::size_t instance, const core_layout &layout,
+                                unsigned num_cpus) {
+  cpu_block block;
+  std::size_t first = 0;
+  std::size_t last = 0;
+
+  // Negative disables pinning, the same convention core_pinning uses in
+  // realtime/pipeline.h.
+  if (layout.base < 0)
+    return block;
+
+  block.count = layout.width > 0 ? layout.width : 1;
+  first = static_cast<std::size_t>(layout.base) +
+          instance * effective_stride(layout);
+  // The whole block has to fit, not just the CPU it starts on.
+  last = first + block.count - 1;
+
+  const auto rejection = [&](const std::string &limit) {
+    return "instance_core_base " + std::to_string(layout.base) + " (width " +
+           std::to_string(block.count) + ", stride " +
+           std::to_string(effective_stride(layout)) +
+           ") puts decoder instance " + std::to_string(instance) + " on " +
+           describe_block(static_cast<int>(first), block.count) + ", " + limit;
+  };
+
+#if defined(__linux__)
+  // A cpu_set_t cannot name a CPU at or beyond CPU_SETSIZE, so reject it here
+  // rather than let pthread_setaffinity_np fail with a bare EINVAL.
+  if (last >= static_cast<std::size_t>(CPU_SETSIZE))
+    throw std::runtime_error(rejection("which exceeds CPU_SETSIZE (" +
+                                       std::to_string(CPU_SETSIZE) + ")"));
+#endif
+
+  // 0 means the CPU count is unknown (hardware_concurrency() is allowed to
+  // return 0); skip the check rather than reject every placement.
+  if (num_cpus > 0 && last >= static_cast<std::size_t>(num_cpus))
+    throw std::runtime_error(rejection("but only " + std::to_string(num_cpus) +
+                                       " CPU(s) are visible"));
+
+  block.first = static_cast<int>(first);
+  return block;
+} // end - resolve_instance_cpus()
+
+instance_pool_result run_instances(std::size_t num_instances,
+                                   const core_layout &layout,
+                                   const instance_work &work) {
+  instance_pool_result result;
+  std::vector<cpu_block> cpus;
+  std::vector<std::thread> instance_threads;
+
+  if (num_instances == 0)
+    return result;
+
+  // Resolve placement up front, on the caller's thread: an impossible core
+  // list must abort before any instance spins up, not surface as a per-instance
+  // error after the run.
+  cpus.reserve(num_instances);
+  for (std::size_t instance = 0; instance < num_instances; ++instance)
+    cpus.push_back(resolve_instance_cpus(instance, layout,
+                                         std::thread::hardware_concurrency()));
+
+  // Sized before any instance starts, so an instance can write its own slot
+  // without synchronization and without reallocating mid-run.
+  result.instances.resize(num_instances);
+
+  std::barrier<> gate(static_cast<std::ptrdiff_t>(num_instances));
+
+  auto instance_body = [&](std::size_t instance) {
+    instance_result &out = result.instances[instance];
+
+    out.error = pin_current_thread(cpus[instance]);
+    if (out.error.empty() && work.setup) {
+      try {
+        work.setup(instance);
+      } catch (const std::exception &e) {
+        out.error = std::string("setup failed: ") + e.what();
+      } catch (...) {
+        out.error = "setup failed with a non-standard exception";
+      }
+    }
+
+    // Reached unconditionally, including on failure: an instance that bails
+    // out before arriving would leave every healthy one blocked here forever.
+    gate.arrive_and_wait();
+
+    if (!out.error.empty() || !work.run)
+      return;
+    // Timed from inside the instance, so the window covers exactly the shots
+    // this instance took and nothing else: not its thread spawn or teardown,
+    // and not the wait a slower sibling would otherwise add to the tail of a
+    // shared span. An aggregate rate is then the sum of the per-instance
+    // rates rather than the total work over one window.
+    const auto entered = clock_type::now();
+    try {
+      work.run(instance, out);
+    } catch (const std::exception &e) {
+      out.error = std::string("run failed: ") + e.what();
+    } catch (...) {
+      out.error = "run failed with a non-standard exception";
+    }
+    // A failed instance's samples are incomplete, so leave its window at 0
+    // and let it drop out of any aggregate instead of weighting it.
+    if (out.error.empty())
+      out.wall_us = elapsed_us(entered, clock_type::now());
+  }; // end - instance_body
+
+  instance_threads.reserve(num_instances);
+  for (std::size_t instance = 0; instance < num_instances; ++instance)
+    instance_threads.emplace_back(instance_body, instance);
+  for (auto &instance_thread : instance_threads)
+    instance_thread.join();
+
+  return result;
+} // end - run_instances()
+
+std::vector<double>
+concat_instance_samples(const std::vector<instance_result> &instances,
+                        instance_sample_kind kind) {
+  std::vector<double> pooled;
+  std::size_t total = 0;
+
+  for (const auto &instance : instances)
+    total += (kind == instance_sample_kind::shot ? instance.shot_us
+                                                 : instance.tail_us)
+                 .size();
+  pooled.reserve(total);
+  for (const auto &instance : instances) {
+    const auto &samples = kind == instance_sample_kind::shot ? instance.shot_us
+                                                             : instance.tail_us;
+    pooled.insert(pooled.end(), samples.begin(), samples.end());
+  }
+  return pooled;
+} // end - concat_instance_samples()
+
+instance_totals
+sum_instance_results(const std::vector<instance_result> &instances) {
+  instance_totals totals;
+
+  for (const auto &instance : instances) {
+    totals.shots += instance.shots;
+    totals.logical_errors += instance.logical_errors;
+  }
+  return totals;
+}
+
+std::string
+first_instance_error(const std::vector<instance_result> &instances) {
+  for (std::size_t i = 0; i < instances.size(); ++i)
+    if (!instances[i].error.empty())
+      return "decoder instance " + std::to_string(i) + ": " +
+             instances[i].error;
+  return {};
+}
+
+std::size_t instance_shot_offset(std::size_t instance,
+                                 std::size_t num_instances, std::size_t shots) {
+  if (num_instances == 0 || shots == 0)
+    return 0;
+  return (instance % num_instances) * shots / num_instances;
+}
+
+} // namespace cudaq::qec::benchmark

--- a/benchmarks/qec/decoder_latency/benchmark_instance_pool.h
+++ b/benchmarks/qec/decoder_latency/benchmark_instance_pool.h
@@ -1,0 +1,245 @@
+/*******************************************************************************
+ * Copyright (c) 2026 NVIDIA Corporation & Affiliates.                         *
+ * All rights reserved.                                                        *
+ *                                                                             *
+ * This source code and the accompanying materials are made available under    *
+ * the terms of the Apache License 2.0 which accompanies this distribution.    *
+ ******************************************************************************/
+
+// Instance harness shared by the decoder benchmarks: runs N independent
+// decoder instances concurrently, one thread each, and collects the
+// per-instance latency samples the caller pools into a single report.
+//
+// An "instance" is one whole decoder, the unit a deployment scales when it
+// decodes several logical qubits at once. It is deliberately not called a
+// "lane", which commonly describes parallelism within a single decoder.
+//
+// An instance owns its decoder end to end.  The decoder base class pins the
+// constructing thread persistently to the decoder's CUDA device (see
+// decoder::get_cuda_device_id()) and the library calls that rule
+// "one-thread-owns-one-decoder", so the thread that will drive a decoder is
+// also the thread that has to build it.  run_instances() therefore splits an
+// instance's work into a setup phase (construction plus warmup, untimed) and a
+// run phase (timed), with a start gate in between so that every instance
+// measures itself while all the others are loaded.
+//
+// Everything here is deliberately free of decoder types: the benchmark supplies
+// the per-instance work as callables, which keeps the threading, pinning, and
+// pooling logic unit-testable on its own.
+
+#pragma once
+
+#include <cstddef>
+#include <functional>
+#include <string>
+#include <vector>
+
+namespace cudaq::qec::benchmark {
+
+/// @brief Timed samples and outcome counters produced by a single instance.
+struct instance_result {
+  /// @brief Per-shot latency in microseconds, one entry per timed shot.
+  std::vector<double> shot_us;
+  /// @brief Per-shot tail latency in microseconds (streaming mode: final round
+  /// plus corrections readout). Batch mode leaves this empty.
+  std::vector<double> tail_us;
+  /// @brief Microseconds this instance spent in its own timed region, entering
+  /// to leaving its run phase. Construction, warmup, thread spawn and teardown
+  /// all fall outside it, as does the wait every other instance's stragglers
+  /// impose -- an aggregate rate is therefore the sum of the per-instance
+  /// rates, not the total work over one shared span. 0 when the instance never
+  /// ran or failed, so a rate taken against it has to guard the division.
+  double wall_us = 0.0;
+  /// @brief Timed shots this instance completed.
+  std::size_t shots = 0;
+  /// @brief Shots whose predicted observable mask missed the sampled mask.
+  std::size_t logical_errors = 0;
+  /// @brief Empty on success, otherwise why this instance produced no samples.
+  std::string error;
+};
+
+/// @brief The work one instance performs, split so construction and warmup
+/// stay outside the timed region.
+struct instance_work {
+  /// @brief Called on the instance's own thread before the start gate. Owns
+  /// decoder construction and warmup. May be empty.
+  std::function<void(std::size_t instance)> setup;
+  /// @brief Called on the same thread once every instance has finished setup.
+  /// Fills the instance's samples and counters.
+  std::function<void(std::size_t instance, instance_result &result)> run;
+};
+
+/// @brief Results of one run of the pool, one entry per instance.
+struct instance_pool_result {
+  /// @brief One entry per instance, in instance order.
+  std::vector<instance_result> instances;
+};
+
+/// @brief How decoder instances are laid out across CPUs.
+///
+/// Instance i is given @p width consecutive CPUs starting at
+/// @p base + i * stride.  Width exists because a decoder's internal threads
+/// inherit their creator's affinity mask, so a width of 1 confines all of them
+/// to a single CPU; a decoder run with num_threads=8 needs a width to match.
+/// Stride exists to control the gap between instances -- most usefully to skip
+/// SMT siblings, since consecutive CPU *ids* are not necessarily distinct
+/// physical cores.
+struct core_layout {
+  /// @brief First CPU of instance 0. Negative disables pinning entirely,
+  /// matching core_pinning in realtime/pipeline.h.
+  int base = -1;
+  /// @brief Consecutive CPUs each instance may run on. 0 is treated as 1.
+  std::size_t width = 1;
+  /// @brief Distance between the first CPUs of consecutive instances. 0 means
+  /// "same as width", which packs instances back to back without overlap.
+  std::size_t stride = 0;
+};
+
+/// @brief Resolve core_layout::stride, applying the "0 means width" default.
+std::size_t effective_stride(const core_layout &layout);
+
+/// @brief CPUs one instance effectively owns.
+///
+/// This is the share a decoder should size itself against when it was asked to
+/// size itself from the machine (the num_threads=0 sentinel), since each
+/// instance resolving that sentinel on its own would claim the whole machine
+/// and N instances would then ask for N machines' worth of threads.
+///
+/// @param num_instances Concurrent instances sharing the machine; 0 counts as
+/// 1.
+/// @param layout CPU placement. When pinning is on the answer is exactly the
+/// block width, which is all the instance is allowed to use.
+/// @param num_cpus Visible CPU count; 0 (unknown) yields 1 rather than a
+/// guess.
+std::size_t cpus_per_instance(std::size_t num_instances,
+                              const core_layout &layout, unsigned num_cpus);
+
+/// @brief Worker threads to substitute for one instance's num_threads=0.
+///
+/// The instance's CPU share less a reserve, because the instance thread is not
+/// a bystander: it runs a slice of every fork-join phase, spins on the join
+/// barrier afterwards, and busy-waits between paced rounds, so a pool as wide
+/// as the share leaves it competing with its own workers and makes every
+/// barrier pay for the preemption. The reserve is at least one CPU and grows
+/// to the four hardware threads a decoder holds back from a whole machine,
+/// which keeps a narrow block from giving up most of itself.
+///
+/// Never 0, since that is the sentinel meaning "size yourself from the
+/// machine" -- the request being substituted in the first place.
+///
+/// @param num_instances Concurrent instances sharing the machine; 0 counts as
+/// 1.
+/// @param layout CPU placement, as for cpus_per_instance().
+/// @param num_cpus Visible CPU count; 0 (unknown) yields 1 rather than a
+/// guess.
+std::size_t worker_threads_per_instance(std::size_t num_instances,
+                                        const core_layout &layout,
+                                        unsigned num_cpus);
+
+/// @brief CPUs this process is allowed to run on, ascending.
+///
+/// Automatic placement has to choose CPUs, so it asks the OS which ones it may
+/// actually use rather than assuming the machine's whole range: a cgroup
+/// cpuset rejects a bind outside itself, and a taskset mask would be silently
+/// widened instead. Empty when the query fails or is unsupported.
+std::vector<int> allowed_cpus();
+
+/// @brief Divide @p cpus evenly among @p num_instances, a block each.
+///
+/// Instances tile the range from its first CPU upwards, so the layout depends
+/// on the instance count and has to be recomputed for each row of a sweep.
+///
+/// @param num_instances Instances to place; 0 disables pinning.
+/// @param cpus Assignable CPUs, as returned by allowed_cpus(). Fewer CPUs than
+/// instances disables pinning, since blocks would have to overlap.
+/// @returns A layout with base at the first CPU and width
+/// cpus.size() / num_instances, or pinning disabled when there is nothing to
+/// divide.
+/// @throws std::runtime_error when @p cpus is not a contiguous run, which a
+/// base-plus-stride layout cannot describe.
+core_layout divide_cpus(std::size_t num_instances,
+                        const std::vector<int> &cpus);
+
+/// @brief A contiguous run of CPUs one instance may run on.
+struct cpu_block {
+  /// @brief First CPU in the block, or -1 when pinning is disabled.
+  int first = -1;
+  /// @brief How many consecutive CPUs the block covers, 0 when disabled.
+  std::size_t count = 0;
+};
+
+/// @brief Run @p num_instances copies of @p work concurrently, one thread each.
+///
+/// Each instance pins itself (when @p layout enables pinning), runs
+/// @p work.setup, waits at the start gate until every instance has done the
+/// same, then runs @p work.run and records how long that took in its own
+/// instance_result::wall_us. An instance that fails to pin or throws during
+/// setup records the reason in its instance_result::error and skips the run
+/// phase without stalling the others.
+///
+/// @param num_instances Number of concurrent decoder instances. 0 yields an
+/// empty result.
+/// @param layout CPU placement for the instances.
+/// @param work Per-instance setup and timed run callables.
+/// @throws std::runtime_error when the requested cores cannot be honored.
+instance_pool_result run_instances(std::size_t num_instances,
+                                   const core_layout &layout,
+                                   const instance_work &work);
+
+/// @brief Resolve the CPUs an instance pins to under @p layout.
+/// @param instance Zero-based instance index.
+/// @param layout CPU placement, whose base may be negative to disable pinning.
+/// @param num_cpus Visible CPU count used for range checking; 0 skips the
+/// check (std::thread::hardware_concurrency() is allowed to return 0).
+/// @returns The block to bind to, or a disabled block when pinning is off.
+/// @throws std::runtime_error when the block runs past the visible CPUs or
+/// cannot be represented in a cpu_set_t.
+cpu_block resolve_instance_cpus(std::size_t instance, const core_layout &layout,
+                                unsigned num_cpus);
+
+/// @brief Bind the calling thread to @p block.
+/// @param block CPUs to allow, or a disabled block for no-op.
+/// @returns An empty string on success, otherwise a description of the
+/// failure. Reported rather than thrown because this runs on an instance
+/// thread.
+std::string pin_current_thread(const cpu_block &block);
+
+/// @brief Which sample vector of an instance_result to read.
+enum class instance_sample_kind {
+  shot, ///< instance_result::shot_us
+  tail, ///< instance_result::tail_us
+};
+
+/// @brief Concatenate one sample vector from every instance, in order.
+///
+/// Pooling the samples is what makes the reported percentiles describe the
+/// whole machine under load: a p99 taken from one instance says nothing about
+/// the other instances contending with it.
+std::vector<double>
+concat_instance_samples(const std::vector<instance_result> &instances,
+                        instance_sample_kind kind);
+
+/// @brief Shot and logical-error counts summed over all instances.
+struct instance_totals {
+  std::size_t shots = 0;
+  std::size_t logical_errors = 0;
+};
+
+/// @brief Sum the per-instance shot and logical-error counters.
+instance_totals
+sum_instance_results(const std::vector<instance_result> &instances);
+
+/// @brief First instance failure, prefixed with the instance index.
+/// @returns An empty string when every instance succeeded.
+std::string first_instance_error(const std::vector<instance_result> &instances);
+
+/// @brief First timed shot an instance starts on.
+///
+/// Instance i starts i * shots / num_instances shots into the pool and wraps,
+/// so concurrent instances do not walk the shared syndrome pool in lockstep
+/// while still decoding the same multiset of shots (which keeps the logical
+/// error rate comparable across instance counts).
+std::size_t instance_shot_offset(std::size_t instance,
+                                 std::size_t num_instances, std::size_t shots);
+
+} // namespace cudaq::qec::benchmark

--- a/benchmarks/qec/nv_fusion_latency/README.md
+++ b/benchmarks/qec/nv_fusion_latency/README.md
@@ -1,0 +1,56 @@
+# NV-Fusion latency study
+
+This directory contains the plotting script for the NV-Fusion performance page
+at `docs/sphinx/performance/nv_fusion_latency_user_guide.rst`.
+
+The published measurements were collected on an NVIDIA Vera CPU system with
+`benchmark-qec-decoder`.
+Commit `3539fecbb1c6e0ca4331b2980a4312d24e54d8b1` is the benchmark-source
+revision used to interpret and plot the supplied logs; the logs themselves do
+not contain a source revision or complete software manifest. The benchmark
+generates rotated-surface-code Z-memory circuits with Stim and writes
+machine-readable rows prefixed by `csv,`.
+
+## Collect results
+
+Build the benchmark as described in
+`benchmarks/qec/decoder_latency/README.md`, then run from the build directory:
+
+```bash
+mkdir -p benchmark-logs
+
+for d in 5 7 13; do
+  numactl --cpunodebind=0 --membind=0 \
+    ./benchmarks/qec/decoder_latency/benchmark-qec-decoder \
+      --decoders pymatching,nv-fusion-decoder \
+      --decoder_instances 1,2,4,8 \
+      --pin-instances \
+      --distances "$d" \
+      --rounds 10,100,500,1000,2000,5000,10000 \
+      --param num_threads=0 \
+      --mode stream \
+      --round_interval_us 1 \
+      --shots 1000 \
+      --csv 2>&1 |
+    tee "benchmark-logs/log-py-nvfusion-stream-d${d}.txt"
+done
+```
+
+For a machine with fewer available cores, reduce the streaming instance list.
+The published Vera data contains one, two, four, and eight instances for all
+three distances.
+
+## Generate figures
+
+From the repository root:
+
+```bash
+python benchmarks/qec/nv_fusion_latency/plot_results.py \
+  /path/to/benchmark-logs assets/docs
+```
+
+The script generates the three PNG files referenced by the performance page,
+including the conceptual fusion-block diagram.
+It reads CSV records from both per-run `.txt` logs and consolidated
+`log*.out` files; consolidated output supplements records missing from the
+per-run logs.

--- a/benchmarks/qec/nv_fusion_latency/plot_results.py
+++ b/benchmarks/qec/nv_fusion_latency/plot_results.py
@@ -315,7 +315,7 @@ def plot_stream_tail(rows: list[dict], output: Path) -> None:
     for ax in flat[len(distances):]:
         ax.set_visible(False)
     fig.suptitle(
-        "NVIDIA Vera CPU — streaming completion latency, one decoder instance\n"
+        "NVIDIA Vera CPU — Streaming Tail Latency, one decoder instance\n"
         "Final detector round through observable correction; 1 µs round interval",
         fontsize=13,
     )

--- a/benchmarks/qec/nv_fusion_latency/plot_results.py
+++ b/benchmarks/qec/nv_fusion_latency/plot_results.py
@@ -1,0 +1,393 @@
+#!/usr/bin/env python3
+"""Plot the NV-Fusion latency study from benchmark-qec-decoder CSV logs."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+from pathlib import Path
+
+import matplotlib
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+import matplotlib.ticker as ticker
+from matplotlib.patches import FancyBboxPatch
+
+COLUMNS = [
+    "csv",
+    "mode",
+    "id",
+    "decoder",
+    "distance",
+    "rounds",
+    "detector_rounds",
+    "instances",
+    "shots",
+    "total_shots",
+    "noise",
+    "p50",
+    "p90",
+    "p99",
+    "tail_p50",
+    "tail_p99",
+    "rounds_per_second",
+    "ler",
+]
+INDEX = {name: i for i, name in enumerate(COLUMNS)}
+NUMERIC_FIELDS = {
+    "p50",
+    "p90",
+    "p99",
+    "tail_p50",
+    "tail_p99",
+    "rounds_per_second",
+    "ler",
+}
+PLOT_DISTANCES = (5, 7, 13)
+PM_COLOR = "#76B900"
+NVF_COLOR = "#1F77B4"
+DISTANCE_COLORS = {
+    5: "#1f77b4",
+    7: "#ff7f0e",
+    13: "#2ca02c",
+    17: "#d62728",
+    21: "#9467bd",
+}
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("log_directory", type=Path)
+    parser.add_argument("output_directory", type=Path)
+    return parser.parse_args()
+
+
+def parse_logs(log_directory: Path) -> list[dict]:
+    stream: dict[tuple, dict] = {}
+
+    paths = [
+        *sorted(log_directory.glob("log*.txt")),
+        *sorted(log_directory.glob("log*.out")),
+    ]
+    for path in paths:
+        with path.open(newline="") as handle:
+            for raw in csv.reader(handle):
+                if len(raw) < len(COLUMNS) or raw[0].strip() != "csv":
+                    continue
+                if not raw[INDEX["distance"]].strip().isdigit():
+                    continue
+                row = {name: raw[i].strip() for i, name in enumerate(COLUMNS)}
+                for field in ("distance", "rounds", "instances", "shots"):
+                    row[field] = int(row[field])
+                for field in NUMERIC_FIELDS:
+                    row[field] = float(row[field])
+                row["source"] = path.name
+
+                if row["mode"] == "stream":
+                    key = (
+                        row["decoder"],
+                        row["distance"],
+                        row["rounds"],
+                        row["instances"],
+                    )
+                    # Prefer a dedicated per-run log; consolidated scheduler
+                    # output supplements keys whose log file is missing.
+                    stream.setdefault(key, row)
+
+    return list(stream.values())
+
+
+def configure_axis(ax: plt.Axes, rounds: list[int]) -> None:
+    ax.set_xscale("log")
+    ax.set_yscale("log")
+    ax.set_xticks(rounds)
+    ax.xaxis.set_major_formatter(ticker.ScalarFormatter())
+    ax.tick_params(axis="x", labelrotation=35, labelsize=7)
+    ax.tick_params(axis="y", labelsize=8)
+    ax.grid(True, which="both", alpha=0.25)
+
+
+def save(fig: plt.Figure, output: Path, name: str) -> None:
+    fig.tight_layout()
+    fig.savefig(output / name, dpi=180, bbox_inches="tight")
+    plt.close(fig)
+
+
+def plot_fusion_blocks(output: Path) -> None:
+    fig, ax = plt.subplots(figsize=(12, 5.2))
+    width = 0.82
+    height = 0.58
+
+    def node(x: float, y: float, text: str, color: str) -> None:
+        patch = FancyBboxPatch(
+            (x - width / 2, y - height / 2),
+            width,
+            height,
+            boxstyle="round,pad=0.04,rounding_size=0.06",
+            facecolor=color,
+            edgecolor="#333333",
+            linewidth=1.2,
+            zorder=2,
+        )
+        ax.add_patch(patch)
+        ax.text(x, y, text, ha="center", va="center", fontsize=9, zorder=3)
+
+    def fused_pair(left_x: float, right_x: float, child_y: float,
+                   parent_x: float, parent_y: float) -> None:
+        child_top = child_y + height / 2
+        parent_bottom = parent_y - height / 2
+        join_y = (child_top + parent_bottom) / 2
+        for child_x, target_x in (
+            (left_x, parent_x - 0.15),
+            (right_x, parent_x + 0.15),
+        ):
+            ax.plot(
+                [child_x, child_x, target_x],
+                [child_top, join_y, join_y],
+                color="#666666",
+                linewidth=1.2,
+                zorder=1,
+            )
+            ax.annotate(
+                "",
+                xy=(target_x, parent_bottom),
+                xytext=(target_x, join_y),
+                arrowprops={
+                    "arrowstyle": "-|>",
+                    "color": "#666666",
+                    "linewidth": 1.2,
+                    "shrinkA": 2,
+                    "shrinkB": 2,
+                },
+                zorder=1,
+            )
+
+    leaf_y, layer1_y, layer2_y = 0.25, 1.65, 3.05
+    for index in range(6):
+        node(index, leaf_y, f"Block {index}\nr{index}–r{index + 1}", "#DCEEFF")
+
+    layer1_x = (0.5, 2.5, 4.5)
+    for index, x in enumerate(layer1_x):
+        node(x, layer1_y, f"Layer-1 fuse {index}", "#DDF3D3")
+        fused_pair(2 * index, 2 * index + 1, leaf_y, x, layer1_y)
+
+    layer2_x = (1.5, 3.5)
+    for index, x in enumerate(layer2_x):
+        node(x, layer2_y, f"Layer-2 fuse {index}", "#FFF0C9")
+        fused_pair(
+            layer1_x[index],
+            layer1_x[index + 1],
+            layer1_y,
+            x,
+            layer2_y,
+        )
+
+    ax.text(-0.62,
+            leaf_y,
+            "Leaf MWPMs",
+            ha="right",
+            va="center",
+            fontsize=10,
+            fontweight="bold")
+    ax.text(-0.62,
+            layer1_y,
+            "Adjacent pairs",
+            ha="right",
+            va="center",
+            fontsize=10,
+            fontweight="bold")
+    ax.text(-0.62,
+            layer2_y,
+            "Overlapping\nfour-block windows",
+            ha="right",
+            va="center",
+            fontsize=10,
+            fontweight="bold")
+    for y in (leaf_y, layer1_y, layer2_y):
+        ax.text(5.72,
+                y,
+                "⋯",
+                ha="center",
+                va="center",
+                fontsize=24,
+                color="#555555")
+    ax.annotate(
+        "Syndrome arrival / time — schedule continues",
+        xy=(6.2, -0.58),
+        xytext=(-0.4, -0.58),
+        ha="center",
+        va="center",
+        fontsize=10,
+        arrowprops={
+            "arrowstyle": "->",
+            "linewidth": 1.3,
+            "color": "#333333"
+        },
+    )
+    ax.set_xlim(-1.5, 6.35)
+    ax.set_ylim(-0.9, 3.65)
+    ax.axis("off")
+    fig.suptitle(
+        "NV-Fusion two-layer brickwall schedule\n"
+        "The pattern repeats as new syndrome blocks arrive",
+        fontsize=13,
+    )
+    save(fig, output, "nv_fusion_block_schedule.png")
+
+
+def stream_value(
+    rows: list[dict],
+    decoder: str,
+    distance: int,
+    rounds: int,
+    field: str,
+    instances: int = 1,
+) -> float | None:
+    for row in rows:
+        if (row["decoder"] == decoder and row["distance"] == distance and
+                row["rounds"] == rounds and row["instances"] == instances):
+            return row[field]
+    return None
+
+
+def plot_stream_tail(rows: list[dict], output: Path) -> None:
+    distances = [
+        distance for distance in PLOT_DISTANCES
+        if any(row["distance"] == distance and
+               row["decoder"] == "nv-fusion-decoder" for row in rows)
+    ]
+    fig, axes = plt.subplots(1,
+                             len(distances),
+                             figsize=(5 * len(distances), 4.6),
+                             squeeze=False)
+    flat = axes.ravel()
+
+    for ax, distance in zip(flat, distances):
+        rounds = sorted({
+            row["rounds"]
+            for row in rows
+            if row["decoder"] == "nv-fusion-decoder" and
+            row["distance"] == distance and row["instances"] == 1
+        })
+        for decoder, color, label in (
+            ("pymatching", PM_COLOR, "PyMatching"),
+            ("nv-fusion-decoder", NVF_COLOR, "NV-Fusion"),
+        ):
+            p50 = [
+                stream_value(rows, decoder, distance, r, "tail_p50")
+                for r in rounds
+            ]
+            p99 = [
+                stream_value(rows, decoder, distance, r, "tail_p99")
+                for r in rounds
+            ]
+            valid = [(r, median, tail)
+                     for r, median, tail in zip(rounds, p50, p99)
+                     if median is not None and tail is not None]
+            x = [item[0] for item in valid]
+            median = [item[1] for item in valid]
+            tail = [item[2] for item in valid]
+            ax.fill_between(
+                x,
+                median,
+                tail,
+                color=color,
+                alpha=0.18,
+                label=f"{label} p50–p99",
+            )
+            ax.plot(
+                x,
+                median,
+                color=color,
+                marker="o",
+                markersize=4,
+                linewidth=1.8,
+                label=f"{label} p50",
+            )
+        configure_axis(ax, rounds)
+        ax.axvline(192, color="gray", linestyle=":", linewidth=1)
+        ax.set_title(f"Distance {distance}")
+        ax.set_xlabel("Stabilizer rounds")
+        ax.set_ylabel("Streaming tail latency (µs)")
+        ax.legend(fontsize=7)
+
+    for ax in flat[len(distances):]:
+        ax.set_visible(False)
+    fig.suptitle(
+        "NVIDIA Vera CPU — streaming completion latency, one decoder instance\n"
+        "Final detector round through observable correction; 1 µs round interval",
+        fontsize=13,
+    )
+    save(fig, output, "nv_fusion_streaming_tail_latency.png")
+
+
+def plot_instance_tail(rows: list[dict], output: Path) -> None:
+    distances = sorted({
+        distance for distance in PLOT_DISTANCES if len({
+            row["instances"] for row in rows
+            if row["decoder"] == "nv-fusion-decoder" and
+            row["distance"] == distance
+        }) > 1
+    })
+    fig, axes = plt.subplots(1, 2, figsize=(12, 4.8))
+    for ax, round_count in zip(axes, (1000, 10000)):
+        for distance in distances:
+            instances = sorted({
+                row["instances"]
+                for row in rows
+                if row["decoder"] == "nv-fusion-decoder" and
+                row["distance"] == distance and row["rounds"] == round_count
+            })
+            values = [
+                stream_value(
+                    rows,
+                    "nv-fusion-decoder",
+                    distance,
+                    round_count,
+                    "tail_p99",
+                    instance,
+                ) for instance in instances
+            ]
+            valid = [(instance, value)
+                     for instance, value in zip(instances, values)
+                     if value is not None]
+            if not valid:
+                continue
+            valid_instances, valid_values = zip(*valid)
+            ax.plot(
+                valid_instances,
+                valid_values,
+                color=DISTANCE_COLORS[distance],
+                marker="o",
+                linewidth=1.8,
+                label=f"d={distance}",
+            )
+        ax.set_yscale("log")
+        ax.set_xticks([1, 2, 4, 8])
+        ax.set_xlabel("Concurrent decoder instances")
+        ax.set_ylabel("Streaming tail p99 (µs)")
+        ax.set_title(f"{round_count:,} rounds")
+        ax.grid(True, which="both", alpha=0.25)
+        ax.legend(fontsize=8)
+    fig.suptitle(
+        "NVIDIA Vera CPU — NV-Fusion latency under concurrent decoder load\n"
+        "Instances are pinned to non-overlapping CPU sets",
+        fontsize=13,
+    )
+    save(fig, output, "nv_fusion_streaming_instance_latency.png")
+
+
+def main() -> None:
+    args = parse_args()
+    args.output_directory.mkdir(parents=True, exist_ok=True)
+    stream = parse_logs(args.log_directory)
+    if not stream:
+        raise RuntimeError("Expected streaming CSV records")
+    plot_fusion_blocks(args.output_directory)
+    plot_stream_tail(stream, args.output_directory)
+    plot_instance_tail(stream, args.output_directory)
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/sphinx/api/qec/cpp_api.rst
+++ b/docs/sphinx/api/qec/cpp_api.rst
@@ -186,6 +186,13 @@ NVIDIA QLDPC Decoder
 
 .. include:: nv_qldpc_decoder_api.rst
 
+.. _nv_fusion_decoder_api_cpp:
+
+NVIDIA Fusion Decoder
+---------------------
+
+.. include:: nv_fusion_decoder_api.rst
+
 Sliding Window Decoder
 ----------------------
 

--- a/docs/sphinx/api/qec/nv_fusion_decoder_api.rst
+++ b/docs/sphinx/api/qec/nv_fusion_decoder_api.rst
@@ -1,7 +1,7 @@
 .. class:: nv_fusion_decoder
 
     A multi-threaded minimum-weight perfect matching (MWPM) decoder based on
-    the NV FusionBrickwall algorithm.  It is in essence a combination of
+    the NV Fusion Brickwall algorithm.  It is in essence a combination of
     *fusion blossom* with *sparse blossom*: the detector matching graph is
     partitioned into temporal blocks that are solved independently and then
     fused across their boundaries (fusion blossom), while each individual

--- a/docs/sphinx/api/qec/nv_fusion_decoder_api.rst
+++ b/docs/sphinx/api/qec/nv_fusion_decoder_api.rst
@@ -2,9 +2,10 @@
 
     A multi-threaded minimum-weight perfect matching (MWPM) decoder based on
     the NV Fusion Brickwall algorithm.  It is in essence a combination of
-    *fusion blossom* with *sparse blossom*: the detector matching graph is
-    partitioned into temporal blocks that are solved independently and then
-    fused across their boundaries (fusion blossom), while each individual
+    `fusion blossom <https://arxiv.org/abs/2305.08307>`_ with
+    `sparse blossom <https://arxiv.org/abs/2303.15933>`_: the detector matching
+    graph is partitioned into temporal blocks that are solved independently and
+    then fused across their boundaries (fusion blossom), while each individual
     block is solved by PyMatching's sparse blossom implementation.  Blocks
     and the fuses between them form a dependency DAG that is dispatched to a
     worker pool as syndrome data arrives, so the decoder is designed to

--- a/docs/sphinx/api/qec/nv_fusion_decoder_api.rst
+++ b/docs/sphinx/api/qec/nv_fusion_decoder_api.rst
@@ -1,0 +1,289 @@
+.. class:: nv_fusion_decoder
+
+    A multi-threaded minimum-weight perfect matching (MWPM) decoder based on
+    the NV FusionBrickwall algorithm.  It is in essence a combination of
+    *fusion blossom* with *sparse blossom*: the detector matching graph is
+    partitioned into temporal blocks that are solved independently and then
+    fused across their boundaries (fusion blossom), while each individual
+    block is solved by PyMatching's sparse blossom implementation.  Blocks
+    and the fuses between them form a dependency DAG that is dispatched to a
+    worker pool as syndrome data arrives, so the decoder is designed to
+    maximize parallel processing utilization and reach minimal latency in a
+    streaming, realtime decoding environment.  Offline batch decoding is
+    supported through the same scaffold.
+
+    Thread count is set by ``num_threads``, which defaults to ``1``; pass
+    ``0`` to size the pool from the hardware.  That pool parallelizes the
+    blocks and fuses *within* one shot; it does not make a decoder callable
+    from several threads at once.
+
+    .. important::
+      **One decoder decodes one shot at a time.**  Both ``decode()`` and the
+      realtime enqueue path keep per-shot state on the decoder -- syndrome
+      routing, block and fuse matching state, and the herald flags -- so two
+      threads sharing a decoder corrupt each other.  Use one decoder per
+      thread.
+
+      This applies to ``decode_async()``, which runs ``decode()`` on a new
+      thread: keeping two futures outstanding on the *same* decoder is not
+      supported.  ``decode_batch()`` is sequential and therefore safe.
+
+      Concurrent ``decode()`` calls on one nv-fusion decoder raise
+      ``std::logic_error`` rather than interleaving, so the misuse surfaces as
+      an exception instead of a wrong answer.
+
+    The decoder is **graphlike**: every error mechanism must touch exactly
+    one (boundary edge) or two (bulk edge) detectors.  Constructing from
+    ``H``, that is a constraint on its columns; constructing from a DEM,
+    Stim's ``^`` decomposition suggestions are applied first, so a hyperedge
+    is accepted only when the DEM suggests a graphlike decomposition for it.
+    Block size is set by ``block_leaf_size``, blocks overlap so
+    that fusing adjacent pairs propagates information across their shared
+    boundary, and the observable corrections that come out are
+    XOR-accumulated into a running Pauli frame.
+
+    .. important::
+      A **single-leaf** schedule is one block with no fuses, and is exact
+      monolithic MWPM.  Any **fused** schedule is a windowed approximation:
+      the brickwall has two fuse layers, so each block's corrections are
+      decided within a window of at most four leaves (two for the first and
+      last blocks) rather than against the whole shot.  An error chain longer
+      than that window can be matched differently than monolithic MWPM would
+      match it, and the result is not always flagged -- the heralded-failure
+      check fires on unresolved virtual-boundary matches, which an undersized
+      window does not reliably produce.
+
+      Sizing the leaf from the code distance is what keeps the window large
+      enough for this to be safe; see ``block_leaf_size`` below.
+
+    References:
+
+    - `Sparse Blossom: correcting a million errors per core second with minimum-weight matching <https://arxiv.org/abs/2303.15933>`_
+    - `Fusion Blossom: Fast MWPM Decoders for QEC <https://arxiv.org/abs/2305.08307>`_
+    - `Quantum error correction below the surface code threshold <https://arxiv.org/abs/2408.13687>`_
+
+    .. note::
+      It is required to create decoders with the ``get_decoder`` API from the
+      CUDA-QX extension points API, such as
+
+      .. tab:: Python
+
+        .. code-block:: python
+
+            import cudaq_qec as qec
+            import numpy as np
+
+            # Two boundary edges carrying one observable each, plus a timelike
+            # edge between the detectors carrying none.
+            H = np.array([[1, 0, 1],              # rows = detectors
+                          [0, 1, 1]], dtype=np.uint8)
+            O = np.array([[1, 0, 0],              # rows = observables
+                          [0, 1, 0]], dtype=np.uint8)
+            opts = {
+                "O": O,
+                # int32, one round index per detector
+                "detector_round": np.array([0, 1], dtype=np.int32),
+            }
+            decoder = qec.get_decoder('nv-fusion-decoder', H, **opts)
+            decoder.decode([1.0, 0.0])            # -> [1.0, 0.0]
+
+      .. tab:: C++
+
+        .. code-block:: cpp
+
+            #include "cudaq/qec/decoder.h"
+
+            // Two boundary edges carrying one observable each, plus a
+            // timelike edge between the detectors carrying none.
+            cudaqx::tensor<uint8_t> H, O;
+            std::vector<uint8_t> H_vec = {1, 0, 1,   // rows = detectors
+                                          0, 1, 1};
+            std::vector<uint8_t> O_vec = {1, 0, 0,   // rows = observables
+                                          0, 1, 0};
+            H.copy(H_vec.data(), {2, 3});
+            O.copy(O_vec.data(), {2, 3});
+
+            cudaqx::heterogeneous_map opts;
+            opts.insert("O", O);
+            opts.insert("detector_round", std::vector<int32_t>{0, 1});
+            auto decoder = cudaq::qec::get_decoder("nv-fusion-decoder", H,
+                                                   opts);
+            decoder->decode({1.0, 0.0});          // -> {1.0, 0.0}
+
+    .. note::
+      The ``"nv-fusion-decoder"`` implements the :class:`cudaq_qec.Decoder`
+      interface for Python and the :cpp:class:`cudaq::qec::decoder` interface
+      for C++, so it supports all the methods in those respective classes.
+
+    :param H: Parity-check matrix (sparse binary matrix or dense
+      ``tensor<uint8_t>``), shape ``(num_detectors, num_error_mechanisms)``.
+      When the matching graph is built from it, each column must have exactly
+      one or two non-zero rows (graphlike error mechanisms); alongside a
+      ``dem_string`` only its shape is read.  Pass Stim DEM text in this
+      position instead to construct from a DEM, which needs neither ``H`` nor
+      ``O``.
+    :param params: Heterogeneous map of parameters:
+
+        .. note::
+          These are the C++ and Python parameters.  The realtime YAML surface
+          is narrower: ``decoder_custom_args`` accepts only ``num_threads``,
+          ``block_leaf_size``, ``fusion_strategy`` and ``error_rate_vec``, and
+          rejects any other key.  A YAML configuration supplies the matrices
+          and the temporal layout through the top-level ``H_sparse``,
+          ``O_sparse`` and ``D_sparse`` fields instead.
+
+        **Construction:**
+
+        - ``dem_string`` (str): Serialized Stim detector error model string.
+          Equivalent to passing the DEM text in place of ``H``, and only
+          needed when you want to supply an ``H`` of your own alongside it:
+          the matching graph and observable wiring still come from the DEM, so
+          ``H`` is read for its shape alone and its dimensions must agree with
+          ``dem.count_detectors()`` and ``dem.count_errors()``.  Either way,
+          Stim detector coordinates supply the per-detector temporal round map
+          automatically, removing the need to pass ``detector_round``
+          explicitly — provided every detector carries a coordinate.  A DEM
+          with an uncoordinated detector is rejected at construction, asking
+          for ``detector_round``.
+
+        - ``O`` (``tensor<uint8_t>`` or ``sparse_binary_matrix``): Observable
+          matrix, shape ``(num_observables, num_error_mechanisms)``.  When
+          provided, ``decode()`` returns observable flip predictions of length
+          ``num_observables`` rather than a block-size correction vector;
+          without it the ``H`` path stays in edge mode.  Redundant with a DEM,
+          which already carries the observable wiring and decodes to
+          ``dem.count_observables()`` observables on its own.  Supplying one
+          alongside a DEM is only useful to widen the correction buffer past
+          that count; an ``O`` with fewer rows than the DEM declares is
+          rejected.  Takes precedence over the ``O_sparse``
+          set-from-outside path: when ``O`` is given, a later
+          ``set_O_sparse()`` does not change the observable wiring the decoder
+          matches against.  Supply one or the other to keep that unambiguous.
+
+        **Temporal layout (one of the following is required, unless a DEM
+        supplies detector coordinates):**
+
+        - ``detector_round`` (``vector<int32_t>``): Per-detector temporal
+          round index, length ``H.num_rows()``.  Maps each parent detector to
+          its round in 0-based integer coordinates.  Takes highest priority
+          over all automatic derivation paths.
+
+        - ``D_sparse`` (``vector<int64_t>``): Flat measurement-to-detector
+          map in row-major format, with ``-1`` row terminators.  The decoder
+          infers the per-detector round from the column stride of the
+          two-entry (timelike) rows.  Rows with more than two entries are
+          treated as terminal boundary detectors placed in the last round.
+          Used automatically by the realtime layer; can also be supplied
+          explicitly when ``detector_round`` is not available at construction
+          time.
+
+        The three sources are consulted in that order: an explicit
+        ``detector_round`` first, then DEM coordinates, then ``D_sparse``.  A
+        DEM therefore takes precedence over ``D_sparse``, and one missing a
+        detector coordinate fails rather than falling back to it.  Without a
+        DEM and with neither vector given, scaffold construction is deferred
+        until ``set_D_sparse()`` is called.
+
+        **Blocking and threading:**
+
+        - ``block_leaf_size`` (uint64): Number of temporal rounds per leaf
+          block.  Smaller values reduce per-block latency but increase fuse
+          overhead; larger values amortize fuse cost at the expense of
+          latency.  An explicit value is always honored as given; if it is
+          below the measured code distance and the schedule fuses more than
+          one block, construction logs a warning, because such a leaf cannot
+          contain a logical error chain and inflates the logical error rate
+          without raising a heralded failure.
+
+          When omitted, the schedule is selected automatically:
+
+          - **192 rounds or fewer** -- a single leaf spanning the shot, which
+            is exact monolithic MWPM.
+          - **More than 192 rounds** -- a fused schedule with a leaf of
+            ``2 * d``, where ``d`` is the code distance measured from the
+            matching graph as the shortest undetectable logical error.  This
+            bounds tail latency, which under a single leaf grows linearly with
+            the number of rounds.
+          - **Distance not measurable** (a model with no observables, or none
+            admitting an undetectable logical error) -- a single leaf at any
+            shot length, since fusing on an unverified leaf height inflates the
+            logical error rate silently.
+
+          .. warning::
+            The second case trades exactness for latency, and it is the
+            default.  A shot longer than 192 rounds is decoded by the windowed
+            approximation described above, not by monolithic MWPM.  A leaf of
+            ``2 * d`` puts four times the margin over the smallest leaf
+            measured to be safe (``0.5 * d``), and over d=5..21 on rotated
+            surface and repetition codes it reproduced single-leaf corrections
+            shot for shot -- but that is a measured result on those codes and
+            noise models, not a guarantee for every code.
+
+            To keep exact monolithic MWPM at any shot length, set
+            ``block_leaf_size`` to the shot's full round count explicitly.
+
+          This differs from earlier releases, where omitting
+          ``block_leaf_size`` always produced a single leaf.
+
+        - ``num_threads`` (uint64): Number of CPU threads to use during
+          scaffold construction and parallel fuse operations.  Defaults to
+          ``1``.
+
+        **Edge weights:**
+
+        - ``error_rate_vec`` (``vector<double>``): Physical error probability
+          per error mechanism (column of ``H``), length
+          ``H.num_cols()``.  Each value must be in the range ``(0, 0.5]``.
+          When provided, edge weights are computed as the log-likelihood
+          ratio ``-log(p / (1 - p))``.  When absent, unit weights are
+          used.  Applies to the ``H`` construction path only: a DEM already
+          carries a probability per error mechanism, so ``error_rate_vec`` is
+          ignored when constructing from one.
+
+        **Fusion schedule:**
+
+        - ``fusion_strategy`` (str): Fusion schedule to use.  Currently
+          only ``"brickwall"`` is supported.
+
+    **Decode result format:**
+
+    ``decode()`` returns a :class:`~cudaq_qec.DecoderResult` where:
+
+    - ``result`` — length ``num_observables`` when constructed from a DEM or
+      with ``O``, otherwise length ``block_size``.  In
+      observable mode each entry is ``0.0`` or ``1.0`` indicating a
+      predicted logical flip.  In edge mode each entry is ``1.0`` if the
+      corresponding H column was selected as a matching edge, ``0.0``
+      otherwise.
+
+    - ``converged`` — ``True`` if the fuse pass raised no herald flag.  A
+      ``False`` value indicates a suspect or ambiguous match; the correction
+      is still populated and may be used.
+
+    - ``opt_results`` — heterogeneous map with key:
+
+      - ``heralded`` (bool): Raw herald flag from the brickwall fuse pass,
+        corresponding to ``converged = not heralded``.
+
+    **Realtime streaming:**
+
+    The decoder supports the base-class realtime API
+    (``enqueue_syndrome``, ``get_obs_corrections``, ``reset_decoder``,
+    ``clear_corrections``).  The realtime path accepts raw per-round
+    *measurement* bits rather than pre-differenced detector bits; the
+    decoder accumulates measurements internally and computes detector events
+    via ``D_sparse`` as each detector round's measurements become complete.
+    Observable corrections are XOR-accumulated into a running Pauli frame
+    and exposed via ``get_obs_corrections()``.
+
+    .. note::
+      ``D_sparse`` must be configured (either via ``set_D_sparse()`` or
+      the ``D_sparse`` constructor parameter) before the first call to
+      ``enqueue_syndrome()``.  The realtime layer in the CUDA-QX QEC stack
+      sets ``D_sparse`` automatically; direct callers must set it manually.
+
+    .. note::
+      Observable corrections accumulate across shots.  Call
+      ``clear_corrections()`` or ``reset_decoder()`` between shots to
+      reset the Pauli frame.  ``reset_decoder()`` also rewinds the
+      streaming session; ``clear_corrections()`` does not.

--- a/docs/sphinx/api/qec/python_api.rst
+++ b/docs/sphinx/api/qec/python_api.rst
@@ -209,6 +209,13 @@ Relay Solutions Post-Processing
 .. autoclass:: cudaq_qec.relay_solutions.StopNConvSweep
     :members:
 
+.. _nv_fusion_decoder_api_python:
+
+NVIDIA Fusion Decoder
+---------------------
+
+.. include:: nv_fusion_decoder_api.rst
+
 Sliding Window Decoder
 ----------------------
 

--- a/docs/sphinx/components/qec/decoders.rst
+++ b/docs/sphinx/components/qec/decoders.rst
@@ -307,6 +307,12 @@ CUDA-Q QEC provides pre-built decoders for a variety of use cases.
      - Yes
      - Yes
      - Supports Relay BP and BP+OSD
+   * - NVIDIA Fusion Decoder
+     - `"nv-fusion-decoder"`
+     - Yes
+     - Yes
+     - Yes
+     - Multithreaded MWPM decoder optimized for low-latency streaming
    * - Tensor Network Decoder¹
      - `"tensor_network_decoder"`
      - Yes²
@@ -419,6 +425,19 @@ Usage:
         auto d2 = cudaq::qec::get_decoder("nv-qldpc-decoder", H, {{"use_osd", true}, {"bp_batch_size", 100}});
 
 For a runnable example, see :ref:`Getting Started with the NVIDIA QLDPC Decoder <qldpc_decoder_example>`.
+
+NVIDIA Fusion Decoder
+^^^^^^^^^^^^^^^^^^^^^
+
+The ``nv-fusion-decoder`` is a multithreaded minimum-weight perfect matching
+(MWPM) decoder for graphlike error models. It partitions detector data into
+temporal blocks and fuses their solutions to reduce latency in streaming,
+realtime decoding environments. It also supports offline batch decoding.
+
+See the :ref:`Python <nv_fusion_decoder_api_python>` and
+:ref:`C++ <nv_fusion_decoder_api_cpp>` API references for configuration and
+usage details. For benchmark results and reproduction instructions, see
+:doc:`NV-Fusion Decoder Latency </performance/nv_fusion_latency_user_guide>`.
 
 Tensor Network Decoder
 ^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/sphinx/conf.py.in
+++ b/docs/sphinx/conf.py.in
@@ -103,6 +103,7 @@ exclude_patterns = [
     '_templates',
     'examples/**/README.md',
     'api/qec/nv_qldpc_decoder_api.rst',
+    'api/qec/nv_fusion_decoder_api.rst',
     'api/qec/sliding_window_api.rst',
     'api/qec/trt_decoder_api.rst',
     'api/qec/tensor_network_decoder_api.rst',

--- a/docs/sphinx/performance/index.rst
+++ b/docs/sphinx/performance/index.rst
@@ -12,8 +12,13 @@ The second study shows how **relay solution recording** replaces a per-``stop_nc
 sweep of full decode runs with a single recording run plus offline post-processing,
 reproducing every RelayBP-N result exactly from one GPU pass.
 
+The third study shows how **NV-Fusion** overlaps decoding with syndrome
+acquisition, bounding the final-round response latency of long-running
+surface-code experiments.
+
 .. toctree::
    :maxdepth: 1
 
    Improving Relay BP Decoding With Gamma Ensembles <nv_qldpc_gamma_ensemble_user_guide>
    Sweeping Relay BP Stopping Criteria From a Single Run <nv_qldpc_relay_solutions_user_guide>
+   Bounding Real-Time Decode Latency With NV-Fusion <nv_fusion_latency_user_guide>

--- a/docs/sphinx/performance/nv_fusion_latency_user_guide.rst
+++ b/docs/sphinx/performance/nv_fusion_latency_user_guide.rst
@@ -106,14 +106,14 @@ used to interpret the data, not a complete reproducibility manifest.
      - PyMatching, using the same decomposed detector error model and sampled
        syndromes
 
-Streaming Completion Latency
-++++++++++++++++++++++++++++
+Streaming Tail Latency
++++++++++++++++++++++++
 
 The following figure shows median and p99 streaming tail latency for one
 decoder instance. Up to 100 rounds, the automatic schedule uses one exact
 leaf, and NV-Fusion broadly follows PyMatching. Above the 192-round automatic
-schedule threshold, NV-Fusion switches to fused leaves and its completion
-latency becomes only weakly dependent on the total number of rounds.
+schedule threshold, NV-Fusion switches to fused leaves and its tail latency
+becomes only weakly dependent on the total number of rounds.
 
 .. image:: ../../../assets/docs/nv_fusion_streaming_tail_latency.png
    :align: center

--- a/docs/sphinx/performance/nv_fusion_latency_user_guide.rst
+++ b/docs/sphinx/performance/nv_fusion_latency_user_guide.rst
@@ -1,0 +1,168 @@
+.. The figures on this page can be regenerated from benchmark logs with the
+   scripts in benchmarks/qec/nv_fusion_latency/ (see the README for the
+   commands, parameters, and plotting instructions).
+   Benchmark-source revision used to interpret the supplied logs:
+     cudaqx  3539fecbb1c6e0ca4331b2980a4312d24e54d8b1
+   The logs do not contain a source revision or complete software manifest.
+
+.. _nv_fusion_latency_user_guide:
+
+Bounding Real-Time Decode Latency With NV-Fusion
+================================================
+
+The NVIDIA Fusion decoder (``nv-fusion-decoder``) is a multi-threaded
+minimum-weight perfect matching (MWPM) decoder designed for long-running,
+real-time quantum error correction. It divides the detector matching graph
+into temporal leaf blocks, solves independent leaves as syndrome data arrives,
+and fuses their matchings through a dependency graph. This moves most decoding
+work ahead of the final syndrome round and limits how much work remains before
+the observable correction is available. Its implementation combines the
+`Sparse Blossom <https://arxiv.org/abs/2303.15933>`_ and
+`Fusion Blossom <https://arxiv.org/abs/2305.08307>`_ algorithms. Experimental
+real-time surface-code decoding is demonstrated in
+`Quantum error correction below the surface code threshold
+<https://arxiv.org/abs/2408.13687>`_.
+
+This study measures that final response time, called the *streaming tail
+latency*, on rotated surface-code Z-memory circuits. For 10,000-round
+experiments at code distances 5, 7, and 13, NV-Fusion lowered median
+streaming tail latency by 27--41x and p99 latency by 22--32x relative to
+monolithic PyMatching.
+
+What Is Streaming Tail Latency?
++++++++++++++++++++++++++++++++
+
+**Streaming tail latency** starts immediately before the final
+``enqueue_syndrome()`` call and ends after ``get_obs_corrections()`` returns.
+It therefore measures the time from receiving the final detector round to
+obtaining the correction needed by a real-time controller.
+
+The benchmark also records the sum of time spent in every streaming enqueue
+call. That sum excludes the configured wait between rounds and is useful for
+measuring decoder work, but it is not the final-round response time reported
+on this page.
+
+For long shots, the default NV-Fusion schedule uses leaves of ``2 * d`` rounds,
+where ``d`` is the measured code distance. Leaves are solved while later
+syndrome rounds are still arriving, so only the last leaf and the remaining
+fusions lie on the final-round critical path. PyMatching instead solves the
+complete matching graph after the final round, causing its tail latency to
+grow with the full experiment length.
+
+.. image:: ../../../assets/docs/nv_fusion_block_schedule.png
+   :align: center
+   :alt: A repeating schedule of temporal leaf blocks feeding adjacent-pair fuses and overlapping four-block fuses
+
+Each layer-1 fuse waits for two adjacent leaf solutions. The staggered
+layer-2 fuses then combine neighboring layer-1 results, creating overlapping
+four-block windows while keeping each fusion local.
+
+Experiment Configuration
+++++++++++++++++++++++++
+
+All measurements were collected on one NVIDIA Vera CPU system. NV-Fusion and
+PyMatching are CPU decoders; the benchmark was bound to a single NUMA node.
+Each point contains 1,000 timed shots after 20 warm-up shots. The
+physical noise model applies the same probability to Clifford
+depolarization, reset flips, measurement flips, and inter-round data
+depolarization.
+
+The result logs record the CPU allocation, but do not capture the exact CPU
+SKU, OS, compiler, CUDA-Q version, container digest, or decoder dependency
+revisions. The source revision above identifies the benchmark implementation
+used to interpret the data, not a complete reproducibility manifest.
+
+.. list-table:: Decoder and experiment parameters
+   :header-rows: 1
+   :widths: 34 66
+
+   * - Parameter
+     - Value
+   * - Platform
+     - NVIDIA Vera CPU, one NUMA node
+   * - Available CPUs
+     - 88 CPUs (CPUs 0--87); 352 reported by
+       ``hardware_concurrency``
+   * - Circuit
+     - Stim rotated surface-code Z memory
+   * - Code distances
+     - 5, 7, 13
+   * - Stabilizer rounds
+     - 10, 100, 500, 1,000, 2,000, 5,000, 10,000
+   * - Physical noise probability
+     - ``p = 0.001``
+   * - Timed and warm-up shots
+     - 1,000 timed shots and 20 warm-up shots per instance
+   * - Streaming round interval
+     - 1 microsecond
+   * - Decoder threads
+     - ``num_threads=0``; resolved to 84 threads for one instance and
+       reduced when instances share the CPU
+   * - CPU placement
+     - Instances pinned to disjoint CPU sets with ``--pin-instances``
+   * - NV-Fusion schedule
+     - Automatic
+   * - Comparison decoder
+     - PyMatching, using the same decomposed detector error model and sampled
+       syndromes
+
+Streaming Completion Latency
+++++++++++++++++++++++++++++
+
+The following figure shows median and p99 streaming tail latency for one
+decoder instance. Up to 100 rounds, the automatic schedule uses one exact
+leaf, and NV-Fusion broadly follows PyMatching. Above the 192-round automatic
+schedule threshold, NV-Fusion switches to fused leaves and its completion
+latency becomes only weakly dependent on the total number of rounds.
+
+.. image:: ../../../assets/docs/nv_fusion_streaming_tail_latency.png
+   :align: center
+   :alt: Streaming tail p50 and p99 latency versus rounds for NV-Fusion and PyMatching at code distances 5, 7, and 13
+
+Between 500 and 10,000 rounds, a 20x increase in experiment length, NV-Fusion
+p99 tail latency increased by only 1.0--1.7x across the three distances, while
+PyMatching p99 latency increased by 26--37x. At 10,000 rounds, NV-Fusion p99
+tail latency ranged from 67 microseconds to 1.28 milliseconds; the
+corresponding PyMatching values were 2.13 and 28.00 milliseconds.
+
+Median speedup increased from 1.00--1.51x at 500 rounds to 26.6--41.4x at
+10,000 rounds. At 10,000 rounds, p99 speedup was 21.8--32.0x.
+
+Lower latency is useful only when decoding quality is preserved. Across these
+1,000-shot measurements, the observed logical error rates for NV-Fusion and
+PyMatching differed by no more than 0.001 in absolute terms. This sample is
+not sufficient to establish equivalent logical error rates, particularly for
+points with no observed failures; a production schedule must also be
+validated with enough shots to resolve its target logical error rate.
+
+These percentiles describe the measured distribution of 1,000 shots. In
+particular, p99 is determined by roughly the ten slowest samples and should
+not be interpreted as a worst-case latency guarantee.
+
+Latency With Concurrent Decoders
+++++++++++++++++++++++++++++++++
+
+A real-time system may decode several logical qubits concurrently. The
+benchmark therefore runs independent decoder instances in parallel, pins each
+instance to a disjoint share of the NUMA node, and pools their latency samples.
+The automatic thread allocation decreases from 84 threads for one instance to
+40, 19, and 10 threads per instance for two, four, and eight instances,
+respectively.
+
+.. image:: ../../../assets/docs/nv_fusion_streaming_instance_latency.png
+   :align: center
+   :alt: NV-Fusion streaming tail p99 latency versus concurrent decoder instances at distances 5, 7, and 13
+
+At 10,000 rounds, increasing from one to eight instances raised p99 tail
+latency by 1.23x at distance 5, 1.58x at distance 7, and 1.35x at distance 13.
+These results include both reduced per-instance thread pools and contention
+for the shared CPU memory system.
+
+See Also
+++++++++
+
+* :ref:`NVIDIA Fusion Decoder API <nv_fusion_decoder_api_python>` -- decoder
+  behavior, schedule selection, parameters, and Python API
+* :ref:`NVIDIA Fusion Decoder C++ API <nv_fusion_decoder_api_cpp>`
+* ``benchmarks/qec/nv_fusion_latency/README.md`` -- commands and plotting
+  instructions used for this study

--- a/libs/qec/CMakeLists.txt
+++ b/libs/qec/CMakeLists.txt
@@ -361,6 +361,9 @@ configure_file("${CMAKE_CURRENT_SOURCE_DIR}/lib/version.cpp.in"
 # ==============================================================================
 
 add_subdirectory(lib)
+add_subdirectory(
+  "${CUDAQX_QEC_SOURCE_DIR}/../../benchmarks/qec"
+  "${CMAKE_CURRENT_BINARY_DIR}/benchmarks")
 if (NOT CUDAQ_QEC_DECODERS_ONLY OR CUDAQ_QEC_BUILD_DECODING_SERVER)
   add_subdirectory(tools)
 endif()


### PR DESCRIPTION
## Description

Adds NV-Fusion decoder latency benchmarks and documentation, including Vera performance results, plots, and reproduction instructions. The benchmark target is opt-in and excluded from default CI builds.
